### PR TITLE
Castle.Core for SL4 can be referenced by .NET project in Partial Trust

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -144,7 +144,9 @@ namespace Castle.DynamicProxy.Generators
 		private FieldReference CreateTargetField(ClassEmitter emitter)
 		{
 			var targetField = emitter.CreateField("__target", targetType);
+#if !SILVERLIGHT
 			emitter.DefineCustomAttributeFor<XmlIgnoreAttribute>(targetField);
+#endif
 			return targetField;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateProxyGenerator.cs
@@ -71,7 +71,9 @@ namespace Castle.DynamicProxy.Generators
 		private FieldReference CreateTargetField(ClassEmitter emitter)
 		{
 			var targetField = emitter.CreateField("__target", targetType);
+#if !SILVERLIGHT
 			emitter.DefineCustomAttributeFor<XmlIgnoreAttribute>(targetField);
+#endif
 			return targetField;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -253,8 +253,9 @@ namespace Castle.DynamicProxy.Generators
 		{
 			base.CreateFields(emitter);
 			targetField = emitter.CreateField("__target", proxyTargetType);
-
+#if !SILVERLIGHT
 			emitter.DefineCustomAttributeFor<XmlIgnoreAttribute>(targetField);
+#endif
 		}
 
 		private void EnsureValidBaseType(Type type)


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/castle-project-users/qytXBc9as6c ,
there is project, that must be tested in Partial Trust environment (using Moq library).
But "Castle.Core" for ".NET" can not be used in Partial Trust environment.
For that reason, can be used "Castle.Core" for "Silverlight 4", but with slight correction ("System.Xml" from "Silverlight 4" can not be used in ".NET" project).
The fix is to remove the use of classes from the "System.Xml" assembly for the project configuration "SL4"
by wrapping the code with condition "#if !Silverlight".
