### PR TITLE
Fix IBindingListSource breaking Silverlight build

### DIFF
--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingList.cs
@@ -18,9 +18,9 @@ namespace Castle.Components.DictionaryAdapter
 	using System.ComponentModel;
 	using SysPropertyDescriptor = System.ComponentModel.PropertyDescriptor;
 
-	public interface IBindingList<T> : IList<T>, IBindingListSource
+	public interface IBindingList<T> : IList<T>
 #if !SILVERLIGHT
-		, ICancelAddNew, IRaiseItemChangedEvents
+		, IBindingListSource, ICancelAddNew, IRaiseItemChangedEvents
 #endif
 	{
 		bool AllowNew                      { get; }


### PR DESCRIPTION
This should resolve the error introduced in 80de1b32.
