### PR TITLE
Fix for DYNPROXY-188

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -38,7 +38,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			{
 				throw new NotSupportedException("Cannot load ByRef values");
 			}
-			else if (type.IsPrimitive && type != typeof(IntPtr))
+			else if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{
 				var opCode = LdindOpCodesDictionary.Instance[type];
 
@@ -148,7 +148,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			{
 				throw new NotSupportedException("Cannot store ByRef values");
 			}
-			else if (type.IsPrimitive && type != typeof(IntPtr))
+			else if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{
 				var opCode = StindOpCodesDictionary.Instance[type];
 


### PR DESCRIPTION
I believe this is a fix for DYNPROXY-188 CreateInterfaceProxyWithoutTarget fails with interface containing member with 'ref UIntPtr'.
http://issues.castleproject.org/issue/DYNPROXY-188

Unfortunately I don't know the project intimately enough to be able to write a test for it.
