### PR TITLE
Fixed DYNPROXY-186 .Net remoting (transparent proxy) cannot be proxied 

### DIFF
--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -565,13 +565,15 @@ namespace Castle.DynamicProxy
 		{
 			//TODO: add <example> to xml comments to show how to use IChangeProxyTarget
 
-			if (target != null && interfaceToProxy.IsInstanceOfType(target) == false)
-			{
-				throw new ArgumentException("targetType");
-			}
+
 			if (interfaceToProxy == null)
 			{
 				throw new ArgumentNullException("interfaceToProxy");
+			}
+			// In the case of a transparent proxy, the call to IsInstanceOfType was executed on the real object.
+			if (target != null && interfaceToProxy.IsInstanceOfType(target) == false)
+			{
+				throw new ArgumentException("Target does not implement interface " + interfaceToProxy.FullName, "target");
 			}
 			if (interceptors == null)
 			{
@@ -584,23 +586,12 @@ namespace Castle.DynamicProxy
 			}
 
 			var isRemotingProxy = false;
-			if (target != null && interfaceToProxy.IsInstanceOfType(target) == false)
-			{
 #if !SILVERLIGHT
-				//check if we have remoting proxy at hand...
-				if (RemotingServices.IsTransparentProxy(target))
-				{
-					var info = (RemotingServices.GetRealProxy(target) as IRemotingTypeInfo);
-					if (info != null)
-					{
-						if (!info.CanCastTo(interfaceToProxy, target))
-						{
-							throw new ArgumentException("Target does not implement interface " + interfaceToProxy.FullName, "target");
-						}
-						isRemotingProxy = true;
-					}
-				}
-				else if (Marshal.IsComObject(target))
+			if (target != null)
+			{
+				isRemotingProxy = RemotingServices.IsTransparentProxy(target);
+
+				if (!isRemotingProxy && Marshal.IsComObject(target))
 				{
 					var interfaceId = interfaceToProxy.GUID;
 					if (interfaceId != Guid.Empty)
@@ -611,19 +602,13 @@ namespace Castle.DynamicProxy
 						if (result == 0 && interfacePointer == IntPtr.Zero)
 						{
 							throw new ArgumentException("Target COM object does not implement interface " + interfaceToProxy.FullName,
-							                            "target");
+										    "target");
 						}
 					}
 				}
-				else
-				{
-#endif
-					throw new ArgumentException("Target does not implement interface " + interfaceToProxy.FullName, "target");
-
-#if !SILVERLIGHT
-				}
-#endif
 			}
+			
+#endif
 
 			CheckNotGenericTypeDefinition(interfaceToProxy, "interfaceToProxy");
 			CheckNotGenericTypeDefinitions(additionalInterfacesToProxy, "additionalInterfacesToProxy");


### PR DESCRIPTION
1- Ensure to validate that the interfaceToProxy member is not null
before using it.

2- Was throwing for this conditon (if (target != null &&
interfaceToProxy.IsInstanceOfType(target) == false)) at the beginning of
the method. There was no need to check this again in the method. In
fact, the code
done in this if would never be executed, it would have been an
exception.

3- This call interfaceToProxy.IsInstanceOfType(target) already
validated that in the case of a transparent proxy, the target implement
the interface. The call IsInstanceOfType is done on the real object (not
the transparent proxy created by .net remoting).

Note : Kept the COM code there, but no idea if it's used by anyone since
I did
not find any issue/defect for lack of support of COM and it was not
working since release 3.1.0 RC.

TEST
Test done on an test application, hard to have a unit test for .net
remoting issue.
Ran Unit Test
