### PR TITLE
Fixed proxy of COM class issue, reference count incremented

### DIFF
--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -596,13 +596,17 @@ namespace Castle.DynamicProxy
 					var interfaceId = interfaceToProxy.GUID;
 					if (interfaceId != Guid.Empty)
 					{
-						var iUnknown = Marshal.GetIUnknownForObject(target);
+						var iUnknown = Marshal.GetIUnknownForObject(target); // Increment the reference count
 						var interfacePointer = IntPtr.Zero;
-						var result = Marshal.QueryInterface(iUnknown, ref interfaceId, out interfacePointer);
-						if (result == 0 && interfacePointer == IntPtr.Zero)
+						var result = Marshal.QueryInterface(iUnknown, ref interfaceId, out interfacePointer); // Increment the reference count
+						var isInterfacePointerNull = interfacePointer == IntPtr.Zero;		        
+						Marshal.Release(iUnknown); // Decrement the reference count
+						Marshal.Release(interfacePointer); // Decrement the reference count
+
+						if (result == 0 && isInterfacePointerNull)
 						{
 							throw new ArgumentException("Target COM object does not implement interface " + interfaceToProxy.FullName,
-										    "target");
+														"target");
 						}
 					}
 				}


### PR DESCRIPTION
Calls to Marshal.GetIUnknownForObject and Marshal.QueryInterface
increment the reference count but the code was not decrementing it. This
could cause major leak since the COM object would not be
destroyed/released (reference count never reaching 0).

As stated in MSDN documentation for both method: "Always use
Marshal.Release to decrement the reference count once you have finished
with the pointer."

TEST: break in atlcom.h (InternalAddRef, InteralRelease) to ensure the
reference count is valid.

NOTE : this problem appeared after commit to fix DYNPROXY-186, before
the code related to COM was not executed.
