### PR TITLE
DYNPROXY-30 - tailoring InternalsVisibleTo message based on assembly of inaccessible type

### DIFF
--- a/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2013 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ namespace CastleTests
 			var exception = Assert.Throws(typeof(GeneratorException),
 			                              () => generator.CreateClassProxy(type, new StandardInterceptor()));
 			Assert.AreEqual(
-				"Type System.AppDomainInitializerInfo is not visible to DynamicProxy. Can not create proxy for types that are not accessible. Make the type public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute.",
+				"Type System.AppDomainInitializerInfo is not visible to DynamicProxy. Can not create proxy for types that are not accessible. Make the type public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly mscorlib is strong-named.",
 				exception.Message);
 		}
 #endif


### PR DESCRIPTION
Tailoring InternalsVisibleTo message based on assembly of inaccessible type.
Had to adjust existing unit test to account for the fact that mcore doesn't reference Castle.Core.

Fixes #30.
