### PR TITLE
34 inaccessible type parameters should give better error messsages

### DIFF
--- a/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
@@ -85,10 +85,9 @@ namespace CastleTests
 			// DynamicProxy2
 
 			var type = Type.GetType("System.AppDomainInitializerInfo, mscorlib");
-			var exception = Assert.Throws(typeof(GeneratorException),
-			                              () => generator.CreateClassProxy(type, new StandardInterceptor()));
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateClassProxy(type, new StandardInterceptor()));
 			Assert.AreEqual(
-				"Type System.AppDomainInitializerInfo is not visible to DynamicProxy. Can not create proxy for types that are not accessible. Make the type public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly mscorlib is strong-named.",
+				"Can not create proxy for type System.AppDomainInitializerInfo because it is not accessible. Make the type public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly mscorlib is strong-named.",
 				exception.Message);
 		}
 #endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
@@ -101,25 +101,25 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(42, result);
 		}
 
-		private class PrivateClass { }
-
 		[Test]
 		public void Cannot_proxy_inaccessible_class()
 		{
 			var exception = Assert.Throws<GeneratorException>(() => generator.CreateClassProxyWithTarget<PrivateClass>(new PrivateClass()));
-			Assert.That(exception.Message, Is.StringStarting("Type Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass is not visible to DynamicProxy. Can not create proxy for types that are not accessible."));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass because it is not accessible. Make the type public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_class_with_inaccessible_type_argument()
 		{
-			generator.CreateClassProxyWithTarget<List<PrivateClass>>(new List<PrivateClass>());
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateClassProxyWithTarget<List<PrivateClass>>(new List<PrivateClass>()));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type System.Collections.Generic.List`1[[Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass, Castle.Core.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc]] because type Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass is not accessible. Make it public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_class_with_type_argument_that_has_inaccessible_type_argument()
 		{
-			generator.CreateClassProxyWithTarget(new List<List<PrivateClass>>(), new IInterceptor[0]);
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateClassProxyWithTarget(new List<List<PrivateClass>>(), new IInterceptor[0]));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type System.Collections.Generic.List`1[[System.Collections.Generic.List`1[[Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass, Castle.Core.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]] because type Castle.DynamicProxy.Tests.ClassProxyWithTargetTestCase+PrivateClass is not accessible. Make it public, or internal"));
 		}
 
 		[Test]
@@ -197,5 +197,7 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(target, result);
 		}
 #endif
+
+		private class PrivateClass { }
 	}
 }

--- a/src/Castle.Core.Tests/GenericClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/GenericClassProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2013 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Tests
 {
 	using System;
 	using System.Collections.Generic;
+	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Tests.GenClasses;
 	using Castle.DynamicProxy.Tests.Interceptors;
 	using NUnit.Framework;
@@ -316,7 +317,7 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		[ExpectedException(typeof (ArgumentException))]
+		[ExpectedException(typeof (GeneratorException))]
 		public void ThrowsWhenProxyingGenericTypeDefNoTarget()
 		{
 			KeepDataInterceptor interceptor = new KeepDataInterceptor();

--- a/src/Castle.Core.Tests/GenericInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/GenericInterfaceProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2013 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -396,7 +396,7 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
+		[ExpectedException(typeof(GeneratorException))]
 		public void ThrowsWhenProxyingGenericTypeDefNoTarget()
 		{
 			var interceptor = new KeepDataInterceptor();

--- a/src/Castle.Core.Tests/InterceptorSelectorTestCase.cs
+++ b/src/Castle.Core.Tests/InterceptorSelectorTestCase.cs
@@ -289,26 +289,24 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreSame(someInstanceOfProxyWithSelector1.GetType(), someInstanceOfProxyWithSelector2.GetType());
 		}
 
-		private interface PrivateInterface { }
-		private class PrivateClass : PrivateInterface { }
-
 		[Test]
 		public void Cannot_proxy_inaccessible_interface()
 		{
 			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTarget<PrivateInterface>(new PrivateClass(), new IInterceptor[0]));
-			Assert.That(exception.Message, Is.StringStarting("Type Castle.DynamicProxy.Tests.InterceptorSelectorTestCase+PrivateInterface is not visible to DynamicProxy. Can not create proxy for types that are not accessible."));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type Castle.DynamicProxy.Tests.InterceptorSelectorTestCase+PrivateInterface because it is not accessible. Make the type public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_interface_with_inaccessible_type_argument()
 		{
-			generator.CreateInterfaceProxyWithTarget<IList<PrivateInterface>>(new List<PrivateInterface>(), new IInterceptor[0]);
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTarget<IList<PrivateInterface>>(new List<PrivateInterface>(), new IInterceptor[0]));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type System.Collections.Generic.IList`1[[Castle.DynamicProxy.Tests.InterceptorSelectorTestCase+PrivateInterface, Castle.Core.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc]] because type Castle.DynamicProxy.Tests.InterceptorSelectorTestCase+PrivateInterface is not accessible. Make it public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_interface_with_type_argument_that_has_inaccessible_type_argument()
 		{
-			generator.CreateInterfaceProxyWithTarget<IList<IList<PrivateInterface>>>(new List<IList<PrivateInterface>>(), new IInterceptor[0]);
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTarget<IList<IList<PrivateInterface>>>(new List<IList<PrivateInterface>>(), new IInterceptor[0]));
 		}
 
 		[Test]
@@ -316,6 +314,10 @@ namespace Castle.DynamicProxy.Tests
 		{
 			generator.CreateInterfaceProxyWithTarget<IList<object>>(new List<object>(), new IInterceptor[0]);
 		}
+
+		private interface PrivateInterface { }
+
+		private class PrivateClass : PrivateInterface { }
 	}
 
 #if !MONO

--- a/src/Castle.Core.Tests/InterfaceProxyWithTargetInterfaceTestCase.cs
+++ b/src/Castle.Core.Tests/InterfaceProxyWithTargetInterfaceTestCase.cs
@@ -180,26 +180,25 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(typeof(One), second.Invocation.InvocationTarget.GetType());
 		}
 
-		private interface PrivateInterface { }
-		private class PrivateClass : PrivateInterface { }
-
 		[Test]
 		public void Cannot_proxy_inaccessible_interface()
 		{
 			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTargetInterface<PrivateInterface>(new PrivateClass(), new IInterceptor[0]));
-			Assert.That(exception.Message, Is.StringStarting("Type Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface is not visible to DynamicProxy. Can not create proxy for types that are not accessible."));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface because it is not accessible. Make the type public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_interface_with_inaccessible_type_argument()
 		{
-			generator.CreateInterfaceProxyWithTargetInterface<IList<PrivateInterface>>(new List<PrivateInterface>(), new IInterceptor[0]);
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTargetInterface<IList<PrivateInterface>>(new List<PrivateInterface>(), new IInterceptor[0]));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type System.Collections.Generic.IList`1[[Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface, Castle.Core.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc]] because type Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface is not accessible. Make it public, or internal"));
 		}
 
 		[Test]
 		public void Cannot_proxy_generic_interface_with_type_argument_that_has_inaccessible_type_argument()
 		{
-			generator.CreateInterfaceProxyWithTargetInterface<IList<IList<PrivateInterface>>>(new List<IList<PrivateInterface>>(), new IInterceptor[0]);
+			var exception = Assert.Throws<GeneratorException>(() => generator.CreateInterfaceProxyWithTargetInterface<IList<IList<PrivateInterface>>>(new List<IList<PrivateInterface>>(), new IInterceptor[0]));
+			Assert.That(exception.Message, Is.StringStarting("Can not create proxy for type System.Collections.Generic.IList`1[[System.Collections.Generic.IList`1[[Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface, Castle.Core.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]] because type Castle.DynamicProxy.Tests.InterfaceProxyWithTargetInterfaceTestCase+PrivateInterface is not accessible. Make it public, or internal"));
 		}
 
 		[Test]
@@ -212,5 +211,9 @@ namespace Castle.DynamicProxy.Tests
 		{
 			return (proxy as IProxyTargetAccessor).DynProxyGetTarget().GetType();
 		}
+
+		private interface PrivateInterface { }
+
+		private class PrivateClass : PrivateInterface { }
 	}
 }

--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2013 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ namespace Castle.DynamicProxy
 	using System.Text;
 
 	using Castle.Core.Logging;
+	using Castle.DynamicProxy.Generators;
 
 	/// <summary>
 	///   Provides proxy objects for classes and interfaces.
@@ -1485,7 +1486,8 @@ namespace Castle.DynamicProxy
 		{
 			if (type != null && type.IsGenericTypeDefinition)
 			{
-				throw new ArgumentException("You can't specify a generic type definition.", argumentName);
+				throw new GeneratorException(string.Format("Can not create proxy for type {0} because it is an open generic type.",
+														   type.FullName ?? type.Name));
 			}
 		}
 


### PR DESCRIPTION
Fixes #34 and fixes #39.

I may have overstepped slightly. While working on #34, I noticed that my changes would affect the way open generic type errors were reported, so I included them in the work.
First, I added (quite a few) characterization tests so I could understand how things worked currently. Then I added the code to recurse through the type parameters and report on what couldn't be proxied, and which type was causing the problem. While I was at it, I ended up changing the type thrown from `ProxyGenerator.CheckNotGenericTypeDefinition` to `GeneratorException` (from `ArgumentException`) to match the error coming from `DefaultProxyBuilder`, and because I thought the new information about the type being proxied would remove the ambiguity that the argument name was trying to solve.

Of course, I understand that some of these decisions were not mine to make. If you disagree, I apologize for wasting your time and will quickly emend.
