### PR TITLE
Added SourceContext to the Serilog Logger

### DIFF
--- a/src/Castle.Services.Logging.SerilogIntegration/SerilogFactory.cs
+++ b/src/Castle.Services.Logging.SerilogIntegration/SerilogFactory.cs
@@ -51,7 +51,7 @@ namespace Castle.Services.Logging.SerilogIntegration
 
             var log = configuration
                 .MinimumLevel.Is(serilogLevel)
-                .CreateLogger();
+                .CreateLogger().ForContext("SourceContext", name);;
 
             return new SerilogLogger(log, this);
         }
@@ -59,7 +59,7 @@ namespace Castle.Services.Logging.SerilogIntegration
         public override Castle.Core.Logging.ILogger Create(string name)
         {
             var log = configuration
-                .CreateLogger();
+                .CreateLogger().ForContext("SourceContext", name);
 
             return new SerilogLogger(log, this);
         }


### PR DESCRIPTION
Without this there is no way to capture the name / context (commonly the type name) provided by a facility while wiring a logger.

AFAIK the .ForContext("SourceContext", name); Has the same behavior as .ForContext<T>() in Serilog. Which is how they capture context and which translates into things like Loggername when you use other sinks in Serilog. I've tested this with a Serilog-NLogSink being injected via the castle facility.

If someone has a better idea for the "SourceContext" constant? Maybe a constructor parameter? It's a cross project dependency :(
