### PR TITLE
Unit test reproducing ProxyGenerationException using 3+ observer (issue #88)

### DIFF
--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -252,6 +252,9 @@
     <Compile Include="DynamicProxy.Tests\ClassProxyWithDefaultValuesTestCase.cs" />
     <Compile Include="DynamicProxy.Tests\GenericInterfaceWithGenericMethod.cs" />
     <Compile Include="DynamicProxy.Tests\Interfaces\InterfaceWithMethodWithParameterWithNullDefaultValue.cs" />
+    <Compile Include="Interfaces\IGeneric.cs" />
+    <Compile Include="Interfaces\IMultipleRepeated.cs" />
+    <Compile Include="MultipleRepeatedInterfaceTestCase.cs" />
     <Compile Include="MultipleSavedAssembliesTestCase.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\AdaptingGenericDictionaryTestCase.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\VirtualObjectTestCase.cs" />

--- a/src/Castle.Core.Tests/Interfaces/IGeneric.cs
+++ b/src/Castle.Core.Tests/Interfaces/IGeneric.cs
@@ -1,0 +1,8 @@
+﻿namespace CastleTests.Interfaces
+{
+    public interface IGeneric<T>
+    {
+        T One { get; }
+        string Two { get; }
+    }
+}

--- a/src/Castle.Core.Tests/Interfaces/IMultipleRepeated.cs
+++ b/src/Castle.Core.Tests/Interfaces/IMultipleRepeated.cs
@@ -1,0 +1,4 @@
+﻿namespace CastleTests.Interfaces
+{
+    public interface IMultipleRepeated : IGeneric<string>, IGeneric<int>, IGeneric<bool> { }
+}

--- a/src/Castle.Core.Tests/MultipleRepeatedInterfaceTestCase.cs
+++ b/src/Castle.Core.Tests/MultipleRepeatedInterfaceTestCase.cs
@@ -1,0 +1,18 @@
+﻿
+using Castle.DynamicProxy;
+using NUnit.Framework;
+
+namespace CastleTests
+{
+    [TestFixture]
+    public class MultipleRepeatedInterface
+    {
+        [Test]
+        public void CanGenerateProxyForInterfaceImplementingMultipleOfRepeatedInterface()
+        {
+            var generator = new ProxyGenerator();
+            var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(Interfaces.IMultipleRepeated), new IInterceptor[0]);
+            Assert.IsNotNull(proxy);
+        }
+    }
+}

--- a/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
@@ -41,14 +41,7 @@ namespace Castle.DynamicProxy.Generators
 				return;
 			}
 			if (Contains(item))
-			{
 				item.SwitchToExplicitImplementation();
-				if (Contains(item))
-				{
-					// there is something reaaaly wrong going on here
-					throw new ProxyGenerationException("Duplicate element: " + item);
-				}
-			}
 			items.Add(item);
 		}
 


### PR DESCRIPTION
Multiple (of the same) generic interface containing non-generic members can now be implemented.