### PR TITLE
Fix for issue #87

### DIFF
--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -247,10 +247,14 @@
     <Compile Include="BugsReported\DynProxy145_SynchronizationContext.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\IPhoneWithFetch.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\NameValueCollectionAdapterTests.cs" />
+    <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodsWithAllKindsOfOptionalParameters.cs" />
     <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodWithParameterWithDefaultValue.cs" />
     <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodWithParameterWithNullDefaultValue.cs" />
     <Compile Include="DynamicProxy.Tests\ClassProxyWithDefaultValuesTestCase.cs" />
+    <Compile Include="DynamicProxy.Tests\ClassProxyWithMethodsWithOptionalParametersTestCase.cs" />
     <Compile Include="DynamicProxy.Tests\GenericInterfaceWithGenericMethod.cs" />
+    <Compile Include="DynamicProxy.Tests\InterfaceProxyWithMethodsWithOptionalParametersTestCase.cs" />
+    <Compile Include="DynamicProxy.Tests\Interfaces\InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs" />
     <Compile Include="DynamicProxy.Tests\Interfaces\InterfaceWithMethodWithParameterWithNullDefaultValue.cs" />
     <Compile Include="MultipleSavedAssembliesTestCase.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\AdaptingGenericDictionaryTestCase.cs" />

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithMethodsWithOptionalParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithMethodsWithOptionalParametersTestCase.cs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#if !DOTNET35
 namespace Castle.DynamicProxy.Tests
 {
 	using CastleTests.DynamicProxy.Tests.Classes;
@@ -28,3 +30,4 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 }
+#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithMethodsWithOptionalParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithMethodsWithOptionalParametersTestCase.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+namespace Castle.DynamicProxy.Tests
+{
+	using CastleTests.DynamicProxy.Tests.Classes;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class ClassProxyWithMethodsWithOptionalParametersTestCase
+	{
+		[Test]
+		public void CanCreateClassProxy()
+		{
+			var proxyGenerator = new ProxyGenerator();
+			proxyGenerator.CreateClassProxy<ClassWithMethodsWithAllKindsOfOptionalParameters>();
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -1,0 +1,241 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Classes
+{
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+
+	public class ClassWithMethodsWithAllKindsOfOptionalParameters : InterfaceWithMethodsWithAllKindsOfOptionalParameters
+	{
+		public virtual void MethodWithOptionalByteParameter(byte b = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultByteParameter(byte b = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableByteParameter(byte? b = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableByteParameter(byte? b = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalSignedByteParameter(sbyte b = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultSignedByteParameter(sbyte b = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableSignedByteParameter(sbyte? b = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableSignedByteParameter(sbyte? b = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalShortParameter(short s = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultShortParameter(short s = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableShortParameter(short? s = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableShortParameter(short? s = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalUnsignedShortParameter(ushort s = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultUnsignedShortParameter(ushort s = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableUnsignedShortParameter(ushort? s = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableUnsignedShortParameter(ushort? s = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalIntParameter(int i = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultIntParameter(int i = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableIntParameter(int? i = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableIntParameter(int? i = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalUnsignedIntParameter(uint i = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultUnsignedIntParameter(uint i = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableUnsignedIntParameter(uint? i = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableUnsignedIntParameter(uint? i = 3)
+		{
+		}
+
+		public virtual void MethodWithOptionalLongParameter(long l = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultLongParameter(long l = 3L)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableLongParameter(long? l = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableLongParameter(long? l = 3L)
+		{
+		}
+
+		public virtual void MethodWithOptionalUnsignedLongParameter(ulong l = 0)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultUnsignedLongParameter(ulong l = 3L)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableUnsignedLongParameter(ulong? l = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableUnsignedLongParameter(ulong? l = 3L)
+		{
+		}
+
+		public virtual void MethodWithOptionalFloatParameter(float f = 0f)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultFloatParameter(float f = 3f)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableFloatParameter(float? f = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableFloatParameter(float? f = 3f)
+		{
+		}
+
+		public virtual void MethodWithOptionalDoubleParameter(double d = 0d)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultDoubleParameter(double d = 3d)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableDoubleParameter(double? d = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableDoubleParameter(double? d = 3d)
+		{
+		}
+
+		public virtual void MethodWithOptionalCharParameter(char c = '\0')
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultCharParameter(char c = 'A')
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableCharParameter(char? c = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableCharParameter(char? c = 'A')
+		{
+		}
+
+		public virtual void MethodWithOptionalBoolParameter(bool b = false)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultBoolParameter(bool b = true)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableBoolParameter(bool? b = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableBoolParameter(bool? b = true)
+		{
+		}
+
+		public virtual void MethodWithOptionalObjectParameter(object o = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullStringParameter(string s = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalStringParameter(string s = "")
+		{
+		}
+
+		public virtual void MethodWithOptionalDecimalParameter(decimal d = 0m)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultDecimalParameter(decimal d = 3m)
+		{
+		}
+
+		public virtual void MethodWithOptionalNullableDecimalarameter(decimal? d = null)
+		{
+		}
+
+		public virtual void MethodWithOptionalNonDefaultNullableDecimalParameter(decimal? d = 3m)
+		{
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !DOTNET35
 namespace CastleTests.DynamicProxy.Tests.Classes
 {
 	using CastleTests.DynamicProxy.Tests.Interfaces;
@@ -239,3 +240,4 @@ namespace CastleTests.DynamicProxy.Tests.Classes
 		}
 	}
 }
+#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithMethodsWithOptionalParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithMethodsWithOptionalParametersTestCase.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !DOTNET35
 namespace Castle.DynamicProxy.Tests
 {
 	using CastleTests.DynamicProxy.Tests.Interfaces;
@@ -29,3 +30,4 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 }
+#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithMethodsWithOptionalParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithMethodsWithOptionalParametersTestCase.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class InterfaceProxyWithMethodsWithOptionalParametersTestCase
+	{
+		[Test]
+		public void CanCreateInterfaceProxy()
+		{
+			var proxyGenerator = new ProxyGenerator();
+			proxyGenerator.CreateInterfaceProxyWithoutTarget<InterfaceWithMethodsWithAllKindsOfOptionalParameters>();
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -1,0 +1,129 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Interfaces
+{
+	public interface InterfaceWithMethodsWithAllKindsOfOptionalParameters
+	{
+		void MethodWithOptionalByteParameter(byte b = 0);
+
+		void MethodWithOptionalNonDefaultByteParameter(byte b = 3);
+
+		void MethodWithOptionalNullableByteParameter(byte? b = null);
+
+		void MethodWithOptionalNonDefaultNullableByteParameter(byte? b = 3);
+
+		void MethodWithOptionalSignedByteParameter(sbyte b = 0);
+
+		void MethodWithOptionalNonDefaultSignedByteParameter(sbyte b = 3);
+
+		void MethodWithOptionalNullableSignedByteParameter(sbyte? b = null);
+
+		void MethodWithOptionalNonDefaultNullableSignedByteParameter(sbyte? b = 3);
+
+		void MethodWithOptionalShortParameter(short s = 0);
+
+		void MethodWithOptionalNonDefaultShortParameter(short s = 3);
+
+		void MethodWithOptionalNullableShortParameter(short? s = null);
+
+		void MethodWithOptionalNonDefaultNullableShortParameter(short? s = 3);
+
+		void MethodWithOptionalUnsignedShortParameter(ushort s = 0);
+
+		void MethodWithOptionalNonDefaultUnsignedShortParameter(ushort s = 3);
+
+		void MethodWithOptionalNullableUnsignedShortParameter(ushort? s = null);
+
+		void MethodWithOptionalNonDefaultNullableUnsignedShortParameter(ushort? s = 3);
+
+		void MethodWithOptionalIntParameter(int i = 0);
+
+		void MethodWithOptionalNonDefaultIntParameter(int i = 3);
+
+		void MethodWithOptionalNullableIntParameter(int? i = null);
+
+		void MethodWithOptionalNonDefaultNullableIntParameter(int? i = 3);
+
+		void MethodWithOptionalUnsignedIntParameter(uint i = 0);
+
+		void MethodWithOptionalNonDefaultUnsignedIntParameter(uint i = 3);
+
+		void MethodWithOptionalNullableUnsignedIntParameter(uint? i = null);
+
+		void MethodWithOptionalNonDefaultNullableUnsignedIntParameter(uint? i = 3);
+
+		void MethodWithOptionalLongParameter(long l = 0);
+
+		void MethodWithOptionalNonDefaultLongParameter(long l = 3L);
+
+		void MethodWithOptionalNullableLongParameter(long? l = null);
+
+		void MethodWithOptionalNonDefaultNullableLongParameter(long? l = 3L);
+
+		void MethodWithOptionalUnsignedLongParameter(ulong l = 0);
+
+		void MethodWithOptionalNonDefaultUnsignedLongParameter(ulong l = 3L);
+
+		void MethodWithOptionalNullableUnsignedLongParameter(ulong? l = null);
+
+		void MethodWithOptionalNonDefaultNullableUnsignedLongParameter(ulong? l = 3L);
+
+		void MethodWithOptionalFloatParameter(float f = 0f);
+
+		void MethodWithOptionalNonDefaultFloatParameter(float f = 3f);
+
+		void MethodWithOptionalNullableFloatParameter(float? f = null);
+
+		void MethodWithOptionalNonDefaultNullableFloatParameter(float? f = 3f);
+
+		void MethodWithOptionalDoubleParameter(double d = 0d);
+
+		void MethodWithOptionalNonDefaultDoubleParameter(double d = 3d);
+
+		void MethodWithOptionalNullableDoubleParameter(double? d = null);
+
+		void MethodWithOptionalNonDefaultNullableDoubleParameter(double? d = 3d);
+
+		void MethodWithOptionalCharParameter(char c = '\0');
+
+		void MethodWithOptionalNonDefaultCharParameter(char c = 'A');
+
+		void MethodWithOptionalNullableCharParameter(char? c = null);
+
+		void MethodWithOptionalNonDefaultNullableCharParameter(char? c = 'A');
+
+		void MethodWithOptionalBoolParameter(bool b = false);
+
+		void MethodWithOptionalNonDefaultBoolParameter(bool b = true);
+
+		void MethodWithOptionalNullableBoolParameter(bool? b = null);
+
+		void MethodWithOptionalNonDefaultNullableBoolParameter(bool? b = true);
+
+		void MethodWithOptionalObjectParameter(object o = null);
+
+		void MethodWithOptionalNullStringParameter(string s = null);
+
+		void MethodWithOptionalStringParameter(string s = "");
+
+		void MethodWithOptionalDecimalParameter(decimal d = 0m);
+
+		void MethodWithOptionalNonDefaultDecimalParameter(decimal d = 3m);
+
+		void MethodWithOptionalNullableDecimalarameter(decimal? d = null);
+
+		void MethodWithOptionalNonDefaultNullableDecimalParameter(decimal? d = 3m);
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !DOTNET35
 namespace CastleTests.DynamicProxy.Tests.Interfaces
 {
+
 	public interface InterfaceWithMethodsWithAllKindsOfOptionalParameters
 	{
 		void MethodWithOptionalByteParameter(byte b = 0);
@@ -127,3 +129,4 @@ namespace CastleTests.DynamicProxy.Tests.Interfaces
 		void MethodWithOptionalNonDefaultNullableDecimalParameter(decimal? d = 3m);
 	}
 }
+#endif

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -159,6 +159,18 @@ namespace Castle.DynamicProxy.Generators.Emitters
 #if DOTNET45
 				if (parameter.HasDefaultValue && parameter.DefaultValue != null)
 				{
+					if (parameter.ParameterType == typeof(decimal) || parameter.ParameterType == typeof(decimal?))
+					{
+						/*
+						 * A decimal value may not be passed to SetConstant(), so omit the call
+						 * in this instance.
+						 * 
+						 * See https://github.com/castleproject/Core/issues/87 and https://bit.ly/1eXx6fF 
+						 * for additional information.
+						 */
+						continue;
+					}
+					
 					parameterBuilder.SetConstant(parameter.DefaultValue);
 				}
 #endif

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -162,10 +162,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 					if (parameter.ParameterType == typeof(decimal) || parameter.ParameterType == typeof(decimal?))
 					{
 						/*
-						 * A decimal value may not be passed to SetConstant(), so omit the call
-						 * in this instance.
+						 * Because of a limitation of the .NET Framework, a decimal value may not 
+						 * be passed to SetConstant(), so omit the call in this instance.
 						 * 
-						 * See https://github.com/castleproject/Core/issues/87 and https://bit.ly/1eXx6fF 
+						 * See https://github.com/castleproject/Core/issues/87 and
+						 * https://msdn.microsoft.com/en-au/library/system.reflection.emit.parameterbuilder.setconstant(v=vs.110).aspx
 						 * for additional information.
 						 */
 						continue;


### PR DESCRIPTION
I have added an `if` statement which checks whether the parameter type is a `decimal` or `decimal?` before `SetConstant`is called. I also added two simple test cases where an `Interface` and `Class` proxy is created for an `Interface` (or `Class`) containing methods with all kinds of optional parameters.