### PR TITLE
Conditionally opt-in legacy reflection API usage with FEATURE_LEGACY_REFLECTION_API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ xbuild /p:Configuration=NET45-Release /t:RunAllTests buildscripts/Build.proj
 
 The following conditional compilation symbols (vertical) are currently defined for each of the build configurations (horizontal):
 
-Symbol                  | NET35              | NET40              | NET45              | SL40               | SL50
------------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
-`FEATURE_SERIALIZATION` | :white_check_mark: | :white_check_mark: | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
-`DOTNET35`              | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:
-`DOTNET40`              | :no_entry_sign:    | :white_check_mark: | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
-`DOTNET45`              | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
-`SILVERLIGHT`           | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :white_check_mark:
-`SL4`                   | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:
-`SL5`                   | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark:
+Symbol                          | NET35              | NET40              | NET45              | SL40               | SL50
+------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
+`FEATURE_LEGACY_REFLECTION_API` | :white_check_mark: | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark:
+`FEATURE_SERIALIZATION`         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
+`DOTNET35`                      | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:
+`DOTNET40`                      | :no_entry_sign:    | :white_check_mark: | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
+`DOTNET45`                      | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
+`SILVERLIGHT`                   | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :white_check_mark:
+`SL4`                           | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:
+`SL5`                           | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :no_entry_sign:    | :white_check_mark:
 
 The `__MonoCS__` symbol is used only in unit tests when compiled on Mono to work around Mono defects and non-Windows differences, however we are trying to move away from platform specific symbols as much as possible.

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -27,7 +27,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;DOTNET40 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DOTNET40 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -41,7 +41,7 @@
     <OutputPath>bin\NET40-Release\</OutputPath>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;DOTNET40 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DOTNET40 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
@@ -53,7 +53,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NET35-Debug|AnyCPU'">
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;DOTNET35 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DOTNET35 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -65,7 +65,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NET35-Release|AnyCPU'">
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Release\</OutputPath>
-    <DefineConstants>TRACE;DOTNET35 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DOTNET35 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -78,7 +78,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL40-Release|AnyCPU'">
     <OutputPath>bin\SL40-Release\</OutputPath>
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
-    <DefineConstants>TRACE;SILVERLIGHT SL4</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL4 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -93,7 +93,7 @@
     <DebugSymbols>true</DebugSymbols>
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
     <OutputPath>bin\SL40-Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;SILVERLIGHT SL4</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT SL4 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -104,7 +104,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL50-Release|AnyCPU'">
     <OutputPath>bin\SL50-Release\</OutputPath>
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
-    <DefineConstants>TRACE;SILVERLIGHT SL5</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL5 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -119,7 +119,7 @@
     <DebugSymbols>true</DebugSymbols>
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
     <OutputPath>bin\SL50-Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;SILVERLIGHT SL5</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;SILVERLIGHT SL5 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Castle.Core.Tests/ClassEmitterTestCase.cs
+++ b/src/Castle.Core.Tests/ClassEmitterTestCase.cs
@@ -117,7 +117,7 @@ namespace Castle.DynamicProxy.Tests
 			emitter.CreateMethod("MyMethod", MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual,
 			                     typeof(void), Type.EmptyTypes);
 			Type t = emitter.BuildType();
-			Assert.IsTrue(t.IsInterface);
+			Assert.IsTrue(t.GetTypeInfo().IsInterface);
 			MethodInfo method = t.GetMethod("MyMethod");
 			Assert.IsNotNull(method);
 		}
@@ -166,7 +166,7 @@ namespace Castle.DynamicProxy.Tests
 			                          typeof(void), Type.EmptyTypes);
 			Type inner = innerEmitter.BuildType();
 			Type outer = outerEmitter.BuildType();
-			Assert.IsTrue(inner.IsInterface);
+			Assert.IsTrue(inner.GetTypeInfo().IsInterface);
 			MethodInfo method = inner.GetMethod("MyMethod");
 			Assert.IsNotNull(method);
 			Assert.AreSame(inner, outer.GetNestedType("IInner", BindingFlags.Public));

--- a/src/Castle.Core.Tests/Interceptors/KeepDataInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/KeepDataInterceptor.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Tests.Interceptors
 {
 	using System;
+	using System.Reflection;
 
 	public class KeepDataInterceptor : IInterceptor
 	{
@@ -34,7 +35,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			{
 				invocation.Proceed();
 			}
-			else if (concreteMethod.ReturnType.IsValueType && !concreteMethod.ReturnType.Equals(typeof(void)))
+			else if (concreteMethod.ReturnType.GetTypeInfo().IsValueType && !concreteMethod.ReturnType.Equals(typeof(void)))
 				// ensure valid return value
 			{
 				invocation.ReturnValue = Activator.CreateInstance(concreteMethod.ReturnType);

--- a/src/Castle.Core.Tests/Interceptors/LogInvocationInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/LogInvocationInterceptor.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 {
 	using System;
 	using System.Collections;
+	using System.Reflection;
 	using System.Text;
 	using System.Collections.Generic;
 
@@ -39,7 +40,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			{
 				base.PerformProceed (invocation);
 			}
-			else if (invocation.Method.ReturnType.IsValueType && invocation.Method.ReturnType != typeof (void))
+			else if (invocation.Method.ReturnType.GetTypeInfo().IsValueType && invocation.Method.ReturnType != typeof (void))
 			{
 				invocation.ReturnValue = Activator.CreateInstance (invocation.Method.ReturnType); // set default return value
 			}

--- a/src/Castle.Core.Tests/ReflectionBasedDictionaryAdapterTestCase.cs
+++ b/src/Castle.Core.Tests/ReflectionBasedDictionaryAdapterTestCase.cs
@@ -16,6 +16,7 @@ namespace Castle.Core.Tests
 {
 	using System;
 	using System.Collections;
+	using System.Reflection;
 
 	using Castle.Core;
 
@@ -109,7 +110,7 @@ namespace Castle.Core.Tests
 		public void Using_anonymous_types_works_without_exception()
 		{
 			var target = new { foo = 1, name = "john", age = 25 };
-			Assert.IsFalse(target.GetType().IsPublic);
+			Assert.IsFalse(target.GetType().GetTypeInfo().IsPublic);
 			var dict = new ReflectionBasedDictionaryAdapter(target);
 
 			Assert.AreEqual(3, dict.Count);

--- a/src/Castle.Core/Castle.Core.csproj
+++ b/src/Castle.Core/Castle.Core.csproj
@@ -26,7 +26,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>TRACE;DEBUG;DOTNET40 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DOTNET40 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -42,7 +42,7 @@
     <OutputPath>bin\NET40-Release\</OutputPath>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;DOTNET40 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DOTNET40 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\NET40-Release\Castle.Core.xml</DocumentationFile>
@@ -55,7 +55,7 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <OutputPath>bin\NET35-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;DOTNET35 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DOTNET35 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <Optimize>true</Optimize>
@@ -72,7 +72,7 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <OutputPath>bin\NET35-Release\</OutputPath>
-    <DefineConstants>TRACE;DOTNET35 FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DOTNET35 FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>bin\NET35-Release\Castle.Core.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -88,7 +88,7 @@
     </TargetFrameworkProfile>
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
     <OutputPath>bin\SL40-Release\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT SL4</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL4 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <DocumentationFile>bin\SL40-Release\Castle.Core.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -105,7 +105,7 @@
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL40-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL4</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL4 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -121,7 +121,7 @@
     </TargetFrameworkProfile>
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
     <OutputPath>bin\SL50-Release\</OutputPath>
-    <DefineConstants>TRACE;SILVERLIGHT SL5</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL5 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <DocumentationFile>bin\SL50-Release\Castle.Core.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -138,7 +138,7 @@
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL40-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL5</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL5 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -183,6 +183,7 @@
     <Compile Include="..\..\buildscripts\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Compatibility\IntrospectionExtensions.cs" />
     <Compile Include="Components.DictionaryAdapter\Util\ListProjectionDebugView.cs" />
     <Compile Include="Components.DictionaryAdapter\Util\ICollectionAdapter.cs" />
     <Compile Include="Components.DictionaryAdapter\Attributes\ReferenceAttribute.cs" />

--- a/src/Castle.Core/Compatibility/IntrospectionExtensions.cs
+++ b/src/Castle.Core/Compatibility/IntrospectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2004-2015 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if FEATURE_LEGACY_REFLECTION_API
+
+namespace System.Reflection
+{
+	internal static class IntrospectionExtensions
+	{
+		// This allows us to use the new reflection API which seperates Type and TypeInfo
+		// while still supporting .NET 3.5 and 4.0.
+		//
+		// Return the System.Type for now, we will probably need to create a TypeInfo class
+		// which inherits from Type like .NET 4.5 and implement the additional methods and
+		// properties.
+		public static Type GetTypeInfo(this Type type)
+		{
+			return type;
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapterVisitor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapterVisitor.cs
@@ -18,6 +18,7 @@ namespace Castle.Components.DictionaryAdapter
 	using System.Linq;
 	using System.Collections;
 	using System.Collections.Generic;
+	using System.Reflection;
 
 	using Castle.Core;
 
@@ -68,7 +69,7 @@ namespace Castle.Components.DictionaryAdapter
 					{
 						VisitCollection(dictionaryAdapter, property, collectionItemType, state);
 					}
-					else if (property.PropertyType.IsInterface)
+					else if (property.PropertyType.GetTypeInfo().IsInterface)
 					{
 						VisitInterface(dictionaryAdapter, property, state);
 					}
@@ -137,11 +138,11 @@ namespace Castle.Components.DictionaryAdapter
 			var propertyType = property.PropertyType;
 			if (propertyType != typeof(string) && typeof(IEnumerable).IsAssignableFrom(propertyType))
 			{
-				if (propertyType.IsArray)
+				if (propertyType.GetTypeInfo().IsArray)
 				{
 					collectionItemType = propertyType.GetElementType();
 				}
-				else if (propertyType.IsGenericType)
+				else if (propertyType.GetTypeInfo().IsGenericType)
 				{
 					var arguments = propertyType.GetGenericArguments();
 					collectionItemType = arguments[0];

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/OnDemandAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/OnDemandAttribute.cs
@@ -67,7 +67,7 @@ namespace Castle.Components.DictionaryAdapter
 
 					if (IsAcceptedType(type))
 					{
-						if (type.IsInterface)
+						if (type.GetTypeInfo().IsInterface)
 						{
 							if (property.IsDynamicProperty == false)
 							{
@@ -77,7 +77,7 @@ namespace Castle.Components.DictionaryAdapter
 								}
 							}
 						}
-						else if (type.IsArray)
+						else if (type.GetTypeInfo().IsArray)
 						{
 							storedValue = Array.CreateInstance(type.GetElementType(), 0);
 						}
@@ -139,7 +139,7 @@ namespace Castle.Components.DictionaryAdapter
 
 		private static bool IsAcceptedType(Type type)
 		{
-			return type != null && type != typeof(String) && !type.IsPrimitive && !type.IsEnum;
+			return type != null && type != typeof(string) && !type.GetTypeInfo().IsPrimitive && !type.GetTypeInfo().IsEnum;
 		}
 
 		private static Type GetInferredType(IDictionaryAdapter dictionaryAdapter, PropertyDescriptor property, out IValueInitializer initializer)
@@ -155,11 +155,11 @@ namespace Castle.Components.DictionaryAdapter
 
 			Type collectionType = null;
 
-			if (type.IsGenericType)
+			if (type.GetTypeInfo().IsGenericType)
 			{
 				var genericDef = type.GetGenericTypeDefinition();
 				var genericArg = type.GetGenericArguments()[0];
-				bool isBindingList = 
+				bool isBindingList =
 #if SILVERLIGHT
 					false;
 #else
@@ -176,10 +176,9 @@ namespace Castle.Components.DictionaryAdapter
 						collectionType = isBindingList ? typeof(EditableBindingList<>) : typeof(EditableList<>);
 #endif
 					}
-					
-#if SILVERLIGHT //never true
-#else
-					if (isBindingList && genericArg.IsInterface)
+
+#if !SILVERLIGHT
+					if (isBindingList && genericArg.GetTypeInfo().IsInterface)
 					{
 						Func<object> addNew = () => dictionaryAdapter.Create(genericArg);
 						initializer = (IValueInitializer)Activator.CreateInstance(

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfAttribute.cs
@@ -17,6 +17,7 @@ namespace Castle.Components.DictionaryAdapter
 	using System;
 	using System.Linq;
 	using System.Collections;
+	using System.Reflection;
 
 	/// <summary>
 	/// Removes a property if matches value.
@@ -77,7 +78,7 @@ namespace Castle.Components.DictionaryAdapter
 				throw new ArgumentNullException(paramName);
 			}
 
-			if (type.IsAbstract == false && typeof(TBase).IsAssignableFrom(type))
+			if (type.GetTypeInfo().IsAbstract == false && typeof(TBase).IsAssignableFrom(type))
 			{
 				var constructor = type.GetConstructor(Type.EmptyTypes);
 				if (constructor != null)
@@ -85,7 +86,7 @@ namespace Castle.Components.DictionaryAdapter
 					return (TBase)constructor.Invoke(new object[0]);
 				}
 			}
-				
+
 			throw new ArgumentException(string.Format(
 				"{0} is not a concrete type implementing {1} with a default constructor",
 				type.FullName, typeof(TBase).FullName));

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringListAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringListAttribute.cs
@@ -18,6 +18,7 @@ namespace Castle.Components.DictionaryAdapter
 	using System.Collections;
 	using System.Collections.Generic;
 	using System.ComponentModel;
+	using System.Reflection;
 	using System.Text;
 
 	/// <summary>
@@ -45,7 +46,7 @@ namespace Castle.Components.DictionaryAdapter
 
 			if (storedValue == null || !storedValue.GetType().IsInstanceOfType(propertyType))
 			{
-				if (propertyType.IsGenericType)
+				if (propertyType.GetTypeInfo().IsGenericType)
 				{
 					var genericDef = propertyType.GetGenericTypeDefinition();
 

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterFactory.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterFactory.cs
@@ -134,8 +134,9 @@ namespace Castle.Components.DictionaryAdapter
 		{
 			if (type == null)
 				throw new ArgumentNullException("type");
-			if (type.IsInterface == false)
+			if (type.GetTypeInfo().IsInterface == false)
 				throw new ArgumentException("Only interfaces can be adapted to a dictionary", "type");
+
 			DictionaryAdapterMeta meta;
 
 			using (interfaceToMetaLock.ForReading())
@@ -402,7 +403,7 @@ namespace Castle.Components.DictionaryAdapter
 			PreparePropertyMethod(descriptor, setILGenerator);
 
 			setILGenerator.Emit(OpCodes.Ldarg_1);
-			if (descriptor.PropertyType.IsValueType)
+			if (descriptor.PropertyType.GetTypeInfo().IsValueType)
 			{
 				setILGenerator.Emit(OpCodes.Box, descriptor.PropertyType);
 			}

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjection.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjection.cs
@@ -19,6 +19,8 @@ namespace Castle.Components.DictionaryAdapter
 	using System.Collections.Generic;
 	using System.ComponentModel;
 	using System.Diagnostics;
+	using System.Reflection;
+
 	using SysPropertyDescriptor = System.ComponentModel.PropertyDescriptor;
 
 	[DebuggerDisplay("Count = {Count}, Adapter = {Adapter}")]
@@ -432,7 +434,7 @@ namespace Castle.Components.DictionaryAdapter
 #else
 		private void AttachPropertyChanged(T value)
 		{
-			if (typeof(T).IsValueType)
+			if (typeof(T).GetTypeInfo().IsValueType)
 				return;
 
 			var notifier = value as INotifyPropertyChanged;
@@ -447,7 +449,7 @@ namespace Castle.Components.DictionaryAdapter
 
 		private void DetachPropertyChanged(T value)
 		{
-			if (typeof(T).IsValueType)
+			if (typeof(T).GetTypeInfo().IsValueType)
 				return;
 
 			var notifier = value as INotifyPropertyChanged;

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadata.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadata.cs
@@ -18,6 +18,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
+	using System.Reflection;
 	using System.Xml;
 	using System.Xml.Serialization;
 
@@ -284,7 +285,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 			switch (kind)
 			{
 				case XmlTypeKind.Complex:
-					if (!clrType.IsInterface) goto default;
+					if (!clrType.GetTypeInfo().IsInterface) goto default;
 					return GetXmlMetadata(clrType).XsiType;
 
 				case XmlTypeKind.Collection:
@@ -338,7 +339,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 		{
 			var kind = XmlTypeSerializer.For(clrType).Kind;
 
-			return kind == XmlTypeKind.Complex && clrType.IsInterface
+			return kind == XmlTypeKind.Complex && clrType.GetTypeInfo().IsInterface
 				? Try.Success(out metadata, GetXmlMetadata(clrType))
 				: Try.Failure(out metadata);
 		}

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
@@ -18,6 +18,8 @@ namespace Castle.Components.DictionaryAdapter.Xml
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
+	using System.Reflection;
+
 	using Castle.Core;
 	using Castle.Core.Internal;
 
@@ -420,7 +422,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 
 		private static bool ShouldExclude(Type type)
 		{
-			return type.IsValueType
+			return type.GetTypeInfo().IsValueType
 				|| type == StringType;
 		}
 

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializerCache.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializerCache.cs
@@ -18,6 +18,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 	using System;
 	using System.Collections.Generic;
 	using System.ComponentModel;
+	using System.Reflection;
 	using System.Xml.Serialization;
 
 	internal class XmlTypeSerializerCache : SingletonDispenser<Type, XmlTypeSerializer>
@@ -53,10 +54,10 @@ namespace Castle.Components.DictionaryAdapter.Xml
 
 		private static XmlTypeSerializer CreateSerializer(Type type)
 		{
-			if (type.IsArray)
+			if (type.GetTypeInfo().IsArray)
 				return XmlArraySerializer.Instance;
 
-			if (type.IsGenericType)
+			if (type.GetTypeInfo().IsGenericType)
 			{
 				var genericType = type.GetGenericTypeDefinition();
 				if (genericType == typeof(IList<>) ||
@@ -88,10 +89,10 @@ namespace Castle.Components.DictionaryAdapter.Xml
 					throw Error.UnsupportedCollectionType(type);
 			}
 
-			if (type.IsInterface)
-			    return XmlComponentSerializer.Instance;
-		    if (type.IsEnum)
-		        return XmlEnumerationSerializer.Instance;
+			if (type.GetTypeInfo().IsInterface)
+				return XmlComponentSerializer.Instance;
+			if (type.GetTypeInfo().IsEnum)
+				return XmlEnumerationSerializer.Instance;
 			if (type.IsCustomSerializable())
 				return XmlCustomSerializer.Instance;
 #if !SILVERLIGHT

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/TypeExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/TypeExtensions.cs
@@ -17,13 +17,14 @@ namespace Castle.Components.DictionaryAdapter.Xml
 {
 	using System;
 	using System.Linq;
+	using System.Reflection;
 	using System.Xml.Serialization;
 
 	public static class TypeExtensions
 	{
 		public static Type NonNullable(this Type type)
 		{
-			return type.IsGenericType
+			return type.GetTypeInfo().IsGenericType
 				&& type.GetGenericTypeDefinition() == typeof(Nullable<>)
 				? type.GetGenericArguments()[0]
 				: type;
@@ -31,9 +32,9 @@ namespace Castle.Components.DictionaryAdapter.Xml
 
 		public static Type GetCollectionItemType(this Type type)
 		{
-			if (type.IsArray)
+			if (type.GetTypeInfo().IsArray)
 				return type.GetElementType();
-			if (type.IsGenericType)
+			if (type.GetTypeInfo().IsGenericType)
 				return type.GetGenericArguments().Single();
 			throw Error.NotCollectionType("type");
 		}

--- a/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
+++ b/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
@@ -18,6 +18,7 @@ namespace Castle.Core.Internal
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Linq;
+	using System.Reflection;
 
 	internal sealed class InterfaceAttributeUtil
 	{
@@ -44,7 +45,7 @@ namespace Castle.Core.Internal
 
 		public static object[] GetAttributes(Type type, bool inherit)
 		{
-			if (type.IsInterface == false)
+			if (type.GetTypeInfo().IsInterface == false)
 				throw new ArgumentOutOfRangeException("type");
 
 			var attributes = type.GetCustomAttributes(false);

--- a/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
@@ -181,7 +181,7 @@ namespace Castle.DynamicProxy
 
 			string methodKindIs;
 			string methodKindDescription;
-			if (Method.DeclaringType.IsClass && Method.IsAbstract)
+			if (Method.DeclaringType.GetTypeInfo().IsClass && Method.IsAbstract)
 			{
 				methodKindIs = "is abstract";
 				methodKindDescription = "an abstract method";

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -160,7 +160,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		private IInvocationCreationContributor GetContributor(Type @delegate, MetaMethod method)
 		{
-			if (@delegate.IsGenericType == false)
+			if (@delegate.GetTypeInfo().IsGenericType == false)
 			{
 				return new InvocationWithDelegateContributor(@delegate, targetType, method, namingScope);
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -107,7 +107,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		private IInvocationCreationContributor GetContributor(Type @delegate, MetaMethod method)
 		{
-			if (@delegate.IsGenericType == false)
+			if (@delegate.GetTypeInfo().IsGenericType == false)
 			{
 				return new InvocationWithDelegateContributor(@delegate, targetType, method, namingScope);
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
+	using System.Reflection;
 
 	using Castle.Core.Logging;
 	using Castle.DynamicProxy.Generators;
@@ -98,7 +99,7 @@ namespace Castle.DynamicProxy.Contributors
 		public void AddInterfaceToProxy(Type @interface)
 		{
 			Debug.Assert(@interface != null, "@interface == null", "Shouldn't be adding empty interfaces...");
-			Debug.Assert(@interface.IsInterface, "@interface.IsInterface", "Should be adding interfaces only...");
+			Debug.Assert(@interface.GetTypeInfo().IsInterface, "@interface.IsInterface", "Should be adding interfaces only...");
 			Debug.Assert(!interfaces.Contains(@interface), "!interfaces.ContainsKey(@interface)",
 			             "Shouldn't be adding same interface twice...");
 

--- a/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeGenerator.cs
@@ -87,7 +87,7 @@ namespace Castle.DynamicProxy.Contributors
 		private Type[] GetParamTypes(AbstractTypeEmitter @delegate)
 		{
 			var parameters = method.MethodOnTarget.GetParameters();
-			if (@delegate.TypeBuilder.IsGenericType)
+			if (@delegate.TypeBuilder.GetTypeInfo().IsGenericType)
 			{
 				var types = new Type[parameters.Length];
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
@@ -33,7 +33,7 @@ namespace Castle.DynamicProxy.Contributors
 		public InvocationWithDelegateContributor(Type delegateType, Type targetType, MetaMethod method,
 		                                         INamingScope namingScope)
 		{
-			Debug.Assert(delegateType.IsGenericType == false, "delegateType.IsGenericType == false");
+			Debug.Assert(delegateType.GetTypeInfo().IsGenericType == false, "delegateType.IsGenericType == false");
 			this.delegateType = delegateType;
 			this.targetType = targetType;
 			this.method = method;

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
@@ -31,7 +31,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		public InvocationWithGenericDelegateContributor(Type delegateType, MetaMethod method, Reference targetReference)
 		{
-			Debug.Assert(delegateType.IsGenericType, "delegateType.IsGenericType");
+			Debug.Assert(delegateType.GetTypeInfo().IsGenericType, "delegateType.IsGenericType");
 			this.delegateType = delegateType;
 			this.method = method;
 			this.targetReference = targetReference;

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
+	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
@@ -44,7 +45,7 @@ namespace Castle.DynamicProxy.Contributors
 		public void AddEmptyInterface(Type @interface)
 		{
 			Debug.Assert(@interface != null, "@interface == null", "Shouldn't be adding empty interfaces...");
-			Debug.Assert(@interface.IsInterface, "@interface.IsInterface", "Should be adding interfaces only...");
+			Debug.Assert(@interface.GetTypeInfo().IsInterface, "@interface.IsInterface", "Should be adding interfaces only...");
 			Debug.Assert(!interfaces.Contains(@interface), "!interfaces.Contains(@interface)",
 			             "Shouldn't be adding same interface twice...");
 			Debug.Assert(!empty.Contains(@interface), "!empty.Contains(@interface)",

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -119,7 +119,7 @@ namespace Castle.DynamicProxy
 
 		private void AssertValidTypeForTarget(Type type, Type target)
 		{
-			if (type.IsGenericTypeDefinition)
+			if (type.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				throw new GeneratorException(string.Format("Can not create proxy for type {0} because type {1} is an open generic type.",
 															target.GetBestName(), type.GetBestName()));
@@ -152,13 +152,13 @@ namespace Castle.DynamicProxy
 
 		private bool IsPublic(Type target)
 		{
-			return target.IsPublic || target.IsNestedPublic;
+			return target.GetTypeInfo().IsPublic || target.GetTypeInfo().IsNestedPublic;
 		}
 
 		private static bool IsInternal(Type target)
 		{
 			var isTargetNested = target.IsNested;
-			var isNestedAndInternal = isTargetNested && (target.IsNestedAssembly || target.IsNestedFamORAssem);
+			var isNestedAndInternal = isTargetNested && (target.GetTypeInfo().IsNestedAssembly || target.GetTypeInfo().IsNestedFamORAssem);
 			var isInternalNotNested = target.IsVisible == false && isTargetNested == false;
 
 			return isInternalNotNested || isNestedAndInternal;

--- a/src/Castle.Core/DynamicProxy/Generators/AttributeDisassembler.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/AttributeDisassembler.cs
@@ -224,7 +224,7 @@ namespace Castle.DynamicProxy.Generators
 			{
 				return false;
 			}
-			if (type.IsEnum)
+			if (type.GetTypeInfo().IsEnum)
 			{
 				return Enum.ToObject(type, 0);
 			}
@@ -232,11 +232,11 @@ namespace Castle.DynamicProxy.Generators
 			{
 				return Char.MinValue;
 			}
-			if (type.IsPrimitive)
+			if (type.GetTypeInfo().IsPrimitive)
 			{
 				return 0;
 			}
-			if(type.IsArray && parameter.IsDefined(typeof(ParamArrayAttribute), true))
+			if(type.GetTypeInfo().IsArray && parameter.IsDefined(typeof(ParamArrayAttribute), true))
 			{
 				return Array.CreateInstance(type.GetElementType(), 0);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -88,7 +88,7 @@ namespace Castle.DynamicProxy.Generators
 		{
 			Debug.Assert(implementer != null, "implementer != null");
 			Debug.Assert(@interface != null, "@interface != null");
-			Debug.Assert(@interface.IsInterface, "@interface.IsInterface");
+			Debug.Assert(@interface.GetTypeInfo().IsInterface, "@interface.IsInterface");
 
 			if (!mapping.ContainsKey(@interface))
 			{
@@ -131,7 +131,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected void CheckNotGenericTypeDefinition(Type type, string argumentName)
 		{
-			if (type != null && type.IsGenericTypeDefinition)
+			if (type != null && type.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				throw new ArgumentException("Type cannot be a generic type definition. Type: " + type.FullName, argumentName);
 			}
@@ -245,7 +245,7 @@ namespace Castle.DynamicProxy.Generators
 			if (baseConstructorParams != null && baseConstructorParams.Length != 0)
 			{
 				var last = baseConstructorParams.Last();
-				if (last.ParameterType.IsArray && last.HasAttribute<ParamArrayAttribute>())
+				if (last.ParameterType.GetTypeInfo().IsArray && last.HasAttribute<ParamArrayAttribute>())
 				{
 					var parameter = constructor.ConstructorBuilder.DefineParameter(args.Length, ParameterAttributes.None, last.Name);
 					var builder = AttributeUtil.CreateBuilder<ParamArrayAttribute>();
@@ -430,7 +430,7 @@ namespace Castle.DynamicProxy.Generators
 			return constructor.IsPublic
 			       || constructor.IsFamily
 			       || constructor.IsFamilyOrAssembly
-#if !Silverlight
+#if !SILVERLIGHT
 			       || (constructor.IsAssembly && InternalsUtil.IsInternalToDynamicProxy(constructor.DeclaringType.Assembly));
 #else
             ;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -58,7 +58,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		{
 			get
 			{
-				if (TypeBuilder.IsInterface)
+				if (TypeBuilder.GetTypeInfo().IsInterface)
 				{
 					throw new InvalidOperationException("This emitter represents an interface; interfaces have no base types.");
 				}
@@ -132,7 +132,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		public ConstructorEmitter CreateConstructor(params ArgumentReference[] arguments)
 		{
-			if (TypeBuilder.IsInterface)
+			if (TypeBuilder.GetTypeInfo().IsInterface)
 			{
 				throw new InvalidOperationException("Interfaces cannot have constructors.");
 			}
@@ -144,7 +144,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		public void CreateDefaultConstructor()
 		{
-			if (TypeBuilder.IsInterface)
+			if (TypeBuilder.GetTypeInfo().IsInterface)
 			{
 				throw new InvalidOperationException("Interfaces cannot have constructors.");
 			}
@@ -294,7 +294,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 			foreach (var genType in genericType.GetGenericArguments())
 			{
-				if (genType.IsGenericParameter)
+				if (genType.GetTypeInfo().IsGenericParameter)
 				{
 					types.Add(name2GenericType[genType.Name]);
 				}
@@ -341,7 +341,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 					throw;
 				}
 
-				if (type.IsGenericTypeDefinition == false)
+				if (type.GetTypeInfo().IsGenericTypeDefinition == false)
 				{
 					throw;
 				}
@@ -359,7 +359,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		protected virtual void EnsureBuildersAreInAValidState()
 		{
-			if (!typebuilder.IsInterface && constructors.Count == 0)
+			if (!typebuilder.GetTypeInfo().IsInterface && constructors.Count == 0)
 			{
 				CreateDefaultConstructor();
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
@@ -118,7 +118,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		{
 			for (var i = 0; i < parameters.Length; i++)
 			{
-				if (parameters[i].ParameterType.IsByRef)
+				if (parameters[i].ParameterType.GetTypeInfo().IsByRef)
 				{
 					return true;
 				}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		protected virtual IEnumerable<Type> InitializeGenericArgumentsFromBases(ref Type baseType,
 		                                                                        IEnumerable<Type> interfaces)
 		{
-			if (baseType != null && baseType.IsGenericTypeDefinition)
+			if (baseType != null && baseType.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				throw new NotSupportedException("ClassEmitter does not support open generic base types. Type: " + baseType.FullName);
 			}
@@ -81,7 +81,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 			foreach (var inter in interfaces)
 			{
-				if (inter.IsGenericTypeDefinition)
+				if (inter.GetTypeInfo().IsGenericTypeDefinition)
 				{
 					throw new NotSupportedException("ClassEmitter does not support open generic interfaces. Type: " + inter.FullName);
 				}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -49,13 +49,13 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		public static Type ExtractCorrectType(Type paramType, Dictionary<string, GenericTypeParameterBuilder> name2GenericType)
 		{
-			if (paramType.IsArray)
+			if (paramType.GetTypeInfo().IsArray)
 			{
 				var rank = paramType.GetArrayRank();
 
 				var underlyingType = paramType.GetElementType();
 
-				if (underlyingType.IsGenericParameter)
+				if (underlyingType.GetTypeInfo().IsGenericParameter)
 				{
 					GenericTypeParameterBuilder genericType;
 					if (name2GenericType.TryGetValue(underlyingType.Name, out genericType) == false)
@@ -76,7 +76,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				return underlyingType.MakeArrayType(rank);
 			}
 
-			if (paramType.IsGenericParameter)
+			if (paramType.GetTypeInfo().IsGenericParameter)
 			{
 				GenericTypeParameterBuilder value;
 				if (name2GenericType.TryGetValue(paramType.Name, out value))
@@ -124,7 +124,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			Type constraint, MethodInfo methodToCopyGenericsFrom, Type[] originalGenericParameters,
 			GenericTypeParameterBuilder[] newGenericParameters)
 		{
-			if (constraint.IsGenericType)
+			if (constraint.GetTypeInfo().IsGenericType)
 			{
 				var genericArgumentsOfConstraint = constraint.GetGenericArguments();
 
@@ -136,7 +136,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				}
 				return constraint.GetGenericTypeDefinition().MakeGenericType(genericArgumentsOfConstraint);
 			}
-			else if (constraint.IsGenericParameter)
+			else if (constraint.GetTypeInfo().IsGenericParameter)
 			{
 				// Determine the source of the parameter
 				if (constraint.DeclaringMethod != null)
@@ -149,8 +149,8 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				}
 				else // parameter from surrounding type
 				{
-					Trace.Assert(constraint.DeclaringType.IsGenericTypeDefinition);
-					Trace.Assert(methodToCopyGenericsFrom.DeclaringType.IsGenericType
+					Trace.Assert(constraint.DeclaringType.GetTypeInfo().IsGenericTypeDefinition);
+					Trace.Assert(methodToCopyGenericsFrom.DeclaringType.GetTypeInfo().IsGenericType
 					             && constraint.DeclaringType == methodToCopyGenericsFrom.DeclaringType.GetGenericTypeDefinition(),
 					             "When a generic method parameter has a constraint on a generic type parameter, the generic type must be the declaring typer of the method.");
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using System;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	internal abstract class OpCodeUtil
@@ -28,17 +29,17 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// <param name = "type"></param>
 		public static void EmitLoadIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum)
+			if (type.GetTypeInfo().IsEnum)
 			{
 				EmitLoadIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
 				return;
 			}
 
-			if (type.IsByRef)
+			if (type.GetTypeInfo().IsByRef)
 			{
 				throw new NotSupportedException("Cannot load ByRef values");
 			}
-			else if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
+			else if (type.GetTypeInfo().IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{
 				var opCode = LdindOpCodesDictionary.Instance[type];
 
@@ -49,11 +50,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 				gen.Emit(opCode);
 			}
-			else if (type.IsValueType)
+			else if (type.GetTypeInfo().IsValueType)
 			{
 				gen.Emit(OpCodes.Ldobj, type);
 			}
-			else if (type.IsGenericParameter)
+			else if (type.GetTypeInfo().IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Ldobj, type);
 			}
@@ -97,7 +98,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// </summary>
 		public static void EmitLoadOpCodeForDefaultValueOfType(ILGenerator gen, Type type)
 		{
-			if (type.IsPrimitive)
+			if (type.GetTypeInfo().IsPrimitive)
 			{
 				var opCode = LdcOpCodesDictionary.Instance[type];
 				switch (opCode.StackBehaviourPush)
@@ -138,17 +139,17 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// <param name = "type"></param>
 		public static void EmitStoreIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum)
+			if (type.GetTypeInfo().IsEnum)
 			{
 				EmitStoreIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
 				return;
 			}
 
-			if (type.IsByRef)
+			if (type.GetTypeInfo().IsByRef)
 			{
 				throw new NotSupportedException("Cannot store ByRef values");
 			}
-			else if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
+			else if (type.GetTypeInfo().IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{
 				var opCode = StindOpCodesDictionary.Instance[type];
 
@@ -159,11 +160,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 				gen.Emit(opCode);
 			}
-			else if (type.IsValueType)
+			else if (type.GetTypeInfo().IsValueType)
 			{
 				gen.Emit(OpCodes.Stobj, type);
 			}
-			else if (type.IsGenericParameter)
+			else if (type.GetTypeInfo().IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Stobj, type);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BindDelegateExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BindDelegateExpression.cs
@@ -29,7 +29,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 		{
 			delegateCtor = @delegate.GetConstructors()[0];
 			this.methodToBindTo = methodToBindTo;
-			if (@delegate.IsGenericTypeDefinition)
+			if (@delegate.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				var closedDelegate = @delegate.MakeGenericType(genericTypeParams);
 				delegateCtor = TypeBuilder.GetConstructor(closedDelegate, delegateCtor);

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
 	using System.Diagnostics;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{value}")]
@@ -26,7 +27,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 		public ConstReference(object value)
 			: base(value.GetType())
 		{
-			if (!value.GetType().IsPrimitive && !(value is String))
+			if (!value.GetType().GetTypeInfo().IsPrimitive && !(value is String))
 			{
 				throw new ProxyGenerationException("Invalid type to ConstReference");
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	public class ConvertExpression : Expression
@@ -44,19 +45,19 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 				return;
 			}
 
-			if (fromType.IsByRef)
+			if (fromType.GetTypeInfo().IsByRef)
 			{
 				fromType = fromType.GetElementType();
 			}
 
-			if (target.IsByRef)
+			if (target.GetTypeInfo().IsByRef)
 			{
 				target = target.GetElementType();
 			}
 
-			if (target.IsValueType)
+			if (target.GetTypeInfo().IsValueType)
 			{
-				if (fromType.IsValueType)
+				if (fromType.GetTypeInfo().IsValueType)
 				{
 					throw new NotImplementedException("Cannot convert between distinct value types");
 				}
@@ -78,7 +79,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 			}
 			else
 			{
-				if (fromType.IsValueType)
+				if (fromType.GetTypeInfo().IsValueType)
 				{
 					// Box conversion
 					gen.Emit(OpCodes.Box, fromType);
@@ -94,15 +95,15 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		private static void EmitCastIfNeeded(Type from, Type target, ILGenerator gen)
 		{
-			if (target.IsGenericParameter)
+			if (target.GetTypeInfo().IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Unbox_Any, target);
 			}
-			else if (from.IsGenericParameter)
+			else if (from.GetTypeInfo().IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Box, from);
 			}
-			else if (target.IsGenericType && target != from)
+			else if (target.GetTypeInfo().IsGenericType && target != from)
 			{
 				gen.Emit(OpCodes.Castclass, target);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
@@ -50,12 +50,12 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 				fromType = fromType.GetElementType();
 			}
 
-			if (target.GetTypeInfo().IsByRef)
+			if (target.IsByRef)
 			{
 				target = target.GetElementType();
 			}
 
-			if (target.GetTypeInfo().IsValueType)
+			if (target.IsValueType)
 			{
 				if (fromType.GetTypeInfo().IsValueType)
 				{
@@ -95,7 +95,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		private static void EmitCastIfNeeded(Type from, Type target, ILGenerator gen)
 		{
-			if (target.GetTypeInfo().IsGenericParameter)
+			if (target.IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Unbox_Any, target);
 			}
@@ -103,7 +103,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 			{
 				gen.Emit(OpCodes.Box, from);
 			}
-			else if (target.GetTypeInfo().IsGenericType && target != from)
+			else if (target.IsGenericType && target != from)
 			{
 				gen.Emit(OpCodes.Castclass, target);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	public class DefaultValueExpression : Expression
@@ -33,7 +34,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 			{
 				OpCodeUtil.EmitLoadOpCodeForDefaultValueOfType(gen, type);
 			}
-			else if (type.IsValueType || type.IsGenericParameter)
+			else if (type.GetTypeInfo().IsValueType || type.GetTypeInfo().IsGenericParameter)
 			{
 				// TODO: handle decimal explicitly
 				var local = gen.DeclareLocal(type);
@@ -41,7 +42,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 				gen.Emit(OpCodes.Initobj, type);
 				gen.Emit(OpCodes.Ldloc, local);
 			}
-			else if (type.IsByRef)
+			else if (type.GetTypeInfo().IsByRef)
 			{
 				EmitByRef(gen);
 			}
@@ -59,7 +60,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 				OpCodeUtil.EmitLoadOpCodeForDefaultValueOfType(gen, elementType);
 				OpCodeUtil.EmitStoreIndirectOpCodeForType(gen, elementType);
 			}
-			else if (elementType.IsGenericParameter || elementType.IsValueType)
+			else if (elementType.GetTypeInfo().IsGenericParameter || elementType.GetTypeInfo().IsValueType)
 			{
 				gen.Emit(OpCodes.Initobj, elementType);
 			}
@@ -71,13 +72,13 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		private bool IsPrimitiveOrClass(Type type)
 		{
-			if ((type.IsPrimitive && type != typeof(IntPtr)))
+			if ((type.GetTypeInfo().IsPrimitive && type != typeof(IntPtr)))
 			{
 				return true;
 			}
-			return ((type.IsClass || type.IsInterface) &&
-			        type.IsGenericParameter == false &&
-			        type.IsByRef == false);
+			return ((type.GetTypeInfo().IsClass || type.GetTypeInfo().IsInterface) &&
+			        type.GetTypeInfo().IsGenericParameter == false &&
+			        type.GetTypeInfo().IsByRef == false);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
 	using System.Diagnostics;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	/// <summary>
@@ -28,7 +29,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 		public IndirectReference(TypeReference byRefReference) :
 			base(byRefReference, byRefReference.Type.GetElementType())
 		{
-			if (!byRefReference.Type.IsByRef)
+			if (!byRefReference.Type.GetTypeInfo().IsByRef)
 			{
 				throw new ArgumentException("Expected an IsByRef reference", "byRefReference");
 			}
@@ -53,7 +54,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		public static TypeReference WrapIfByRef(TypeReference reference)
 		{
-			return reference.Type.IsByRef ? new IndirectReference(reference) : reference;
+			return reference.Type.GetTypeInfo().IsByRef ? new IndirectReference(reference) : reference;
 		}
 
 		// TODO: Better name

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
+	using System.Reflection;
 	using System.Reflection.Emit;
 
 	/// <summary>
@@ -45,16 +46,16 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 				ArgumentsUtil.EmitLoadOwnerAndReference(reference, gen);
 
-				if (reference.Type.IsByRef)
+				if (reference.Type.GetTypeInfo().IsByRef)
 				{
 					throw new NotSupportedException();
 				}
 
-				if (reference.Type.IsValueType)
+				if (reference.Type.GetTypeInfo().IsValueType)
 				{
 					gen.Emit(OpCodes.Box, reference.Type.UnderlyingSystemType);
 				}
-				else if (reference.Type.IsGenericParameter)
+				else if (reference.Type.GetTypeInfo().IsGenericParameter)
 				{
 					gen.Emit(OpCodes.Box, reference.Type);
 				}

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -35,7 +35,7 @@ namespace Castle.DynamicProxy.Generators
 
 			for (var i = 0; i < parameters.Length; i++)
 			{
-				if (!parameters[i].ParameterType.IsByRef)
+				if (!parameters[i].ParameterType.GetTypeInfo().IsByRef)
 				{
 					continue;
 				}

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -271,12 +271,12 @@ namespace Castle.DynamicProxy.Generators
 					"Base type for proxy is null reference. Please set it to System.Object or some other valid type.");
 			}
 
-			if (!type.IsClass)
+			if (!type.GetTypeInfo().IsClass)
 			{
 				ThrowInvalidBaseType(type, "it is not a class type");
 			}
 
-			if (type.IsSealed)
+			if (type.GetTypeInfo().IsSealed)
 			{
 				ThrowInvalidBaseType(type, "it is sealed");
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -133,7 +133,7 @@ namespace Castle.DynamicProxy.Generators
 				var param = parameters[i];
 
 				var paramType = invocation.GetClosedParameterType(param.ParameterType);
-				if (paramType.GetTypeInfo().IsByRef)
+				if (paramType.IsByRef)
 				{
 					var localReference = invokeMethodOnTarget.CodeBuilder.DeclareLocal(paramType.GetElementType());
 					invokeMethodOnTarget.CodeBuilder

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -133,7 +133,7 @@ namespace Castle.DynamicProxy.Generators
 				var param = parameters[i];
 
 				var paramType = invocation.GetClosedParameterType(param.ParameterType);
-				if (paramType.IsByRef)
+				if (paramType.GetTypeInfo().IsByRef)
 				{
 					var localReference = invokeMethodOnTarget.CodeBuilder.DeclareLocal(paramType.GetElementType());
 					invokeMethodOnTarget.CodeBuilder

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -109,7 +109,7 @@ namespace Castle.DynamicProxy.Generators
 			var methodInfo = Method;
 			var attributes = MethodAttributes.Virtual;
 
-			if (methodInfo.IsFinal || Method.DeclaringType.IsInterface)
+			if (methodInfo.IsFinal || Method.DeclaringType.GetTypeInfo().IsInterface)
 			{
 				attributes |= MethodAttributes.NewSlot;
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElement.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators
 {
 	using System;
+	using System.Reflection;
 
 	public abstract class MetaTypeElement
 	{
@@ -27,7 +28,7 @@ namespace Castle.DynamicProxy.Generators
 
 		internal bool CanBeImplementedExplicitly
 		{
-			get { return sourceType != null && sourceType.IsInterface; }
+			get { return sourceType != null && sourceType.GetTypeInfo().IsInterface; }
 		}
 
 		internal abstract void SwitchToExplicitImplementation();

--- a/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
@@ -48,7 +48,7 @@ namespace Castle.DynamicProxy.Generators
 			var methodEmitter = overrideMethod(method.Name, method.Attributes, MethodToOverride);
 			var proxiedMethod = BuildProxiedMethodBody(methodEmitter, @class, options, namingScope);
 
-			if (MethodToOverride.DeclaringType.IsInterface)
+			if (MethodToOverride.DeclaringType.GetTypeInfo().IsInterface)
 			{
 				@class.TypeBuilder.DefineMethodOverride(proxiedMethod.MethodBuilder, MethodToOverride);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -41,12 +41,12 @@ namespace Castle.DynamicProxy.Generators
 
 				for (var i = 0; i < xArgs.Length; ++i)
 				{
-					if (xArgs[i].IsGenericParameter != yArgs[i].IsGenericParameter)
+					if (xArgs[i].GetTypeInfo().IsGenericParameter != yArgs[i].GetTypeInfo().IsGenericParameter)
 					{
 						return false;
 					}
 
-					if (!xArgs[i].IsGenericParameter && !xArgs[i].Equals(yArgs[i]))
+					if (!xArgs[i].GetTypeInfo().IsGenericParameter && !xArgs[i].Equals(yArgs[i]))
 					{
 						return false;
 					}
@@ -79,12 +79,12 @@ namespace Castle.DynamicProxy.Generators
 
 		public bool EqualSignatureTypes(Type x, Type y)
 		{
-			if (x.IsGenericParameter != y.IsGenericParameter)
+			if (x.GetTypeInfo().IsGenericParameter != y.GetTypeInfo().IsGenericParameter)
 			{
 				return false;
 			}
 
-			if (x.IsGenericParameter)
+			if (x.GetTypeInfo().IsGenericParameter)
 			{
 				if (x.GenericParameterPosition != y.GenericParameterPosition)
 				{

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -62,7 +62,7 @@ namespace Castle.DynamicProxy.Generators
 		{
 			var invocationType = invocation;
 
-			Trace.Assert(MethodToOverride.IsGenericMethod == invocationType.IsGenericTypeDefinition);
+			Trace.Assert(MethodToOverride.IsGenericMethod == invocationType.GetTypeInfo().IsGenericTypeDefinition);
 			var genericArguments = Type.EmptyTypes;
 
 			var constructor = invocation.GetConstructors()[0];
@@ -165,7 +165,7 @@ namespace Castle.DynamicProxy.Generators
 
 		private void EmitLoadGenricMethodArguments(MethodEmitter methodEmitter, MethodInfo method, Reference invocationLocal)
 		{
-			var genericParameters = method.GetGenericArguments().FindAll(t => t.IsGenericParameter);
+			var genericParameters = method.GetGenericArguments().FindAll(t => t.GetTypeInfo().IsGenericParameter);
 			var genericParamsArrayLocal = methodEmitter.CodeBuilder.DeclareLocal(typeof(Type[]));
 			methodEmitter.CodeBuilder.AddStatement(
 				new AssignStatement(genericParamsArrayLocal, new NewArrayExpression(genericParameters.Length, typeof(Type))));
@@ -208,7 +208,7 @@ namespace Castle.DynamicProxy.Generators
 		{
 			for (int i = 0; i < arguments.Length; i++ )
 			{
-				if (arguments[i].Type.IsByRef)
+				if (arguments[i].Type.GetTypeInfo().IsByRef)
 				{
 					return true;
 				}

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -87,7 +87,7 @@ namespace Castle.DynamicProxy.Internal
 		private static object ReadAttributeValue(CustomAttributeTypedArgument argument)
 		{
 			var value = argument.Value;
-			if (argument.ArgumentType.IsArray == false)
+			if (argument.ArgumentType.GetTypeInfo().IsArray == false)
 			{
 				return value;
 			}
@@ -224,7 +224,7 @@ namespace Castle.DynamicProxy.Internal
 		/// </summary>
 		private static bool ShouldSkipAttributeReplication(Type attribute)
 		{
-			if (attribute.IsPublic == false)
+			if (attribute.GetTypeInfo().IsPublic == false)
 			{
 				return true;
 			}

--- a/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
@@ -86,7 +86,7 @@ namespace Castle.DynamicProxy.Internal
 			}
 			var declaringType = proxiedMethod.DeclaringType;
 			MethodInfo methodOnTarget = null;
-			if (declaringType.IsInterface)
+			if (declaringType.GetTypeInfo().IsInterface)
 			{
 				var mapping = type.GetInterfaceMap(declaringType);
 				var index = Array.IndexOf(mapping.InterfaceMethods, proxiedMethod);

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -30,7 +30,7 @@ namespace Castle.DynamicProxy.Internal
 				throw new ArgumentNullException("type");
 			}
 
-			if (type.IsClass == false)
+			if (type.GetTypeInfo().IsClass == false)
 			{
 				throw new ArgumentException(string.Format("Type {0} is not a class type. This method supports only classes", type));
 			}
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Internal
 					continue;
 				}
 
-				if (type.IsInterface)
+				if (type.GetTypeInfo().IsInterface)
 				{
 					if (interfaces.Add(type) == false)
 					{
@@ -95,12 +95,12 @@ namespace Castle.DynamicProxy.Internal
 
 		public static Type GetClosedParameterType(this AbstractTypeEmitter type, Type parameter)
 		{
-			if (parameter.IsGenericTypeDefinition)
+			if (parameter.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				return parameter.GetGenericTypeDefinition().MakeGenericType(type.GetGenericArgumentsFor(parameter));
 			}
 
-			if (parameter.IsGenericType)
+			if (parameter.GetTypeInfo().IsGenericType)
 			{
 				var arguments = parameter.GetGenericArguments();
 				if (CloseGenericParametersIfAny(type, arguments))
@@ -109,22 +109,21 @@ namespace Castle.DynamicProxy.Internal
 				}
 			}
 
-
-			if (parameter.IsGenericParameter)
+			if (parameter.GetTypeInfo().IsGenericParameter)
 			{
 				return type.GetGenericArgument(parameter.Name);
 			}
 
-			if (parameter.IsArray)
+			if (parameter.GetTypeInfo().IsArray)
 			{
 				var elementType = GetClosedParameterType(type, parameter.GetElementType());
-                int rank = parameter.GetArrayRank();
-                return rank == 1
-                    ? elementType.MakeArrayType()
-                    : elementType.MakeArrayType(rank);
+				int rank = parameter.GetArrayRank();
+				return rank == 1
+					? elementType.MakeArrayType()
+					: elementType.MakeArrayType(rank);
 			}
 
-			if (parameter.IsByRef)
+			if (parameter.GetTypeInfo().IsByRef)
 			{
 				var elementType = GetClosedParameterType(type, parameter.GetElementType());
 				return elementType.MakeByRefType();

--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -318,7 +318,7 @@ namespace Castle.DynamicProxy
 				throw new ArgumentNullException("interceptors");
 			}
 
-			if (!interfaceToProxy.IsInterface)
+			if (!interfaceToProxy.GetTypeInfo().IsInterface)
 			{
 				throw new ArgumentException("Specified type is not an interface", "interfaceToProxy");
 			}
@@ -573,7 +573,7 @@ namespace Castle.DynamicProxy
 				throw new ArgumentNullException("interceptors");
 			}
 
-			if (!interfaceToProxy.IsInterface)
+			if (!interfaceToProxy.GetTypeInfo().IsInterface)
 			{
 				throw new ArgumentException("Specified type is not an interface", "interfaceToProxy");
 			}
@@ -592,7 +592,7 @@ namespace Castle.DynamicProxy
 						var iUnknown = Marshal.GetIUnknownForObject(target); // Increment the reference count
 						var interfacePointer = IntPtr.Zero;
 						var result = Marshal.QueryInterface(iUnknown, ref interfaceId, out interfacePointer); // Increment the reference count
-						var isInterfacePointerNull = interfacePointer == IntPtr.Zero;		        
+						var isInterfacePointerNull = interfacePointer == IntPtr.Zero;
 						Marshal.Release(iUnknown); // Decrement the reference count
 						Marshal.Release(interfacePointer); // Decrement the reference count
 
@@ -852,7 +852,7 @@ namespace Castle.DynamicProxy
 				throw new ArgumentNullException("interceptors");
 			}
 
-			if (!interfaceToProxy.IsInterface)
+			if (!interfaceToProxy.GetTypeInfo().IsInterface)
 			{
 				throw new ArgumentException("Specified type is not an interface", "interfaceToProxy");
 			}
@@ -1161,7 +1161,7 @@ namespace Castle.DynamicProxy
 			{
 				throw new ArgumentNullException("options");
 			}
-			if (!classToProxy.IsClass)
+			if (!classToProxy.GetTypeInfo().IsClass)
 			{
 				throw new ArgumentException("'classToProxy' must be a class", "classToProxy");
 			}
@@ -1425,7 +1425,7 @@ namespace Castle.DynamicProxy
 			{
 				throw new ArgumentNullException("options");
 			}
-			if (!classToProxy.IsClass)
+			if (!classToProxy.GetTypeInfo().IsClass)
 			{
 				throw new ArgumentException("'classToProxy' must be a class", "classToProxy");
 			}
@@ -1476,7 +1476,7 @@ namespace Castle.DynamicProxy
 
 		protected void CheckNotGenericTypeDefinition(Type type, string argumentName)
 		{
-			if (type != null && type.IsGenericTypeDefinition)
+			if (type != null && type.GetTypeInfo().IsGenericTypeDefinition)
 			{
 				throw new GeneratorException(string.Format("Can not create proxy for type {0} because it is an open generic type.",
 														   type.GetBestName()));

--- a/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
+++ b/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
@@ -31,7 +31,7 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
@@ -57,7 +57,7 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
@@ -118,7 +118,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Debug\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -132,7 +132,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Release\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -147,7 +147,7 @@
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
     <OutputPath>bin\SL40-Release\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;SILVERLIGHT SL40</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL40 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -164,7 +164,7 @@
     <MSBuildTargets>Silverlight 4.0</MSBuildTargets>
     <OutputPath>bin\SL40-Debug\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL40</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL40 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <FileAlignment>4096</FileAlignment>
@@ -179,7 +179,7 @@
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
     <OutputPath>bin\SL50-Release\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;SILVERLIGHT SL50</DefineConstants>
+    <DefineConstants>TRACE;SILVERLIGHT SL50 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -196,7 +196,7 @@
     <MSBuildTargets>Silverlight 5.0</MSBuildTargets>
     <OutputPath>bin\SL50-Debug\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL50</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SILVERLIGHT SL50 FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <FileAlignment>4096</FileAlignment>

--- a/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
+++ b/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -61,7 +61,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\NET40-Release\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -70,30 +70,34 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\NET40-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NET35-Debug|AnyCPU'">
     <OutputPath>bin\NET35-Debug\</OutputPath>
-    <DefineConstants>FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NET35-Release|AnyCPU'">
     <OutputPath>bin\NET35-Release\</OutputPath>
-    <DefineConstants>FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL40-Debug|AnyCPU'">
     <OutputPath>bin\SL40-Debug\</OutputPath>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL40-Release|AnyCPU'">
     <OutputPath>bin\SL40-Release\</OutputPath>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL50-Debug|AnyCPU'">
     <OutputPath>bin\SL50-Debug\</OutputPath>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL50-Release|AnyCPU'">
     <OutputPath>bin\SL50-Release\</OutputPath>
+    <DefineConstants>FEATURE_LEGACY_REFLECTION_API</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Serilog, Version=1.3.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
+++ b/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
@@ -43,7 +43,7 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>TRACE;DEBUG;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
@@ -68,7 +68,7 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <DocumentationFile>
     </DocumentationFile>
     <DebugSymbols>true</DebugSymbols>
@@ -89,7 +89,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Debug\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -103,7 +103,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <OutputPath>bin\NET35-Release\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>TRACE;FEATURE_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API FEATURE_SERIALIZATION</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -116,7 +116,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL40-Release|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL40-Release\</OutputPath>
-    <DefineConstants>TRACE;</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -129,7 +129,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL40-Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL40-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <FileAlignment>4096</FileAlignment>
@@ -141,7 +141,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL50-Release|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL50-Release\</OutputPath>
-    <DefineConstants>TRACE;</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <Optimize>true</Optimize>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -154,7 +154,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SL50-Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\SL50-Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_LEGACY_REFLECTION_API</DefineConstants>
     <BaseAddress>285212672</BaseAddress>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <FileAlignment>4096</FileAlignment>


### PR DESCRIPTION
Switch to using the new `TypeInfo` based reflection API rather than the legacy properties on `Type` so that we can take advantage of newer platforms (e.g. .NET Core and UWP). I've added a `FEATURE_LEGACY_REFLECTION_API` conditional symbol which provides a shim to the old reflection API to support .NET 3.5 and 4.0.

So far I've only changed the majority of property usages. I've also had to revert a couple of calls to `GetTypeInfo` because they threw "Cannot cast from source type to destination type" on Mono which we'll have to look into, not sure why but the only reason would be if the type didn't implement `IReflectableType`. Will continue migrating the usage over.

I've updated the README symbols matrix with this new symbol.