### PR TITLE
Upgrade to Mono 4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ See the [documentation](docs/README.md).
 
 See the [Releases](https://github.com/castleproject/Core/releases).
 
-## Copyright
-
-Copyright 2004-2015 Castle Project
-
 ## License
 
-Castle Core is licensed under the [Apache 2.0](http://opensource.org/licenses/Apache-2.0) license. Refer to license.txt for more information.
+Castle Core is &copy; 2004-2015 Castle Project. It is free software, and may be redistributed under the terms of the [Apache 2.0](http://opensource.org/licenses/Apache-2.0) license.
 
 ## Building
 
@@ -31,6 +27,8 @@ msbuild /p:Configuration=SL40-Release /t:RunAllTests buildscripts/Build.proj
 ```
 
 ### Mono
+
+Castle Core supports Mono 4.0.2+, previous 4.x releases have serious runtime bugs that cause runtime crashes. Mono 3.x releases used to work well, but are not supported.
 
 ```
 xbuild /p:Configuration=NET45-Release /t:RunAllTests buildscripts/Build.proj

--- a/src/Castle.Core.Tests/BugsReported/ConstraintViolationInDebuggerTestCase.cs
+++ b/src/Castle.Core.Tests/BugsReported/ConstraintViolationInDebuggerTestCase.cs
@@ -25,9 +25,6 @@ namespace Castle.DynamicProxy.Tests.BugsReported
 		// It also produces verifiable code.
 		// In Visual Studio 2010 this test passes just fine with the debugger attached.
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void TestCase()
 		{
 			generator.ProxyBuilder.CreateInterfaceProxyTypeWithTarget(

--- a/src/Castle.Core.Tests/GenericClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/GenericClassProxyTestCase.cs
@@ -114,8 +114,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		[Platform(Exclude = "mono", Reason = "Assertion at sgen-alloc.c:460, condition `*p == NULL' not met. " +
-			"Fixed in https://bugzilla.xamarin.com/show_bug.cgi?id=28182")]
+#if __MonoCS__
+		[Ignore("System.InvalidCastException : Cannot cast from source type to destination type.")]
+#endif
 		public void ProxyWithMethodReturningGenericOfGenericOfT()
 		{
 			var proxy = generator.CreateClassProxy<ClassWithMethodWithReturnArrayOfListOfT>();
@@ -124,9 +125,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void ProxyWithGenericArgumentsAndMethodGenericArguments()
 		{
 			GenClassWithGenMethods<List<object>> proxy =
@@ -142,9 +140,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void ProxyWithGenericArgumentsAndMethodGenericArgumentsWithConstraints()
 		{
 			GenClassWithGenMethodsConstrained<List<object>> proxy =
@@ -160,9 +155,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void ProxyWithGenericArgumentsAndMethodGenericArgumentsWithOneNotDefinedOnType()
 		{
 			GenClassWithGenMethods<List<object>> proxy =
@@ -212,9 +204,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void ClassWithGenMethodOnly()
 		{
 			OnlyGenMethodsClass proxy =
@@ -229,9 +218,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenTypeGenMethodRefType()
 		{
 			KeepDataInterceptor interceptor = new KeepDataInterceptor();
@@ -247,9 +233,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenTypeGenMethodValueType()
 		{
 			KeepDataInterceptor interceptor = new KeepDataInterceptor();
@@ -313,9 +296,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInNongenTypeGenMethod()
 		{
 			KeepDataInterceptor interceptor = new KeepDataInterceptor();
@@ -330,8 +310,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		[Platform(Exclude = "mono", Reason = "Assertion at sgen-alloc.c:460, condition `*p == NULL' not met. " +
-			"Fixed in https://bugzilla.xamarin.com/show_bug.cgi?id=28182")]
 		public void TypeWithGenericMethodHavingArgumentBeingGenericArrayOfT()
 		{
 			var proxy = generator.CreateClassProxy<MethodWithArgumentBeingArrayOfGenericTypeOfT>();

--- a/src/Castle.Core.Tests/GenericInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/GenericInterfaceProxyTestCase.cs
@@ -198,9 +198,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenIfcGenMethodRefTypeNoTarget()
 		{
 			var interceptor = new KeepDataInterceptor();
@@ -218,9 +215,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenIfcGenMethodValueTypeNoTarget()
 		{
 			var interceptor = new KeepDataInterceptor();
@@ -266,9 +260,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInNongenIfcGenMethodNoTarget()
 		{
 			var interceptor = new KeepDataInterceptor();
@@ -283,9 +274,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenIfcGenMethodRefTypeWithTarget()
 		{
 			var interceptor = new KeepDataInterceptor();
@@ -311,9 +299,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInGenIfcGenMethodValueTypeWithTarget()
 		{
 			var interceptor = new KeepDataInterceptor();
@@ -385,9 +370,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void MethodInfoClosedInNongenIfcGenMethodWithTarget()
 		{
 			var interceptor = new KeepDataInterceptor();

--- a/src/Castle.Core.Tests/GenericMethodsProxyTestCase.cs
+++ b/src/Castle.Core.Tests/GenericMethodsProxyTestCase.cs
@@ -27,8 +27,6 @@ namespace Castle.DynamicProxy.Tests
 	public class GenericMethodsProxyTestCase : BasePEVerifyTestCase
 	{
 		[Test]
-		[Platform(Exclude = "mono", Reason = "Assertion at sgen-alloc.c:460, condition `*p == NULL' not met. " +
-			"Fixed in https://bugzilla.xamarin.com/show_bug.cgi?id=28182")]
 		public void GenericMethod_WithArrayOfGenericOfGenericArgument()
 		{
 			var proxy = generator.CreateClassProxy<ClassWithMethodWithArrayOfListOfT>();
@@ -36,9 +34,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void GenericMethod_WithConstraintOnOtherParameter()
 		{
 			var type = typeof(IInterfaceWithGenericMethodWithDependentConstraint);
@@ -57,9 +52,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void GenericMethod_WithConstraintOnSurroundingTypeParameter()
 		{
 			var type = typeof(IGenericInterfaceWithGenericMethodWithDependentConstraint<object>);
@@ -78,8 +70,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		[Platform(Exclude = "mono", Reason = "Assertion at sgen-alloc.c:460, condition `*p == NULL' not met. " +
-			"Fixed in https://bugzilla.xamarin.com/show_bug.cgi?id=28182")]
 		public void GenericMethod_WithGenericOfGenericArgument()
 		{
 			var proxy = generator.CreateClassProxy<ClassWithMethodWithGenericOfGenericOfT>();

--- a/src/Castle.Core.Tests/InterceptorSelectorTestCase.cs
+++ b/src/Castle.Core.Tests/InterceptorSelectorTestCase.cs
@@ -48,9 +48,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-#if __MonoCS__
-		[Ignore("System.Type[] doesn't implement interface Castle.DynamicProxy.IInvocation")]
-#endif
 		public void SelectorWorksForGenericMethods()
 		{
 			var options = new ProxyGenerationOptions();


### PR DESCRIPTION
Re-enable unit tests that now work in 4.0.2 and declare the minimum supported Mono version as 4.0.2.

The unit tests that are ignored on Mono are being tracked in #94.