### PR TITLE
Can create proxy for interface with custom attribute having an enum a…

### DIFF
--- a/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
+++ b/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
@@ -76,16 +76,79 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 
-	public enum SomeEnumForAttributeWithEnumArrayArgument
+	public enum SomeByteEnumForAttributeWithEnumArrayArgument : byte
 	{
 		Default,
 		Special
 	}
 
-	[AttributeUsage(AttributeTargets.All, Inherited = false)]
+	public enum SomeSbyteEnumForAttributeWithEnumArrayArgument : sbyte
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeShortEnumForAttributeWithEnumArrayArgument : short
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeUshortEnumForAttributeWithEnumArrayArgument : ushort
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeIntEnumForAttributeWithEnumArrayArgument : int
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeUintEnumForAttributeWithEnumArrayArgument : uint
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeLongEnumForAttributeWithEnumArrayArgument : long
+	{
+		Default,
+		Special
+	}
+
+	public enum SomeUlongEnumForAttributeWithEnumArrayArgument : ulong
+	{
+		Default,
+		Special
+	}
+
+	[AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
 	public sealed class AttributeWithEnumArrayArgument : Attribute
 	{
-		public AttributeWithEnumArrayArgument(params SomeEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		public AttributeWithEnumArrayArgument(params SomeByteEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeSbyteEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeShortEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeUshortEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeIntEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeUintEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeLongEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+		public AttributeWithEnumArrayArgument(params SomeUlongEnumForAttributeWithEnumArrayArgument[] attributeEnums)
 		{
 		}
 	}
@@ -103,7 +166,14 @@ namespace Castle.DynamicProxy.Tests
 	{
 	}
 
-	[AttributeWithEnumArrayArgument(SomeEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeByteEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeSbyteEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeShortEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeUshortEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeIntEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeUintEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeLongEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeUlongEnumForAttributeWithEnumArrayArgument.Special)]
 	public interface IHasAttributeWithEnumArray
 	{
 	}

--- a/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
+++ b/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
@@ -76,16 +76,16 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 
-    public enum SomeEnumForAttributeWithEnumArrayArgument
-    {
-        Default,
-        Special
-    }
+	public enum SomeEnumForAttributeWithEnumArrayArgument
+	{
+		Default,
+		Special
+	}
 
 	[AttributeUsage(AttributeTargets.All, Inherited = false)]
 	public sealed class AttributeWithEnumArrayArgument : Attribute
 	{
-        public AttributeWithEnumArrayArgument(params SomeEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		public AttributeWithEnumArrayArgument(params SomeEnumForAttributeWithEnumArrayArgument[] attributeEnums)
 		{
 		}
 	}
@@ -103,7 +103,7 @@ namespace Castle.DynamicProxy.Tests
 	{
 	}
 
-    [AttributeWithEnumArrayArgument(SomeEnumForAttributeWithEnumArrayArgument.Special)]
+	[AttributeWithEnumArrayArgument(SomeEnumForAttributeWithEnumArrayArgument.Special)]
 	public interface IHasAttributeWithEnumArray
 	{
 	}

--- a/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
+++ b/src/Castle.Core.Tests/CanDefineAdditionalCustomAttributes.cs
@@ -40,6 +40,12 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+		public void Can_clone_attributes_with_array_enums()
+		{
+			generator.CreateInterfaceProxyWithoutTarget(typeof(IHasAttributeWithEnumArray));
+		}
+
+		[Test]
 		public void On_class()
 		{
 			var options = new ProxyGenerationOptions();
@@ -70,6 +76,20 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 
+    public enum SomeEnumForAttributeWithEnumArrayArgument
+    {
+        Default,
+        Special
+    }
+
+	[AttributeUsage(AttributeTargets.All, Inherited = false)]
+	public sealed class AttributeWithEnumArrayArgument : Attribute
+	{
+        public AttributeWithEnumArrayArgument(params SomeEnumForAttributeWithEnumArrayArgument[] attributeEnums)
+		{
+		}
+	}
+
 	[AttributeUsage(AttributeTargets.All, Inherited = false)]
 	public sealed class AttributeWithIntArrayArgument : Attribute
 	{
@@ -80,6 +100,11 @@ namespace Castle.DynamicProxy.Tests
 
 	[AttributeWithTypeArrayArgument(typeof(string))]
 	public interface IHasAttributeWithTypeArray
+	{
+	}
+
+    [AttributeWithEnumArrayArgument(SomeEnumForAttributeWithEnumArrayArgument.Special)]
+	public interface IHasAttributeWithEnumArray
 	{
 	}
 

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -93,8 +93,8 @@ namespace Castle.DynamicProxy.Internal
 			}
 			//special case for handling arrays in attributes
 			var arguments = GetArguments((IList<CustomAttributeTypedArgument>)value);
-            var array = new object[arguments.Length];
-            arguments.CopyTo(array, 0);
+			var array = new object[arguments.Length];
+			arguments.CopyTo(array, 0);
 			return array;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -93,8 +93,8 @@ namespace Castle.DynamicProxy.Internal
 			}
 			//special case for handling arrays in attributes
 			var arguments = GetArguments((IList<CustomAttributeTypedArgument>)value);
-			var array = Array.CreateInstance(argument.ArgumentType.GetElementType() ?? typeof(object), arguments.Length);
-			arguments.CopyTo(array, 0);
+            var array = new object[arguments.Length];
+            arguments.CopyTo(array, 0);
 			return array;
 		}
 


### PR DESCRIPTION
…rray parameter. Fix for #104

Creating a typed array in AttributeUtil.ReadAttributeValue is not needed and raises an exception when the array is of an enum type because the CustomAttributeTypedArgument.Value returns the Integer behind the enum value.