### PR TITLE
Fix unit tests to actually run on .NET 3.5 under TeamCity

### DIFF
--- a/buildscripts/Build.proj
+++ b/buildscripts/Build.proj
@@ -212,8 +212,8 @@ limitations under the License.
 
 		<Message Text="Running tests from assemblies: $(TestAssemblies)" />
 
-		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(OS)' == 'Windows_NT' " />
-		<Exec Command="mono --runtime=v4.0 ../tools/NUnit/bin/nunit-console.exe $(OutputPath)Castle.Core.Tests.dll -nologo -noshadow -xml=$(NUnitTestResultXmlFiles)" Condition=" '$(OS)' != 'Windows_NT' " />
+		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(OS)' == 'Windows_NT' " ContinueOnError="true" />
+		<Exec Command="mono --runtime=v4.0 ../tools/NUnit/bin/nunit-console.exe $(OutputPath)Castle.Core.Tests.dll -nologo -noshadow -xml=$(NUnitTestResultXmlFiles)" Condition=" '$(OS)' != 'Windows_NT' " ContinueOnError="true" />
 
 		<!-- Publish the unit test results if we are running under TeamCity -->
 		<Message Text="##teamcity[importData type='nunit' path='$(NUnitTestResultXmlFiles)']" Condition="$(TEAMCITY_VERSION) != ''" />

--- a/buildscripts/Build.proj
+++ b/buildscripts/Build.proj
@@ -197,10 +197,6 @@ limitations under the License.
 
 	</Target>
 
-
-	<!-- Use TeamCity's when running on the build server -->
-	<UsingTask TaskName="NUnitTeamCity" AssemblyFile="$(teamcity_dotnet_nunitlauncher_msbuild_task)" Condition=" '$(teamcity_dotnet_nunitlauncher_msbuild_task)' != '' "/>
-
 	<Target
 		Name="_ExecNUnit"
 		>
@@ -216,14 +212,11 @@ limitations under the License.
 
 		<Message Text="Running tests from assemblies: $(TestAssemblies)" />
 
-		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(TEAMCITY_VERSION)' == '' and '$(OS)' == 'Windows_NT' " />
+		<Exec Command="$(NUnitPath)$(NUnitExecutable) /nologo $(TestAssemblies) /xml=$(NUnitTestResultXmlFiles) /framework=$(TargetFrameworkVersion)" Condition=" '$(OS)' == 'Windows_NT' " />
 		<Exec Command="mono --runtime=v4.0 ../tools/NUnit/bin/nunit-console.exe $(OutputPath)Castle.Core.Tests.dll -nologo -noshadow -xml=$(NUnitTestResultXmlFiles)" Condition=" '$(OS)' != 'Windows_NT' " />
 
-		<NUnitTeamCity
-			Assemblies="@(TestAssemblies)"
-			NUnitVersion="NUnit-2.5.5"
-			Condition=" '$(teamcity_dotnet_nunitlauncher_msbuild_task)' != ''"
-		/>
+		<!-- Publish the unit test results if we are running under TeamCity -->
+		<Message Text="##teamcity[importData type='nunit' path='$(NUnitTestResultXmlFiles)']" Condition="$(TEAMCITY_VERSION) != ''" />
 
 	</Target>
 

--- a/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
@@ -286,6 +286,9 @@ namespace CastleTests
 		}
 
 		[Test]
+#if DOTNET35
+		[Ignore("https://support.microsoft.com/en-us/kb/960240")]
+#endif
 		public void ProxyTypeWithMultiDimentionalArrayAsParameters()
 		{
 			LogInvocationInterceptor log = new LogInvocationInterceptor();

--- a/src/Castle.Core.Tests/BasicInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicInterfaceProxyTestCase.cs
@@ -105,6 +105,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+#if DOTNET35
+		[Ignore("Signature of the body and declaration in a method implementation do not match. https://support.microsoft.com/en-us/kb/960240")]
+#endif
 		public void ProxyTypeWithMultiDimentionalArrayAsParameter()
 		{
 			var proxy = generator.CreateInterfaceProxyWithTarget<IClassWithMultiDimentionalArray>(


### PR DESCRIPTION
Under TeamCity because the `NUnitTeamCity` MSBuild task was taking over it ended up running the unit tests under 4.0 because we need MSBuild 4.0 to run the build scripts.

This changes from using the MSBuild task to publishing the results using the service messages.

Fixes #122

/cc @jeremymeng