### PR TITLE
Add NETCORE build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ artifacts/
 src/**/obj/
 src/**/bin/
 project.lock.json
+/.dnx/

--- a/buildscripts/Build-NetCore.ps1
+++ b/buildscripts/Build-NetCore.ps1
@@ -1,0 +1,39 @@
+$frameworkVersion = "1.0.0-rc1-update1"
+$frameworkArchitecture = "x86"
+
+$dnxHome = Join-Path (Get-Location) ".dnx"
+$dnxPath = Join-Path $dnxHome "bin"
+
+Write-Host "Downloading dnvm to: $dnxPath"
+if (!(Test-Path $dnxPath)) { md $dnxPath | Out-Null }
+
+$dnvmPs1Path = Join-Path $dnxPath "dnvm.ps1"
+$dnvmCmdPath = Join-Path $dnxPath "dnvm.cmd"
+
+$wc = New-Object System.Net.WebClient
+$wc.DownloadFile('https://raw.githubusercontent.com/aspnet/Home/dev/dnvm.ps1', $dnvmPs1Path)
+$wc.DownloadFile('https://raw.githubusercontent.com/aspnet/Home/dev/dnvm.cmd', $dnvmCmdPath)
+
+Write-Host "Downloading dnx"
+
+$env:PATH = ("$dnxPath;" + $env:PATH)
+
+dnvm install $frameworkVersion -runtime coreclr -arch $frameworkArchitecture
+
+dnx --version
+
+Write-Host "Downloading packages"
+
+dnu restore
+
+Write-Host "Building"
+
+$env:Path = ((Join-Path $dnxHome "runtimes\dnx-coreclr-win-$frameworkArchitecture.$frameworkVersion\bin") + ";" + $env:Path)
+
+dnu build src/Castle.Core src/Castle.Core.Tests --configuration Release --out build/NETCORE
+
+Write-Host "Running tests"
+
+dnx -p src/Castle.Core.Tests test
+
+exit $LASTEXITCODE

--- a/buildscripts/Build-NetCore.ps1
+++ b/buildscripts/Build-NetCore.ps1
@@ -34,6 +34,7 @@ dnu build src/Castle.Core src/Castle.Core.Tests --configuration Release --out bu
 
 Write-Host "Running tests"
 
-dnx -p src/Castle.Core.Tests test
+cd src/Castle.Core.Tests
+dnx test
 
 exit $LASTEXITCODE

--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -19,6 +19,13 @@ IF NOT EXIST %~dp0..\Settings.proj GOTO msbuild_not_configured
 REM Set Framework version based on passed in parameter
 IF "%1" == "" goto no_nothing
 
+REM nesting the netcore build in an IF body prevents reporting of the error level
+IF /i "%1" NEQ "NETCORE" goto not_netcore
+
+PowerShell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Unrestricted -Command %~dp0Build-NetCore.ps1
+EXIT /B %ERRORLEVEL%
+
+:not_netcore
 IF /i "%1" == "NET40" (SET FrameworkVersion=v4.0)
 IF /i "%1" == "NET40" (SET BuildConfigKey=NET40)
 


### PR DESCRIPTION
Fixes #139.
Fixes #130. (Once we have the build server use `build.cmd NETCORE`.)