### PR TITLE
Add notification for virtual but final methods

### DIFF
--- a/src/Castle.Core.Tests/LoggingTestCase.cs
+++ b/src/Castle.Core.Tests/LoggingTestCase.cs
@@ -104,9 +104,9 @@ namespace Castle.DynamicProxy.Tests
 			generator.CreateClassProxy<NonVirtualMethodClass>();
 
 			// Assert
-			Assert.True(logger.RecordedMessage(LoggerLevel.Debug, "Excluded non-virtual method ClassMethod on " +
+			Assert.True(logger.RecordedMessage(LoggerLevel.Debug, "Excluded non-overridable method ClassMethod on " +
 				"Castle.DynamicProxy.Tests.LoggingTestCase+NonVirtualMethodClass because it cannot be intercepted."));
-			Assert.True(logger.RecordedMessage(LoggerLevel.Debug, "Excluded sealed method InterfaceMethod on " +
+			Assert.True(logger.RecordedMessage(LoggerLevel.Debug, "Excluded non-overridable method InterfaceMethod on " +
 				"Castle.DynamicProxy.Tests.LoggingTestCase+NonVirtualMethodClass because it cannot be intercepted."));
 		}
 #endif

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -200,20 +200,13 @@ namespace Castle.DynamicProxy.Contributors
 		/// <returns></returns>
 		protected bool AcceptMethod(MethodInfo method, bool onlyVirtuals, IProxyGenerationHook hook)
 		{
-			// we can never intercept a sealed (final) method
-			if (method.IsFinal)
-			{
-				Logger.DebugFormat("Excluded sealed method {0} on {1} because it cannot be intercepted.", method.Name,
-				                   method.DeclaringType.FullName);
-				return false;
-			}
-
 			if (IsInternalAndNotVisibleToDynamicProxy(method))
 			{
 				return false;
 			}
 
-			if (onlyVirtuals && !method.IsVirtual)
+			var isOverridable = method.IsVirtual && !method.IsFinal;
+			if (onlyVirtuals && !isOverridable)
 			{
 				if (
 #if !SILVERLIGHT
@@ -222,10 +215,18 @@ namespace Castle.DynamicProxy.Contributors
 					method.IsGetType() == false &&
 					method.IsMemberwiseClone() == false)
 				{
-					Logger.DebugFormat("Excluded non-virtual method {0} on {1} because it cannot be intercepted.", method.Name,
+					Logger.DebugFormat("Excluded non-overridable method {0} on {1} because it cannot be intercepted.", method.Name,
 					                   method.DeclaringType.FullName);
 					hook.NonProxyableMemberNotification(type, method);
 				}
+				return false;
+			}
+
+			// we can never intercept a sealed (final) method
+			if (method.IsFinal)
+			{
+				Logger.DebugFormat("Excluded sealed method {0} on {1} because it cannot be intercepted.", method.Name,
+				                   method.DeclaringType.FullName);
 				return false;
 			}
 


### PR DESCRIPTION
If a class implements an interface method, the .net runtime marks this method as virtual but final, which means it's not overridable. If such a method should be part of a class (not interface) proxy, we have a problem: since it's marked as final, it's not "accepted" for our proxy. BUT, since it's marked as virtual, the configured proxy generation hook doesn't get any notification.