### PR TITLE
Fix for optional, nullable enum method parameters

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithDefaultValuesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithDefaultValuesTestCase.cs
@@ -34,14 +34,13 @@ namespace Castle.DynamicProxy.Tests
 		// https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.cs#L101
 		[Ignore("System.ArgumentException : Constant does not match the defined type.")]
 #endif
-		public void MethodParameterWithDefaultValue_DefaultValueIsSetOnProxiedMethodAsWell()
+		public void MethodParameterWithDefaultValue_DefaultValueIsNotSetOnProxiedMethod()
 		{
 			var proxiedType = generator.CreateClassProxy<ClassWithMethodWithParameterWithDefaultValue>().GetType();
 
 			var parameter = proxiedType.GetMethod("Method").GetParameters().Single(paramInfo => paramInfo.Name == "value");
 
-			Assert.True(parameter.HasDefaultValue);
-			Assert.AreEqual(3, parameter.DefaultValue);
+			Assert.False(parameter.HasDefaultValue);
 		}
 
 		[Test]

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -15,6 +15,7 @@
 #if !DOTNET35 && !SILVERLIGHT
 namespace CastleTests.DynamicProxy.Tests.Classes
 {
+	using System;
 	using CastleTests.DynamicProxy.Tests.Interfaces;
 
 	public class ClassWithMethodsWithAllKindsOfOptionalParameters : InterfaceWithMethodsWithAllKindsOfOptionalParameters
@@ -236,6 +237,12 @@ namespace CastleTests.DynamicProxy.Tests.Classes
 		}
 
 		public virtual void MethodWithOptionalNonDefaultNullableDecimalParameter(decimal? d = 3m)
+		{
+		}
+		public void MethodWithOptionalNullableEnumParameter(ConsoleColor? c = null)
+		{
+		}
+		public void MethodWithOptionalNonDefaultNullableEnumParameter(ConsoleColor? c = ConsoleColor.Cyan)
 		{
 		}
 	}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -15,6 +15,7 @@
 #if !DOTNET35 && !SILVERLIGHT
 namespace CastleTests.DynamicProxy.Tests.Interfaces
 {
+	using System;
 	public interface InterfaceWithMethodsWithAllKindsOfOptionalParameters
 	{
 		void MethodWithOptionalByteParameter(byte b = 0);
@@ -126,6 +127,8 @@ namespace CastleTests.DynamicProxy.Tests.Interfaces
 		void MethodWithOptionalNullableDecimalarameter(decimal? d = null);
 
 		void MethodWithOptionalNonDefaultNullableDecimalParameter(decimal? d = 3m);
+		void MethodWithOptionalNullableEnumParameter(ConsoleColor? c = null);
+		void MethodWithOptionalNonDefaultNullableEnumParameter(ConsoleColor? c = ConsoleColor.Cyan);
 	}
 }
 #endif

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -156,25 +156,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				{
 					parameterBuilder.SetCustomAttribute(attribute);
 				}
-#if DOTNET45
-				if (parameter.HasDefaultValue && parameter.DefaultValue != null)
-				{
-					if (parameter.ParameterType == typeof(decimal) || parameter.ParameterType == typeof(decimal?))
-					{
-						/*
-						 * Because of a limitation of the .NET Framework, a decimal value may not 
-						 * be passed to SetConstant(), so omit the call in this instance.
-						 * 
-						 * See https://github.com/castleproject/Core/issues/87 and
-						 * https://msdn.microsoft.com/en-au/library/system.reflection.emit.parameterbuilder.setconstant(v=vs.110).aspx
-						 * for additional information.
-						 */
-						continue;
-					}
-					
-					parameterBuilder.SetConstant(parameter.DefaultValue);
-				}
-#endif
 			}
 		}
 


### PR DESCRIPTION
Fixes #141 

I only have VS2015 on my computer, and I ran into a few difficulties:

1. Needed to add `C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64` to `PeVerifyProbingPaths` to avoid test failures.
1. VS wanted to migrate app.config values to Settings.Settings. That is, VS removed the `<userSettings>` element from app.config completely; instead, it inlines that value into the `Settings.settings` and `Settings.Designer.cs` files (duplicated in both places). I'm not sure how user settings were handled in previous versions of Visual Studio, but I guess it now wants to bake the default values into the DLLs. 
1. Couldn't build the `SL40` or `SL50` configurations from Visual Studio, either in `Castle.Core.sln` or `Castle.Core-SL.sln`. Was able to build and run tests from the command-line. Didn't investigate this too much, but I'm guessing that the command-line build does things slightly differently from the VS build.
1. Was not able to test on Mono. I would appreciate if somebody with an established Mono environment would run the unit tests. 