### PR TITLE
Upgrade Serilog to build 509

### DIFF
--- a/src/Castle.Services.Logging.SerilogIntegration/project.json
+++ b/src/Castle.Services.Logging.SerilogIntegration/project.json
@@ -7,8 +7,8 @@
   "licenseUrl": "",
   "dependencies": {
     "Castle.Core": { "target": "project", "version": "" },
-    "Serilog": "2.0.0-beta-505",
-    "Serilog.Sinks.ColoredConsole": "2.0.0-beta-505"
+    "Serilog": "2.0.0-beta-509",
+    "Serilog.Sinks.ColoredConsole": "2.0.0-beta-509"
   },
   "frameworks": {
     "dotnet5.4": { }


### PR DESCRIPTION
Build 509 has assemblies marked CLS compliant.