### PR TITLE
Fix build errors in Mono build.

### DIFF
--- a/src/Castle.Core/Compatibility/CustomAttributeExtensions.cs
+++ b/src/Castle.Core/Compatibility/CustomAttributeExtensions.cs
@@ -29,12 +29,18 @@ namespace System.Reflection
 	{
 		public static IEnumerable<T> GetCustomAttributes<T>(this Assembly element) where T : Attribute
 		{
-			return (IEnumerable<T>)Attribute.GetCustomAttributes(element, typeof(T));
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T)))
+			{
+				yield return a;
+			}
 		}
 
 		public static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element, bool inherit) where T : Attribute
 		{
-			return (IEnumerable<T>)Attribute.GetCustomAttributes(element, typeof(T), inherit);
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T), inherit))
+			{
+				yield return a;
+			}
 		}
 
 		public static bool IsDefined(this MemberInfo element, Type attributeType)

--- a/src/Castle.Core/Core/Internal/AttributesUtil.cs
+++ b/src/Castle.Core/Core/Internal/AttributesUtil.cs
@@ -44,9 +44,26 @@ namespace Castle.Core.Internal
 		{
 			if (typeof(T) != typeof(object))
 			{
+#if __MonoCS__
+				foreach (var a in type.GetTypeInfo().GetCustomAttributes(typeof(T), false))
+				{
+					yield return (T)a;
+				}
+#else
 				return (IEnumerable<T>)type.GetTypeInfo().GetCustomAttributes(typeof(T), false);
+#endif
 			}
-			return (IEnumerable<T>)type.GetTypeInfo().GetCustomAttributes(false);
+			else
+			{
+#if __MonoCS__
+				foreach (var a in type.GetTypeInfo().GetCustomAttributes(false))
+				{
+					yield return (T)a;
+				}
+#else
+				return (IEnumerable<T>)type.GetTypeInfo().GetCustomAttributes(false);
+#endif
+			}
 		}
 
 		/// <summary>
@@ -68,9 +85,26 @@ namespace Castle.Core.Internal
 		{
 			if (typeof(T) != typeof(object))
 			{
+#if __MonoCS__
+				foreach (var a in member.GetCustomAttributes(typeof(T), false))
+				{
+					yield return (T)a;
+				}
+#else
 				return (IEnumerable<T>)member.GetCustomAttributes(typeof(T), false);
+#endif
 			}
-			return (IEnumerable<T>)member.GetCustomAttributes(false);
+			else
+			{
+#if __MonoCS__
+				foreach (var a in member.GetCustomAttributes(false))
+				{
+					yield return (T)a;
+				}
+#else
+				return (IEnumerable<T>)member.GetCustomAttributes(false);
+#endif
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
in Mono, *.GetCustomerAttributes() returns an object array which cannot
be converted to IEnumerable<T>.  So changing to yield return each
element from the array.  In Attributesutil.GetAttributes() I had to use
__MonoCS__ because on Windows TypeInfo.GetCustomAttributes() could
return IEnumerable<Attribute>, and Attribute cannot be casted to T where
T : class.

Fixes #155 

Still needs the PR against master branch for fixes to other build errors.