### PR TITLE
Fix build errors in Mono build.

### DIFF
--- a/src/Castle.Core/Compatibility/CustomAttributeExtensions.cs
+++ b/src/Castle.Core/Compatibility/CustomAttributeExtensions.cs
@@ -29,12 +29,18 @@ namespace System.Reflection
 	{
 		public static IEnumerable<T> GetCustomAttributes<T>(this Assembly element) where T : Attribute
 		{
-			return (IEnumerable<T>)Attribute.GetCustomAttributes(element, typeof(T));
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T)))
+			{
+				yield return a;
+			}
 		}
 
 		public static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element, bool inherit) where T : Attribute
 		{
-			return (IEnumerable<T>)Attribute.GetCustomAttributes(element, typeof(T), inherit);
+			foreach (T a in Attribute.GetCustomAttributes(element, typeof(T), inherit))
+			{
+				yield return a;
+			}
 		}
 
 		public static bool IsDefined(this MemberInfo element, Type attributeType)

--- a/src/Castle.Core/Core/Internal/AttributesUtil.cs
+++ b/src/Castle.Core/Core/Internal/AttributesUtil.cs
@@ -44,9 +44,18 @@ namespace Castle.Core.Internal
 		{
 			if (typeof(T) != typeof(object))
 			{
-				return (IEnumerable<T>)type.GetTypeInfo().GetCustomAttributes(typeof(T), false);
+				foreach (var a in type.GetTypeInfo().GetCustomAttributes(typeof(T), false))
+				{
+					yield return (T)a;
+				}
 			}
-			return (IEnumerable<T>)type.GetTypeInfo().GetCustomAttributes(false);
+			else
+			{
+				foreach (var a in type.GetTypeInfo().GetCustomAttributes(false))
+				{
+					yield return (T)a;
+				}
+			}
 		}
 
 		/// <summary>
@@ -68,9 +77,18 @@ namespace Castle.Core.Internal
 		{
 			if (typeof(T) != typeof(object))
 			{
-				return (IEnumerable<T>)member.GetCustomAttributes(typeof(T), false);
+				foreach (var a in member.GetCustomAttributes(typeof(T), false))
+				{
+					yield return (T)a;
+				}
 			}
-			return (IEnumerable<T>)member.GetCustomAttributes(false);
+			else
+			{
+				foreach (var a in member.GetCustomAttributes(false))
+				{
+					yield return (T)a;
+				}
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Mono compiler issues CS0030 error when an array (of object or Attribute)
is casted to IEnumerable<T>.  So change to yield return each element
from the array.

Fixes #155. 