### PR TITLE
Move framework-specific properties into their target framework section.

### DIFF
--- a/src/Castle.Core.Tests/project.json
+++ b/src/Castle.Core.Tests/project.json
@@ -9,22 +9,27 @@
     "Castle.Core": { "target": "project", "version" : "" },
     "Castle.Services.Logging.SerilogIntegration": { "target": "project", "version" : "" },
     "Castle.Services.Logging.NLogIntegration": { "target": "project", "version": ""},
-    "Microsoft.CSharp": "4.0.0",
     "Serilog.Sinks.TextWriter": "2.0.0-beta-505",
-    "System.Console": "4.0.0-beta-23516",
-    "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204"
+    "xunit": "2.1.0"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnxcore50": { }
+    "dnxcore50": {
+      "compilationOptions": {
+        "define": [ "FEATURE_XUNITNET", "FEATURE_TEST_SERILOGINTEGRATION" ]
+      },
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.0",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
+        "xunit.runner.dnx": "2.1.0-rc1-build204"
+      }
+    }
   },
   "compilationOptions": {
     "warningsAsErrors": true,
-    "define": [ "FEATURE_XUNITNET", "FEATURE_TEST_SERILOGINTEGRATION" ],
     "keyFile": "../../buildscripts/CastleKey.snk"
   },
   "namedResource": {

--- a/src/Castle.Core/project.json
+++ b/src/Castle.Core/project.json
@@ -6,36 +6,40 @@
   "projectUrl": "",
   "licenseUrl": "",
   "dependencies": {
-    "System.AppContext": "4.0.0",
-    "System.Collections.Specialized": "4.0.0",
-    "System.ComponentModel.TypeConverter": "4.0.0",
-    "System.Console": "4.0.0-beta-23516",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
-    "System.Dynamic.Runtime": "4.0.10",
-    "System.Globalization": "4.0.10",
-    "System.Linq": "4.0.0",
-    "System.ObjectModel": "4.0.10",
-    "System.Reflection": "4.0.10",
-    "System.Reflection.Emit": "4.0.0",
-    "System.Reflection.Emit.Lightweight": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
-    "System.Reflection.TypeExtensions": "4.0.0",
-    "System.Runtime.Extensions": "4.0.10",
-    "System.Threading": "4.0.10",
-    "System.Xml.XmlDocument": "4.0.0",
-    "System.Xml.XmlSerializer": "4.0.10"
   },
   "frameworks": {
-    "dotnet5.4": { }
+    "dotnet5.4": {
+      "compilationOptions": {
+        "define": [ "FEATURE_NETCORE_REFLECTION_API" ]
+      },
+      "dependencies": {
+        "System.AppContext": "4.0.0",
+        "System.Collections.Specialized": "4.0.0",
+        "System.ComponentModel.TypeConverter": "4.0.0",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
+        "System.Dynamic.Runtime": "4.0.10",
+        "System.Globalization": "4.0.10",
+        "System.Linq": "4.0.0",
+        "System.ObjectModel": "4.0.10",
+        "System.Reflection": "4.0.10",
+        "System.Reflection.Emit": "4.0.0",
+        "System.Reflection.Emit.Lightweight": "4.0.0",
+        "System.Reflection.Extensions": "4.0.0",
+        "System.Reflection.TypeExtensions": "4.0.0",
+        "System.Runtime.Extensions": "4.0.10",
+        "System.Threading": "4.0.10",
+        "System.Xml.XmlDocument": "4.0.0",
+        "System.Xml.XmlSerializer": "4.0.10"
+      }
+    }
   },
   "compilationOptions": {
     "warningsAsErrors": true,
-    "define": [ "FEATURE_NETCORE_REFLECTION_API" ],
     "keyFile": "../../buildscripts/CastleKey.snk"
   },
   "compileFiles": [
-    "Properties/InternalsVisibleToTests.cs",
     "../../buildscripts/CommonAssemblyInfo.cs"
   ]
 }


### PR DESCRIPTION
Since more target frameworks could be added in the future.