### PR TITLE
Set level of contained object to 99 for ConvertTo-Json.

### DIFF
--- a/buildscripts/Set-VersionInfo.ps1
+++ b/buildscripts/Set-VersionInfo.ps1
@@ -57,5 +57,5 @@ Get-ChildItem -Filter project.json -Recurse |
 
         $json.version = $assembly_informational_version
 
-        $json | ConvertTo-Json | Set-Content -Encoding UTF8 $_.FullName
+        $json | ConvertTo-Json -Depth 99 | Set-Content -Encoding UTF8 $_.FullName
     }


### PR DESCRIPTION
The default value of 2 isn't enough to serialize project.json's object representation.  An argument of 99 should be enough.