### PR TITLE
Support SL5 (.net 4) for referencing by .NET APTCA assembly

### DIFF
--- a/src/Castle.Core/SecurityAssemblyInfo.cs
+++ b/src/Castle.Core/SecurityAssemblyInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Sets up assembly level security settings
-#if ! SILVERLIGHT
+#if SILVERLIGHT
+[assembly: System.Security.SecurityTransparent]
+#else
 [assembly: System.Security.AllowPartiallyTrustedCallers]
 #if DOTNET40
 [assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level2)]


### PR DESCRIPTION
we have a .net 4 assembly with an APTCA attribute and it referencing a "Moq.Silverlight" assembly (we should reference exactly SL version).

while Castle.Core & Moq.Silverlight moved from SL4 to SL5, that assemblies currently are "security critical" http://stackoverflow.com/questions/12092435/system-methodaccessexception-attempt-by-security-transparent-method-to-access-s/13583246#13583246 (sl4 is for .net2, sl5 is for .net4).

please please please, access this small (but useful for us) pull request : )