### PR TITLE
Fix test failure on .NET Core

### DIFF
--- a/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicClassProxyTestCase.cs
@@ -86,11 +86,13 @@ namespace CastleTests
 			// have to use a type that is not from this assembly, because it is marked as internals visible to 
 			// DynamicProxy2
 
-			var type = Type.GetType("System.AppDomainInitializerInfo, mscorlib");
+			var type = Type.GetType("System.StubHelpers.StubHelpers, mscorlib");
 			var exception = Assert.Throws<GeneratorException>(() => generator.CreateClassProxy(type, new StandardInterceptor()));
-			Assert.AreEqual(
-				"Can not create proxy for type System.AppDomainInitializerInfo because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly mscorlib is strong-named.",
-				exception.Message);
+			Assert.IsTrue(
+				exception.Message.StartsWith(
+					"Can not create proxy for type System.StubHelpers.StubHelpers because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly "
+					)
+				);
 		}
 
 		[Test]


### PR DESCRIPTION
Use another internal type from mscorlib since System.AppDomainInitializerInfo is gone in .NET Core 1.0 RTM.  Also change to verify prefix of exception message because the assembly name of the type could be different due to type forwarding in mscorlib.

Fixes #184.