### PR TITLE
Fix `netstandard` target framework moniker in Castle.Core.nuspec file

### DIFF
--- a/buildscripts/Castle.Core.nuspec
+++ b/buildscripts/Castle.Core.nuspec
@@ -17,7 +17,7 @@
       <group targetFramework="net35" />
       <group targetFramework="net40" />
       <group targetFramework="net45" />
-      <group targetFramework=".NETStandard1.3">
+      <group targetFramework="netstandard1.3">
         <dependency id="System.AppContext" version="4.1.0" />
         <dependency id="System.Collections.Specialized" version="4.0.1" />
         <dependency id="System.ComponentModel.TypeConverter" version="4.0.1" />


### PR DESCRIPTION
Previous one prevents from installing a package through NuGet, and [NuGet Gallery](https://www.nuget.org/packages/Castle.Core/4.0.0-alpha001) displays this target as "Unsupported 0.0". Correct TFM is `netstandard1.3`, as in other places. Fixes #191.

<img width="576" alt="2016-07-06 12 10 13" src="https://cloud.githubusercontent.com/assets/1078718/16613025/0b17015e-437b-11e6-8403-707997eeb09a.png">