### PR TITLE
Add Windows SDK v8.1 paths for probing PEVerify.exe

### DIFF
--- a/src/Castle.Core.Tests/BasePEVerifyTestCase.cs
+++ b/src/Castle.Core.Tests/BasePEVerifyTestCase.cs
@@ -28,15 +28,19 @@ namespace Castle.DynamicProxy.Tests
 		private static readonly string[] PeVerifyProbingPaths =
 		{
 			@"C:\Program Files\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools",
-			@"C:\Program Files\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools",
-			@"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\NETFX 4.0 Tools",
-			@"C:\Program Files\Microsoft SDKs\Windows\v7.0A\bin\NETFX 4.0 Tools",
-			@"C:\Program Files\Microsoft SDKs\Windows\v6.0A\Bin",
 			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools",
+			@"C:\Program Files\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools",
+			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools",
+			@"C:\Program Files\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools",
 			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools",
+			@"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\NETFX 4.0 Tools",
 			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1\Bin\NETFX 4.0 Tools",
+			@"C:\Program Files\Microsoft SDKs\Windows\v7.0A\bin\NETFX 4.0 Tools",
 			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools",
+			@"C:\Program Files\Microsoft SDKs\Windows\v7.0A\Bin",
 			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin",
+			@"C:\Program Files\Microsoft SDKs\Windows\v6.0A\Bin",
+			@"C:\Program Files (x86)\Microsoft SDKs\Windows\v6.0A\Bin",
 			@"C:\Program Files (x86)\Microsoft Visual Studio 8\SDK\v2.0\bin"
 		};
 


### PR DESCRIPTION
Also re-order the paths so newer version is picked first.