### PR TITLE
Improve default list of attributes to avoid replicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking Changes:
 
 Enhancements:
 * Add IProxyGenerator interface for the ProxyGenerator class (#215)
+* Improve default list of attributes to avoid replicating. Code Access Security attributes and MarshalAsAttribute will no longer be replicated (#221)
 
 Bugfixes:
 * Fix building on Mono 4.6.1

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Components.DictionaryAdapter.Tests\DynamicDictionaryTests.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\IPhoneWithFetch.cs" />
     <Compile Include="Components.DictionaryAdapter.Tests\NameValueCollectionAdapterTests.cs" />
+    <Compile Include="DynamicProxy.Tests\AttributesToAvoidReplicatingTestCase.cs" />
     <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodsWithAllKindsOfOptionalParameters.cs" />
     <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodWithParameterWithDefaultValue.cs" />
     <Compile Include="DynamicProxy.Tests\Classes\ClassWithMethodWithParameterWithNullDefaultValue.cs" />

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System.ComponentModel;
+	using System.Linq;
+	using System.Reflection;
+#if FEATURE_SECURITY_PERMISSIONS
+	using System.Security.Permissions;
+#endif
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AttributesToAvoidReplicatingTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public void DisplayNameAttribute_should_be_replicated_as_it_is_not_inherited()
+		{
+			var proxy = generator.CreateClassProxy<AttributedClass_DisplayName>();
+			Assert.AreEqual(1, proxy.GetType().GetTypeInfo().GetCustomAttributes<DisplayNameAttribute>().Count());
+		}
+
+		[DisplayName("Test")]
+		public class AttributedClass_DisplayName
+		{
+		}
+
+#if FEATURE_SECURITY_PERMISSIONS
+		[Test]
+		public void SecurityPermissionAttribute_should_not_be_replicated_as_it_is_part_of_cas()
+		{
+			var proxy = generator.CreateClassProxy<AttributedClass_SecurityPermission>();
+			Assert.IsEmpty(proxy.GetType().GetTypeInfo().GetCustomAttributes<SecurityPermissionAttribute>());
+		}
+
+		[SecurityPermission(SecurityAction.Demand)]
+		public class AttributedClass_SecurityPermission
+		{
+		}
+
+		[Test]
+		public void ReflectionPermissionAttribute_should_not_be_replicated_as_it_is_part_of_cas()
+		{
+			var proxy = generator.CreateClassProxy<AttributedClass_ReflectionPermission>();
+			Assert.IsEmpty(proxy.GetType().GetTypeInfo().GetCustomAttributes<ReflectionPermissionAttribute>());
+		}
+
+		[ReflectionPermission(SecurityAction.Demand)]
+		public class AttributedClass_ReflectionPermission
+		{
+		}
+#endif
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/AttributesToAvoidReplicating.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/AttributesToAvoidReplicating.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
 namespace Castle.DynamicProxy.Generators
 {
 	using System;
+	using System.Reflection;
 	using System.Collections.Generic;
-	using System.Runtime.InteropServices;
-#if FEATURE_SECURITY_PERMISSIONS
-	using System.Security.Permissions;
-#endif
+	using System.Linq;
 
 	public static class AttributesToAvoidReplicating
 	{
@@ -27,18 +25,19 @@ namespace Castle.DynamicProxy.Generators
 
 		static AttributesToAvoidReplicating()
 		{
-			Add<ComImportAttribute>();
-#if FEATURE_SECURITY_PERMISSIONS
-			Add<SecurityPermissionAttribute>();
-#endif
+			Add<System.Runtime.InteropServices.ComImportAttribute>();
+			Add<System.Runtime.InteropServices.MarshalAsAttribute>();
 #if !DOTNET35
-			Add<TypeIdentifierAttribute>();
+			Add<System.Runtime.InteropServices.TypeIdentifierAttribute>();
+#endif
+#if FEATURE_SECURITY_PERMISSIONS
+			Add<System.Security.Permissions.SecurityAttribute>();
 #endif
 		}
 
 		public static void Add(Type attribute)
 		{
-			if (attributes.Contains(attribute) == false)
+			if (!attributes.Contains(attribute))
 			{
 				attributes.Add(attribute);
 			}
@@ -49,9 +48,14 @@ namespace Castle.DynamicProxy.Generators
 			Add(typeof(T));
 		}
 
-		public static bool Contains(Type type)
+		public static bool Contains(Type attribute)
 		{
-			return attributes.Contains(type);
+			return attributes.Contains(attribute);
+		}
+
+		internal static bool ShouldAvoid(Type attribute)
+		{
+			return attributes.Any(attr => attr.GetTypeInfo().IsAssignableFrom(attribute.GetTypeInfo()));
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -260,7 +260,7 @@ namespace Castle.DynamicProxy.Internal
 				return true;
 			}
 
-			if (SpecialCaseAttributThatShouldNotBeReplicated(attribute))
+			if (SpecialCaseAttributeThatShouldNotBeReplicated(attribute))
 			{
 				return true;
 			}
@@ -274,9 +274,9 @@ namespace Castle.DynamicProxy.Internal
 			return true;
 		}
 
-		private static bool SpecialCaseAttributThatShouldNotBeReplicated(Type attribute)
+		private static bool SpecialCaseAttributeThatShouldNotBeReplicated(Type attribute)
 		{
-			return AttributesToAvoidReplicating.Contains(attribute);
+			return AttributesToAvoidReplicating.ShouldAvoid(attribute);
 		}
 
 		public static CustomAttributeBuilder CreateBuilder<TAttribute>() where TAttribute : Attribute, new()


### PR DESCRIPTION
Code Access Security attributes and MarshalAsAttribute will no longer be replicated.