### PR TITLE
Deal with untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/**/obj/
 src/**/bin/
 project.lock.json
 /.dnx/
+/.dotnet/


### PR DESCRIPTION
While working on #236 I noticed some untracked files sitting around after a build.
One was easy to deal with as an ignore, but the .NET Core test results looked to me to be going to the wrong directory, so I changed the test run to put them in a path analogous to their NET40, NET45, … siblings.