### PR TITLE
Fix build errors introduced in #236

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyConstructorsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyConstructorsTestCase.cs
@@ -124,9 +124,14 @@ namespace Castle.DynamicProxy.Tests
 		public void Cannot_proxy_inaccessible_class()
 		{
 			var ex = Assert.Throws<GeneratorException>(() => generator.CreateClassProxy(typeof(PrivateClass), new IInterceptor[0]));
-			StringAssert.StartsWith(
-				"Can not create proxy for type Castle.DynamicProxy.Tests.ClassProxyConstructorsTestCase+PrivateClass because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.",
-				ex.Message);
+
+#if FEATURE_GET_REFERENCED_ASSEMBLIES
+			var expectedMessage = "Can not create proxy for type Castle.DynamicProxy.Tests.ClassProxyConstructorsTestCase+PrivateClass because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
+#else
+			var expectedMessage = "Can not create proxy for type Castle.DynamicProxy.Tests.ClassProxyConstructorsTestCase+PrivateClass because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
+#endif
+
+			Assert.AreEqual(expectedMessage, ex.Message);
 		}
 
 		[Test]

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
@@ -64,12 +64,12 @@ namespace Castle.DynamicProxy.Tests
 			string reason;
 			ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName), out reason);
 
-			var expectedReason =
-				"Can not create proxy for method Void APrivateMethod() " +
-				"because it is not accessible. Make it public, or internal " +
-				"and mark your assembly with " +
-				"[assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] " +
-				"attribute, because assembly Castle.Core.Tests is strong-named.";
+#if FEATURE_GET_REFERENCED_ASSEMBLIES
+			var expectedReason = "Can not create proxy for method Void APrivateMethod() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
+#else
+			var expectedReason = "Can not create proxy for method Void APrivateMethod() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
+#endif
+
 			Assert.AreEqual(expectedReason, reason);
 		}
 
@@ -79,7 +79,7 @@ namespace Castle.DynamicProxy.Tests
 				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 		}
 
-		private static readonly object[] AccessibleMethods =
+		public static readonly object[] AccessibleMethods =
 		{
 			new object[] { "APublicMethod" },
 			new object[] { "AProtectedMethod" },
@@ -87,7 +87,7 @@ namespace Castle.DynamicProxy.Tests
 			new object[] { "AProtectedInternalMethod" }
 		};
 
-		private static readonly object[] InaccessibleMethods =
+		public static readonly object[] InaccessibleMethods =
 		{
 			new object[] { "APrivateMethod" },
 		};


### PR DESCRIPTION
.NET Standard 1.3 doesn't support Assembly.GetReferencedAssemblies, so we can't reference `InternalsVisible.ToDynamicProxyGenAssembly2`.
`#if`ing the expected messages. That fixes the NETCORE build on my machine.

I believe the `public` switch will fix the MONO build, but... I haven't tried it (yet?).