### PR TITLE
Refactor build: Dotnet core tests (win7-x64)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: csharp
+
+solution: Castle.Core-VS2017.sln
+
+mono: none
+
+dotnet: none
+
+sudo: required
+
+dist: trusty
+
+before_install:  
+
+    - sudo apt-get -qq update
+    
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  
+    - sudo apt-get install -y libunwind8
+
+    - wget -O - https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash -s -- -i ./dotnetcli/
+
+script:
+
+    - ./dotnetcli/dotnet restore ./src/Castle.Core/Castle.Core-VS2017.csproj
+    
+    - ./dotnetcli/dotnet restore ./src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+    
+    - ./dotnetcli/dotnet restore ./src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration-VS2017.csproj
+    
+    - ./dotnetcli/dotnet restore ./src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration-VS2017.csproj
+    
+    - ./dotnetcli/dotnet restore ./src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj

--- a/Castle.Core-VS2017.sln
+++ b/Castle.Core-VS2017.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Castle Build", "Castle Build", "{1B999D24-B7AB-4997-96E7-08FA05325694}"
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		build-vs2017.cmd = build-vs2017.cmd
 		CHANGELOG.md = CHANGELOG.md

--- a/build
+++ b/build
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# ****************************************************************************
+# Copyright 2004-2013 Castle Project - http://www.castleproject.org/
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ****************************************************************************
+
+
+sudo apt-get -qq update
+    
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  
+sudo apt-get install -y libunwind8
+
+wget -O - https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash -s -- -i ./dotnetcli/
+
+./dotnetcli/dotnet restore ./src/Castle.Core/Castle.Core-VS2017.csproj
+    
+./dotnetcli/dotnet restore ./src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration-VS2017.csproj
+    
+./dotnetcli/dotnet restore ./src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration-VS2017.csproj
+    
+./dotnetcli/dotnet restore ./src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj
+
+./dotnetcli/dotnet restore ./src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+    
+# Tough one, needs a way of excluding desktop clr.
+#./dotnetcli/dotnet build ./src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj

--- a/buildscripts/build-vs2017.cmd
+++ b/buildscripts/build-vs2017.cmd
@@ -38,5 +38,14 @@ dotnet build Castle.Core-VS2017.sln -c %Configuration%
 GOTO test
 
 :test
-%UserProfile%\.nuget\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe src/Castle.Core.Tests/bin/%Configuration%/net46/Castle.Core.Tests.dll
-rem dotnet test ./src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+
+echo Running NET461 Tests
+echo --------------------
+
+%UserProfile%\.nuget\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe src/Castle.Core.Tests/bin/%Configuration%/net461/win7-x64/Castle.Core.Tests.exe
+
+echo Running NETCOREAPP1.1 Tests
+echo ---------------------------
+
+.\src\Castle.Core.Tests\bin\%Configuration%\netcoreapp1.1\win7-x64\Castle.Core.Tests.exe
+

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -31,12 +31,12 @@
 		<DefineConstants>$(DesktopClrConstants)</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net46|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants)</DefineConstants>
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Debug'">
+		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants);FEATURE_TEST_SERILOGINTEGRATION</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net46|Release'">
-		<DefineConstants>$(DesktopClrConstants)</DefineConstants>
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Release'">
+		<DefineConstants>$(DesktopClrConstants);FEATURE_TEST_SERILOGINTEGRATION</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.3|Debug'">
@@ -47,11 +47,11 @@
 		<DefineConstants>$(NetStandardConstants)</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.0|Debug'">
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.1|Debug'">
 		<DefineConstants>$(DiagnosticsConstants);$(NetStandardConstants)</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.0|Release'">
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.1|Release'">
 		<DefineConstants>$(NetStandardConstants)</DefineConstants>
 	</PropertyGroup>
 

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -32,11 +32,11 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants);FEATURE_TEST_SERILOGINTEGRATION</DefineConstants>
+		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Release'">
-		<DefineConstants>$(DesktopClrConstants);FEATURE_TEST_SERILOGINTEGRATION</DefineConstants>
+		<DefineConstants>$(DesktopClrConstants)</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.3|Debug'">

--- a/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
@@ -32,6 +32,8 @@
 		<PackageReference Include="NUnit" Version="3.6.1" />
 		<PackageReference Include="NUnit.Console" Version="3.6.1" />
 		<PackageReference Include="NUnitLite" Version="3.6.1" />
+		<PackageReference Include="log4net" Version="2.0.8" />
+		<PackageReference Include="Serilog" Version="2.0.0" />
 		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
 		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
@@ -49,6 +51,9 @@
 		<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
+		<PackageReference Include="NLog" Version="4.4.1" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
 		<ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
 		<ProjectReference Include="..\Castle.Services.Logging.log4netIntegration\Castle.Services.Logging.log4netIntegration-VS2017.csproj" />
 		<ProjectReference Include="..\Castle.Services.Logging.NLogIntegration\Castle.Services.Logging.NLogIntegration-VS2017.csproj" />
@@ -56,6 +61,7 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
 		<ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
+		<ProjectReference Include="..\Castle.Services.Logging.SerilogIntegration\Castle.Services.Logging.SerilogIntegration-VS2017.csproj" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
 		<Reference Include="Microsoft.CSharp" />

--- a/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
@@ -56,7 +56,6 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
 		<ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
-		<ProjectReference Include="..\Castle.Services.Logging.SerilogIntegration\Castle.Services.Logging.SerilogIntegration-VS2017.csproj" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
 		<Reference Include="Microsoft.CSharp" />

--- a/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests-VS2017.csproj
@@ -1,41 +1,67 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\buildscripts\common.props"></Import>
-  <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <AssemblyName>Castle.Core.Tests</AssemblyName>
-    <RootNamespace>CastleTests</RootNamespace>
-    <SignAssembly>True</SignAssembly>
-    <Version>0.0.0.0</Version>
-    <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <AssemblyOriginatorKeyFile>..\..\buildscripts\CastleKey.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Core.Tests\Resources\file1.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Core.Tests\Resources\MoreRes\file2.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit.Console" Version="3.6.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
-    <ProjectReference Include="..\Castle.Services.Logging.log4netIntegration\Castle.Services.Logging.log4netIntegration-VS2017.csproj" />
-    <ProjectReference Include="..\Castle.Services.Logging.NLogIntegration\Castle.Services.Logging.NLogIntegration-VS2017.csproj" />
-    <ProjectReference Include="..\Castle.Services.Logging.SerilogIntegration\Castle.Services.Logging.SerilogIntegration-VS2017.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="log4netIntegration\log4net.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<Import Project="..\..\buildscripts\common.props"></Import>
+	<PropertyGroup>
+		<TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+		<OutputType>Exe</OutputType>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+		<AssemblyName>Castle.Core.Tests</AssemblyName>
+		<RootNamespace>CastleTests</RootNamespace>
+		<SignAssembly>True</SignAssembly>
+		<Version>0.0.0.0</Version>
+		<AssemblyVersion>0.0.0.0</AssemblyVersion>
+		<AssemblyOriginatorKeyFile>..\..\buildscripts\CastleKey.snk</AssemblyOriginatorKeyFile>
+		<RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+	  <Compile Remove="Components.DictionaryAdapter.Tests\Xml\**" />
+	  <Compile Remove="log4netIntegration\**" />
+	  <Compile Remove="NLogIntegration\**" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="log4netIntegration\log4net.xml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<EmbeddedResource Include="Core.Tests\Resources\file1.txt">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="Core.Tests\Resources\MoreRes\file2.txt">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</EmbeddedResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="NUnit" Version="3.6.1" />
+		<PackageReference Include="NUnit.Console" Version="3.6.1" />
+		<PackageReference Include="NUnitLite" Version="3.6.1" />
+		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+		<PackageReference Include="System.Reflection" Version="4.3.0" />
+		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+		<PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
+		<PackageReference Include="System.ComponentModel" Version="4.3.0" />
+		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XPath" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />
+		<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
+		<ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
+		<ProjectReference Include="..\Castle.Services.Logging.log4netIntegration\Castle.Services.Logging.log4netIntegration-VS2017.csproj" />
+		<ProjectReference Include="..\Castle.Services.Logging.NLogIntegration\Castle.Services.Logging.NLogIntegration-VS2017.csproj" />
+		<ProjectReference Include="..\Castle.Services.Logging.SerilogIntegration\Castle.Services.Logging.SerilogIntegration-VS2017.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+		<ProjectReference Include="..\Castle.Core\Castle.Core-VS2017.csproj" />
+		<ProjectReference Include="..\Castle.Services.Logging.SerilogIntegration\Castle.Services.Logging.SerilogIntegration-VS2017.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="WindowsBase" />
+	</ItemGroup>
+	
 </Project>

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -331,11 +331,6 @@
     <Compile Include="XmlSerializationTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="log4netIntegration\log4netConfig.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>log4netConfig.resx</DependentUpon>
-    </Compile>
     <Compile Include="log4netIntegration\Log4netFactoryTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -514,11 +509,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <Content Include="Core.Tests\Resources\MoreRes\file2.txt" />
-    <EmbeddedResource Include="log4netIntegration\log4netConfig.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>log4netConfig.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Castle.Core\Castle.Core.csproj">

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/MySerializableClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/MySerializableClass.cs
@@ -15,8 +15,9 @@
 namespace Castle.DynamicProxy.Tests.Classes
 {
 	using System;
+#if FEATURE_SERIALIZATION
 	using System.Runtime.Serialization;
-
+#endif
 	/// <summary>
 	/// Summary description for MySerializableClass.
 	/// </summary>

--- a/src/Castle.Core.Tests/Program.cs
+++ b/src/Castle.Core.Tests/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Reflection;
+using NUnit.Common;
+using NUnitLite;
+
+internal class Program
+{
+	public static int Main(string[] args)
+	{
+		return new AutoRun(typeof(Program).GetTypeInfo().Assembly)
+			.Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
+	}
+}

--- a/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj
+++ b/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyName>Castle.Services.Logging.SerilogIntegration</AssemblyName>
     <RootNamespace>Castle.Services.Logging.SerilogIntegration</RootNamespace>

--- a/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj
+++ b/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration-VS2017.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\buildscripts\common.props"></Import>
   
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyName>Castle.Services.Logging.SerilogIntegration</AssemblyName>
     <RootNamespace>Castle.Services.Logging.SerilogIntegration</RootNamespace>

--- a/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration-VS2017.csproj
+++ b/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration-VS2017.csproj
@@ -15,7 +15,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.5'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
Got some dotnet core tests going on windows. A few things to note: 

 - Serilog has gone backwards, I still need to work out why I am getting compilation errors when enabling the build symbol `FEATURE_TEST_SERILOGINTEGRATION`. Care factor is waning. Any help would be appreciated. 

 - log4net upgrade was not possible just yet, a lot of the XmlConfigurator.ConfigureAndWatch relied on Assembly.GetCallingAssembly. This was dropped by MS in the current versions of netstandard because it was vulnerable to inlining. I get it, but damn I miss inlining and linking in C#. 

 - A start has been made on the TravisCI. This review should exclude any efforts here. Consider these delta's as a starting block. Had a helluva time getting this project to build on Ubuntu. Needs more work, these commits should be ignored. 

I consider the AppVeyor implementation complete minus the SeriFlog problems. 
