### PR TITLE
Only release non-null COM interface pointers

### DIFF
--- a/src/Castle.Core.Tests/ComInterfacesTests.cs
+++ b/src/Castle.Core.Tests/ComInterfacesTests.cs
@@ -15,13 +15,23 @@
 #if FEATURE_TEST_COM && !__MonoCS__ // Avoid loading adodb.dll
 namespace Castle.DynamicProxy.Tests
 {
+	using System;
 	using System.Reflection;
+	using System.Runtime.InteropServices;
+
 	using ADODB;
+
 	using NUnit.Framework;
 
 	[TestFixture]
 	public class ComInterfacesTests:BasePEVerifyTestCase
 	{
+		[Test]
+		public void Marshal_Release_throws_when_called_with_IntPtr_Zero()
+		{
+			Assert.Throws<ArgumentNullException>(() => Marshal.Release(IntPtr.Zero));
+		}
+
 		[Test]
 		public void Can_proxy_ADO_RecorsSet()
 		{

--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -595,7 +595,10 @@ namespace Castle.DynamicProxy
 						var result = Marshal.QueryInterface(iUnknown, ref interfaceId, out interfacePointer); // Increment the reference count
 						var isInterfacePointerNull = interfacePointer == IntPtr.Zero;
 						Marshal.Release(iUnknown); // Decrement the reference count
-						Marshal.Release(interfacePointer); // Decrement the reference count
+						if (!isInterfacePointerNull)
+						{
+							Marshal.Release(interfacePointer); // Decrement the reference count
+						}
 
 						if (result == 0 && isInterfacePointerNull)
 						{


### PR DESCRIPTION
While playing around a bit for #280, I stumbled upon what looks like a minor bug:

When given a COM object as the target, `ProxyGenerator.CreateInterfaceProxyWithTargetInterface` checks whether that target implements the specified `interfaceToProxy`. It does this by calling `Marshal.QueryInterface` on the target, seeing whether it got back a non-null interface pointer, and
releasing the retrieved interface pointer (since it doesn't actually need it for anything).

However, the retrieved interface pointer must only be released if it is not a null reference. This commit adds the necessary check for that.