### PR TITLE
Add missing Mono guard for PEVerify

### DIFF
--- a/src/Castle.Core.Tests/CustomModifiersTestCase.cs
+++ b/src/Castle.Core.Tests/CustomModifiersTestCase.cs
@@ -123,9 +123,11 @@ namespace Castle.DynamicProxy.Tests
 				this.AddTypeWithCustomModifiersAsModreqOnReturnType(moduleScope, partialTypeName, customModifiers);
 			}
 
+#if !__MonoCS__ // Mono doesn't have PEVerify
 			// Let's persist and PE-verify the dynamic assembly before it gets used in tests:
 			var assemblyPath = moduleScope.SaveAssembly();
 			base.RunPEVerifyOnGeneratedAssembly(assemblyPath);
+#endif
 		}
 
 		/// <summary>


### PR DESCRIPTION
Once the build bug described in #282 is fixed, this should take care of the compilation error I caused on the Mono build.

Perhaps it would be better to add the `#if !__MonoCS__` directly inside the method body of  `BasePEVerifyTestCase.RunPEVerifyOnGeneratedAssembly` to prevent that preprocessor symbol from spilling into dependent code?