### PR TITLE
Prevent member name collision when proxy implements same generic interface more than twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bugfixes:
+- Prevent member name collision when proxy implements same generic interface more than twice (@stakx, #88)
 - Fix incorrect replication (reversed order) of custom modifiers (modopts and modreqs) on the CLR, does not work yet on Mono (@stakx, #277)
 - Fix COM interface proxy error case throwing exceptions trying to release null pointer from QueryInterface (@stakx, #281)
 

--- a/src/Castle.Core.Tests/BasicInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/BasicInterfaceProxyTestCase.cs
@@ -218,7 +218,7 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void Should_choose_noncolliding_member_names_when_implementing_same_generic_interface_several_times()
+		public void Should_choose_noncolliding_method_names_when_implementing_same_generic_interface_several_times()
 		{
 			var boolInterfaceType = typeof(IGenericWithNonGenericMethod<bool>);
 			var intInterfaceType = typeof(IGenericWithNonGenericMethod<int>);
@@ -231,13 +231,71 @@ namespace Castle.DynamicProxy.Tests
 			var type = proxy.GetType().GetTypeInfo();
 
 			var boolMethod = type.GetRuntimeInterfaceMap(boolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("DoSomething", boolMethod.Name);
+			Assert.AreEqual("SomeMethod", boolMethod.Name);
 
 			var intMethod = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`1[Int32].DoSomething", intMethod.Name);
+			Assert.AreEqual("IGenericWithNonGenericMethod`1[Int32].SomeMethod", intMethod.Name);
 
 			var nestedGenericBoolMethod = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`1[IGenericWithNonGenericMethod`1[Boolean]].DoSomething", nestedGenericBoolMethod.Name);
+			Assert.AreEqual("IGenericWithNonGenericMethod`1[IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", nestedGenericBoolMethod.Name);
+		}
+
+		[Test]
+		public void Should_choose_noncolliding_property_accessor_names_when_implementing_same_generic_interface_several_times()
+		{
+			var boolInterfaceType = typeof(IGenericWithProperty<bool>);
+			var intInterfaceType = typeof(IGenericWithProperty<int>);
+			var nestedGenericBoolInterfaceType = typeof(IGenericWithProperty<IGenericWithProperty<bool>>);
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(
+				boolInterfaceType,
+				new[] { intInterfaceType, nestedGenericBoolInterfaceType });
+
+			var type = proxy.GetType().GetTypeInfo();
+
+			var boolGetter = type.GetRuntimeInterfaceMap(boolInterfaceType).TargetMethods[0];
+			var boolSetter = type.GetRuntimeInterfaceMap(boolInterfaceType).TargetMethods[1];
+			Assert.AreEqual("get_SomeProperty", boolGetter.Name);
+			Assert.AreEqual("set_SomeProperty", boolSetter.Name);
+
+			var intGetter = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
+			var intSetter = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[1];
+			Assert.AreEqual("IGenericWithProperty`1[Int32].get_SomeProperty", intGetter.Name);
+			Assert.AreEqual("IGenericWithProperty`1[Int32].set_SomeProperty", intSetter.Name);
+
+			var nestedGenericBoolGetter = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
+			var nestedGenericBoolSetter = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[1];
+			Assert.AreEqual("IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].get_SomeProperty", nestedGenericBoolGetter.Name);
+			Assert.AreEqual("IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].set_SomeProperty", nestedGenericBoolSetter.Name);
+		}
+
+		[Test]
+		public void Should_choose_noncolliding_event_accessor_names_when_implementing_same_generic_interface_several_times()
+		{
+			var boolInterfaceType = typeof(IGenericWithEvent<bool>);
+			var intInterfaceType = typeof(IGenericWithEvent<int>);
+			var nestedGenericBoolInterfaceType = typeof(IGenericWithEvent<IGenericWithEvent<bool>>);
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(
+				boolInterfaceType,
+				new[] { intInterfaceType, nestedGenericBoolInterfaceType });
+
+			var type = proxy.GetType().GetTypeInfo();
+
+			var boolAdder = type.GetRuntimeInterfaceMap(boolInterfaceType).TargetMethods[0];
+			var boolRemover = type.GetRuntimeInterfaceMap(boolInterfaceType).TargetMethods[1];
+			Assert.AreEqual("add_SomeEvent", boolAdder.Name);
+			Assert.AreEqual("remove_SomeEvent", boolRemover.Name);
+
+			var intAdder = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
+			var intRemover = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[1];
+			Assert.AreEqual("IGenericWithEvent`1[Int32].add_SomeEvent", intAdder.Name);
+			Assert.AreEqual("IGenericWithEvent`1[Int32].remove_SomeEvent", intRemover.Name);
+
+			var nestedGenericBoolAdder = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
+			var nestedGenericBoolRemover = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[1];
+			Assert.AreEqual("IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].add_SomeEvent", nestedGenericBoolAdder.Name);
+			Assert.AreEqual("IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].remove_SomeEvent", nestedGenericBoolRemover.Name);
 		}
 
 		[Test]
@@ -254,13 +312,13 @@ namespace Castle.DynamicProxy.Tests
 			var type = proxy.GetType().GetTypeInfo();
 
 			var boolIntMethod = type.GetRuntimeInterfaceMap(boolIntInterfaceType).TargetMethods[0];
-			Assert.AreEqual("DoSomething", boolIntMethod.Name);
+			Assert.AreEqual("SomeMethod", boolIntMethod.Name);
 
 			var intBoolMethod = type.GetRuntimeInterfaceMap(intBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,Boolean].DoSomething", intBoolMethod.Name);
+			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,Boolean].SomeMethod", intBoolMethod.Name);
 
 			var intNestedGenericBoolMethod = type.GetRuntimeInterfaceMap(intNestedGenericBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,IGenericWithNonGenericMethod`1[Boolean]].DoSomething", intNestedGenericBoolMethod.Name);
+			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", intNestedGenericBoolMethod.Name);
 		}
 
 		private ParameterInfo[] GetMyTestMethodParams(Type type)

--- a/src/Castle.Core.Tests/Interfaces/IGenericWithEvent.cs
+++ b/src/Castle.Core.Tests/Interfaces/IGenericWithEvent.cs
@@ -14,13 +14,10 @@
 
 namespace Castle.DynamicProxy.Tests.Interfaces
 {
-	public interface IGenericWithNonGenericMethod<T>
-	{
-		void SomeMethod();
-	}
+	using System;
 
-	public interface IGenericWithNonGenericMethod<T1, T2>
+	public interface IGenericWithEvent<T>
 	{
-		void SomeMethod();
+		event EventHandler SomeEvent;
 	}
 }

--- a/src/Castle.Core.Tests/Interfaces/IGenericWithNonGenericMethod.cs
+++ b/src/Castle.Core.Tests/Interfaces/IGenericWithNonGenericMethod.cs
@@ -1,0 +1,26 @@
+// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	public interface IGenericWithNonGenericMethod<T>
+	{
+		void DoSomething();
+	}
+
+	public interface IGenericWithNonGenericMethod<T1, T2>
+	{
+		void DoSomething();
+	}
+}

--- a/src/Castle.Core.Tests/Interfaces/IGenericWithProperty.cs
+++ b/src/Castle.Core.Tests/Interfaces/IGenericWithProperty.cs
@@ -14,13 +14,8 @@
 
 namespace Castle.DynamicProxy.Tests.Interfaces
 {
-	public interface IGenericWithNonGenericMethod<T>
+	public interface IGenericWithProperty<T>
 	{
-		void SomeMethod();
-	}
-
-	public interface IGenericWithNonGenericMethod<T1, T2>
-	{
-		void SomeMethod();
+		object SomeProperty { get; set; }
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -145,7 +145,7 @@ namespace Castle.DynamicProxy.Generators
 
 		internal override void SwitchToExplicitImplementation()
 		{
-			name = string.Format("{0}.{1}", sourceType.Name, name);
+			name = MetaTypeElementUtil.CreateNameForExplicitImplementation(sourceType, name);
 			adder.SwitchToExplicitImplementation();
 			remover.SwitchToExplicitImplementation();
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -17,7 +17,6 @@ namespace Castle.DynamicProxy.Generators
 	using System;
 	using System.Diagnostics;
 	using System.Reflection;
-	using System.Text;
 
 	using Castle.DynamicProxy.Internal;
 
@@ -102,30 +101,7 @@ namespace Castle.DynamicProxy.Generators
 				Attributes |= MethodAttributes.SpecialName;
 			}
 
-			var nameBuilder = new StringBuilder();
-			AppendTypeNameTo(nameBuilder, Method.DeclaringType);
-			nameBuilder.Append('.');
-			nameBuilder.Append(Method.Name);
-			name = nameBuilder.ToString();
-		}
-
-		private static void AppendTypeNameTo(StringBuilder stringBuilder, Type type)
-		{
-			stringBuilder.Append(type.Name);
-			if (type.GetTypeInfo().IsGenericType)
-			{
-				stringBuilder.Append('[');
-				var genericTypeArguments = type.GetGenericArguments();
-				for (int i = 0, n = genericTypeArguments.Length; i < n; ++i)
-				{
-					if (i > 0)
-					{
-						stringBuilder.Append(',');
-					}
-					AppendTypeNameTo(stringBuilder, genericTypeArguments[i]);
-				}
-				stringBuilder.Append(']');
-			}
+			name = MetaTypeElementUtil.CreateNameForExplicitImplementation(sourceType, Method.Name);
 		}
 
 		private MethodAttributes ObtainAttributes()

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System;
 	using System.Diagnostics;
 	using System.Reflection;
+	using System.Text;
 
 	using Castle.DynamicProxy.Internal;
 
@@ -101,7 +102,30 @@ namespace Castle.DynamicProxy.Generators
 				Attributes |= MethodAttributes.SpecialName;
 			}
 
-			name = string.Format("{0}.{1}", Method.DeclaringType.Name, Method.Name);
+			var nameBuilder = new StringBuilder();
+			AppendTypeNameTo(nameBuilder, Method.DeclaringType);
+			nameBuilder.Append('.');
+			nameBuilder.Append(Method.Name);
+			name = nameBuilder.ToString();
+		}
+
+		private static void AppendTypeNameTo(StringBuilder stringBuilder, Type type)
+		{
+			stringBuilder.Append(type.Name);
+			if (type.GetTypeInfo().IsGenericType)
+			{
+				stringBuilder.Append('[');
+				var genericTypeArguments = type.GetGenericArguments();
+				for (int i = 0, n = genericTypeArguments.Length; i < n; ++i)
+				{
+					if (i > 0)
+					{
+						stringBuilder.Append(',');
+					}
+					AppendTypeNameTo(stringBuilder, genericTypeArguments[i]);
+				}
+				stringBuilder.Append(']');
+			}
 		}
 
 		private MethodAttributes ObtainAttributes()

--- a/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
@@ -184,7 +184,7 @@ namespace Castle.DynamicProxy.Generators
 
 		internal override void SwitchToExplicitImplementation()
 		{
-			name = string.Format("{0}.{1}", sourceType.Name, name);
+			name = MetaTypeElementUtil.CreateNameForExplicitImplementation(sourceType, name);
 			if (setter != null)
 			{
 				setter.SwitchToExplicitImplementation();

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
@@ -1,0 +1,61 @@
+// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Generators
+{
+	using System;
+	using System.Reflection;
+	using System.Text;
+
+	internal static class MetaTypeElementUtil
+    {
+		[ThreadStatic]
+		private static StringBuilder sharedNameBuilder;
+
+		public static string CreateNameForExplicitImplementation(Type sourceType, string name)
+		{
+			if (sharedNameBuilder == null)
+			{
+				sharedNameBuilder = new StringBuilder();
+			}
+
+			var nameBuilder = sharedNameBuilder;
+			nameBuilder.Length = 0;
+			nameBuilder.AppendNameOf(sourceType);
+			nameBuilder.Append('.');
+			nameBuilder.Append(name);
+
+			return nameBuilder.ToString();
+		}
+
+		private static void AppendNameOf(this StringBuilder nameBuilder, Type type)
+		{
+			nameBuilder.Append(type.Name);
+			if (type.GetTypeInfo().IsGenericType)
+			{
+				nameBuilder.Append('[');
+				var genericTypeArguments = type.GetGenericArguments();
+				for (int i = 0, n = genericTypeArguments.Length; i < n; ++i)
+				{
+					if (i > 0)
+					{
+						nameBuilder.Append(',');
+					}
+					nameBuilder.AppendNameOf(genericTypeArguments[i]);
+				}
+				nameBuilder.Append(']');
+			}
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
@@ -19,24 +19,21 @@ namespace Castle.DynamicProxy.Generators
 	using System.Text;
 
 	internal static class MetaTypeElementUtil
-    {
-		[ThreadStatic]
-		private static StringBuilder sharedNameBuilder;
-
+	{
 		public static string CreateNameForExplicitImplementation(Type sourceType, string name)
 		{
-			if (sharedNameBuilder == null)
+			if (sourceType.GetTypeInfo().IsGenericType)
 			{
-				sharedNameBuilder = new StringBuilder();
+				var nameBuilder = new StringBuilder();
+				nameBuilder.AppendNameOf(sourceType);
+				nameBuilder.Append('.');
+				nameBuilder.Append(name);
+				return nameBuilder.ToString();
 			}
-
-			var nameBuilder = sharedNameBuilder;
-			nameBuilder.Length = 0;
-			nameBuilder.AppendNameOf(sourceType);
-			nameBuilder.Append('.');
-			nameBuilder.Append(name);
-
-			return nameBuilder.ToString();
+			else
+			{
+				return string.Concat(sourceType.Name, ".", name);
+			}
 		}
 
 		private static void AppendNameOf(this StringBuilder nameBuilder, Type type)


### PR DESCRIPTION
After #89, this is a second attempt at fixing #88.

When a proxy is made to implement the same generic interface more than twice, and that generic interface contains a method that does not use any generic type parameters, this can result in a member name collision. This would happen e.g. with a proxy implementing `IObserver<T>` three times.

DynamicProxy already checks for member name collisions, and when it detects one, it switches to explicit interface implementation and prefixes member names with the interface's type name. For the above example, this will add the following methods to the proxy:

    OnCompleted
    IObserver`1.OnCompleted
    IObserver`1.OnCompleted

Because the actual type arguments are omitted and only their count is included, the current collision checks are not sufficient. This commit makes explicitly implemented methods' names unique by including the full type names of the generic type arguments; for instance:

    OnCompleted
    System.IObserver`1[[System.Int32, mscorlib, Version=…, Culture=…, PublicKeyToken=…]].OnCompleted
    System.IObserver`1[[System.String, mscorlib, Version=…, Culture=…, PublicKeyToken=…]].OnCompleted

(I've omitted some detail above for brevity, using `…`.)

This is about the simplest possible solution to #88, but I'm not sure if you are OK with these kinds of member names. They are unique, but also long and ugly (which could be partly mitigated by using `System.CodeDom` to produce more C#-like type names), and they contain whitespace and other special characters; I have no idea whether these are always safe for proxy consumers.

Feel free to request modifications or to close this PR if it's not acceptable.