### PR TITLE
Fix Mono build by excluding failing modopt tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Bugfixes:
-- Fix incorrect replication (reversed order) of custom modifiers (modopts and modreqs) (@stakx, #277)
+- Fix incorrect replication (reversed order) of custom modifiers (modopts and modreqs) on the CLR, does not work yet on Mono (@stakx, #277)
 - Fix COM interface proxy error case throwing exceptions trying to release null pointer from QueryInterface (@stakx, #281)
 
 ## 4.1.0 (2017-06-11)

--- a/src/Castle.Core.Tests/CustomModifiersTestCase.cs
+++ b/src/Castle.Core.Tests/CustomModifiersTestCase.cs
@@ -26,6 +26,11 @@ namespace Castle.DynamicProxy.Tests
 	using NUnit.Framework;
 
 	[TestFixture]
+	[Platform(Exclude = "Mono", Reason = "The tests in this fixture do not pass on Mono, " +
+		"because Mono handles custom modifiers in a slightly different way than the CLR does. " +
+		"Since custom modifiers are less likely to be used on Mono (no C++/CLI compiler), we " +
+		"exclude these tests on Mono for now. For details regarding this decision, see " +
+		"https://github.com/castleproject/Core/issues/277.")]
 	public class CustomModifiersTestCase : BasePEVerifyTestCase
 	{
 		private static Dictionary<string, Type[]> customModifiers;
@@ -147,7 +152,10 @@ namespace Castle.DynamicProxy.Tests
 
 			var modopts = this.generatedTypes[typeName].GetMethod("Foo").GetParameters()[0].GetOptionalCustomModifiers();
 			CollectionAssert.AreEqual(expected: CustomModifiersTestCase.customModifiers[typeNameWithoutSuffix].Reverse(), actual: modopts);
-			// ^ The `.Reverse()` is needed because .NET reports custom modifiers in reverse order.
+			// ^ The `.Reverse()` is needed because the CLR reports custom modifiers in reverse order.
+			//   Note to future maintainers: Mono either does not report custom modifiers at all,
+			//   or it reports them in the correct order. This needs further investigation, but
+			//   in either case, the above assertion would make the test fail on Mono!
 		}
 
 		/// <summary>
@@ -167,7 +175,7 @@ namespace Castle.DynamicProxy.Tests
 
 			var modreqs = this.generatedTypes[typeName].GetMethod("Foo").GetParameters()[0].GetRequiredCustomModifiers();
 			CollectionAssert.AreEqual(expected: CustomModifiersTestCase.customModifiers[typeNameWithoutSuffix].Reverse(), actual: modreqs);
-			// ^ The `.Reverse()` is needed because .NET reports custom modifiers in reverse order.
+			// ^ see comment about `.Reverse()` above.
 		}
 
 		/// <summary>
@@ -187,7 +195,7 @@ namespace Castle.DynamicProxy.Tests
 
 			var modopts = this.generatedTypes[typeName].GetMethod("Foo").ReturnParameter.GetOptionalCustomModifiers();
 			CollectionAssert.AreEqual(expected: CustomModifiersTestCase.customModifiers[typeNameWithoutSuffix].Reverse(), actual: modopts);
-			// ^ The `.Reverse()` is needed because .NET reports custom modifiers in reverse order.
+			// ^ see comment about `.Reverse()` above.
 		}
 
 		/// <summary>
@@ -207,7 +215,7 @@ namespace Castle.DynamicProxy.Tests
 
 			var modreqs = this.generatedTypes[typeName].GetMethod("Foo").ReturnParameter.GetRequiredCustomModifiers();
 			CollectionAssert.AreEqual(expected: CustomModifiersTestCase.customModifiers[typeNameWithoutSuffix].Reverse(), actual: modreqs);
-			// ^ The `.Reverse()` is needed because .NET reports custom modifiers in reverse order.
+			// ^ see comment about `.Reverse()` above.
 		}
 
 		/// <summary>

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -171,24 +171,43 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		private void SetSignature(Type returnType, ParameterInfo returnParameter, Type[] parameters,
 		                          ParameterInfo[] baseMethodParameters)
 		{
+			Type[] returnRequiredCustomModifiers;
+			Type[] returnOptionalCustomModifiers;
+			Type[][] parametersRequiredCustomModifiers;
+			Type[][] parametersOptionalCustomModifiers;
+
+#if FEATURE_EMIT_CUSTOMMODIFIERS
+			returnRequiredCustomModifiers = returnParameter.GetRequiredCustomModifiers();
+			Array.Reverse(returnRequiredCustomModifiers);
+
+			returnOptionalCustomModifiers = returnParameter.GetOptionalCustomModifiers();
+			Array.Reverse(returnOptionalCustomModifiers);
+
+			int parameterCount = baseMethodParameters.Length;
+			parametersRequiredCustomModifiers = new Type[parameterCount][];
+			parametersOptionalCustomModifiers = new Type[parameterCount][];
+			for (int i = 0; i < parameterCount; ++i)
+			{
+				parametersRequiredCustomModifiers[i] = baseMethodParameters[i].GetRequiredCustomModifiers();
+				Array.Reverse(parametersRequiredCustomModifiers[i]);
+
+				parametersOptionalCustomModifiers[i] = baseMethodParameters[i].GetOptionalCustomModifiers();
+				Array.Reverse(parametersOptionalCustomModifiers[i]);
+			}
+#else
+			returnRequiredCustomModifiers = null;
+			returnOptionalCustomModifiers = null;
+			parametersRequiredCustomModifiers = null;
+			parametersOptionalCustomModifiers = null;
+#endif
+
 			builder.SetSignature(
 				returnType,
-#if FEATURE_EMIT_CUSTOMMODIFIERS
-				returnParameter.GetRequiredCustomModifiers().Reverse().ToArray(),
-				returnParameter.GetOptionalCustomModifiers().Reverse().ToArray(),
-#else
-				null,
-				null,
-#endif
+				returnRequiredCustomModifiers,
+				returnOptionalCustomModifiers,
 				parameters,
-#if FEATURE_EMIT_CUSTOMMODIFIERS
-				baseMethodParameters.Select(x => x.GetRequiredCustomModifiers().Reverse().ToArray()).ToArray(),
-				baseMethodParameters.Select(x => x.GetOptionalCustomModifiers().Reverse().ToArray()).ToArray()
-#else
-				null,
-				null
-#endif
-			);
+				parametersRequiredCustomModifiers,
+				parametersOptionalCustomModifiers);
 		}
 	}
 }


### PR DESCRIPTION
as discussed in https://github.com/castleproject/Core/issues/277#issuecomment-312653793. I am happy to provide a proper fix for Mono at a later time, but I guess for now it's more important to have a successful build again.