### PR TITLE
Make `ProxyUtil.IsAccessible(MethodBase)` take into account declaring type's accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Bugfixes:
+- Make ProxyUtil.IsAccessible(MethodBase) take into account declaring type's accessibility so it doesn't report false negatives for e.g. public methods in inaccessible classes. (@stakx, #289)
+
 ## 4.1.1 (2017-07-12)
 
 Bugfixes:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
@@ -14,6 +14,7 @@
 
 namespace Castle.DynamicProxy.Tests
 {
+	using System;
 	using System.Reflection;
 
 	using Castle.DynamicProxy;
@@ -23,76 +24,77 @@ namespace Castle.DynamicProxy.Tests
 	[TestFixture]
 	public class ProxyUtilTestCase
 	{
-		[TestCaseSource("AccessibleMethods")]
-		public void IsAccessible_Accessible_Method_Returns_True(string methodName)
+		[TestCaseSource(nameof(AccessibleMethods))]
+		public void IsAccessible_Accessible_Method_Returns_True(MethodBase method)
 		{
-			Assert.IsTrue(ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName)));
+			Assert.IsTrue(ProxyUtil.IsAccessible(method));
 		}
 
-		[TestCaseSource("InaccessibleMethods")]
-		public void IsAccessible_Inaccessible_Method_ReturnsFalse(string methodName)
+		[TestCaseSource(nameof(InaccessibleMethods))]
+		public void IsAccessible_Inaccessible_Method_Returns_False(MethodBase method)
 		{
-			Assert.IsFalse(ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName)));
+			Assert.IsFalse(ProxyUtil.IsAccessible(method));
 		}
 
-		[TestCaseSource("AccessibleMethods")]
-		public void IsAccessibleWithReason_Accessible_Method_Returns_True(string methodName)
+		[TestCaseSource(nameof(AccessibleMethods))]
+		public void IsAccessibleWithReason_Accessible_Method_Returns_True(MethodBase method)
 		{
 			string reason;
-			Assert.IsTrue(ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName), out reason));
+			Assert.IsTrue(ProxyUtil.IsAccessible(method, out reason));
 		}
 
-		[TestCaseSource("AccessibleMethods")]
-		public void IsAccessibleWithReason_Accessible_Method_Does_Not_Populate_ReasonMethodIsNotAccessible(string methodName)
+		[TestCaseSource(nameof(AccessibleMethods))]
+		public void IsAccessibleWithReason_Accessible_Method_Does_Not_Populate_ReasonMethodIsNotAccessible(MethodBase method)
 		{
 			string reason;
-			ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName), out reason);
+			ProxyUtil.IsAccessible(method, out reason);
 
 			Assert.IsNull(reason);
 		}
 
-		[TestCaseSource("InaccessibleMethods")]
-		public void IsAccessibleWithReason_Inaccessible_Method_ReturnsFalse(string methodName)
+		[TestCaseSource(nameof(InaccessibleMethods))]
+		public void IsAccessibleWithReason_Inaccessible_Method_Returns_False(MethodBase method)
 		{
 			string reason;
-			Assert.IsFalse(ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName), out reason));
+			Assert.IsFalse(ProxyUtil.IsAccessible(method, out reason));
 		}
 
-		[TestCaseSource("InaccessibleMethods")]
-		public void IsAccessibleWithReason_Inaccessible_Method_Populates_ReasonMethodIsNotAccessible(string methodName)
+		[TestCaseSource(nameof(InaccessibleMethods))]
+		public void IsAccessibleWithReason_Inaccessible_Method_Populates_ReasonMethodIsNotAccessible(MethodBase method)
 		{
 			string reason;
-			ProxyUtil.IsAccessible(GetMethod<TestClass>(methodName), out reason);
+			ProxyUtil.IsAccessible(method, out reason);
 
 #if FEATURE_GET_REFERENCED_ASSEMBLIES
-			var expectedReason = "Can not create proxy for method Void APrivateMethod() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
+			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
 #else
-			var expectedReason = "Can not create proxy for method Void APrivateMethod() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
+			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
 #endif
 
 			Assert.AreEqual(expectedReason, reason);
 		}
 
-		private static MethodInfo GetMethod<T>(string name)
+		private static MethodInfo GetMethod(Type declaringType, string name)
 		{
-			return typeof(T).GetMethod(name,
+			return declaringType.GetMethod(name,
 				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 		}
 
-		public static readonly object[] AccessibleMethods =
+		public static readonly MethodBase[] AccessibleMethods =
 		{
-			new object[] { "APublicMethod" },
-			new object[] { "AProtectedMethod" },
-			new object[] { "AnInternalMethod" }, // because our internals are visible to DynamicProxy2 
-			new object[] { "AProtectedInternalMethod" }
+			GetMethod(typeof(PublicTestClass), "APublicMethod"),
+			GetMethod(typeof(PublicTestClass), "AProtectedMethod"),
+			GetMethod(typeof(PublicTestClass), "AnInternalMethod"), // because our internals are visible to DynamicProxy2
+			GetMethod(typeof(PublicTestClass), "AProtectedInternalMethod"),
 		};
 
-		public static readonly object[] InaccessibleMethods =
+		public static readonly MethodBase[] InaccessibleMethods =
 		{
-			new object[] { "APrivateMethod" },
+			GetMethod(typeof(PublicTestClass), "APrivateMethod"),
+			GetMethod(typeof(PrivateTestClass), "APublicMethod"),
 		};
 
-		public class TestClass
+		public class PublicTestClass
 		{
 			public void APublicMethod()
 			{
@@ -111,6 +113,13 @@ namespace Castle.DynamicProxy.Tests
 			}
 
 			private void APrivateMethod()
+			{
+			}
+		}
+
+		private class PrivateTestClass
+		{
+			public void APublicMethod()
 			{
 			}
 		}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
@@ -66,9 +66,9 @@ namespace Castle.DynamicProxy.Tests
 			ProxyUtil.IsAccessible(method, out reason);
 
 #if FEATURE_GET_REFERENCED_ASSEMBLIES
-			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
+			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it or its declaring type is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(InternalsVisible.ToDynamicProxyGenAssembly2)] attribute, because assembly Castle.Core.Tests is strong-named.";
 #else
-			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
+			var expectedReason = "Can not create proxy for method Void " + method.Name + "() because it or its declaring type is not accessible. Make it public, or internal and mark your assembly with [assembly: InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7\")] attribute, because assembly Castle.Core.Tests is strong-named.";
 #endif
 
 			Assert.AreEqual(expectedReason, reason);

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
@@ -18,7 +18,6 @@ namespace Castle.DynamicProxy.Contributors
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Internal;
 
 	public class ClassMembersCollector : MembersCollector
 	{
@@ -29,7 +28,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.IsAccessible() == false)
+			if (ProxyUtil.IsAccessibleMethod(method) == false)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -18,7 +18,6 @@ namespace Castle.DynamicProxy.Contributors
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Internal;
 
 	public class InterfaceMembersCollector : MembersCollector
 	{
@@ -29,7 +28,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.IsAccessible() == false)
+			if (ProxyUtil.IsAccessibleMethod(method) == false)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
@@ -18,7 +18,6 @@ namespace Castle.DynamicProxy.Contributors
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Internal;
 
 	public class InterfaceMembersOnClassCollector : MembersCollector
 	{
@@ -33,7 +32,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.IsAccessible() == false)
+			if (ProxyUtil.IsAccessibleMethod(method) == false)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -21,7 +21,6 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.Core.Logging;
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Internal;
 
 	public abstract class MembersCollector
@@ -252,8 +251,8 @@ namespace Castle.DynamicProxy.Contributors
 
 		private static bool IsInternalAndNotVisibleToDynamicProxy(MethodInfo method)
 		{
-			return method.IsInternal() &&
-			       method.DeclaringType.GetTypeInfo().Assembly.IsInternalToDynamicProxy() == false;
+			return ProxyUtil.IsInternal(method) &&
+				   ProxyUtil.AreInternalsVisibleToDynamicProxy(method.DeclaringType.GetTypeInfo().Assembly) == false;
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -37,7 +37,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.IsAccessible() == false)
+			if (ProxyUtil.IsAccessibleMethod(method) == false)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -22,9 +22,6 @@ namespace Castle.DynamicProxy
 	using Castle.Core.Internal;
 	using Castle.Core.Logging;
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Generators.Emitters;
-	using Castle.DynamicProxy.Internal;
-
 
 	/// <summary>
 	///   Default implementation of <see cref = "IProxyBuilder" /> interface producing in-memory proxy assemblies.
@@ -124,7 +121,7 @@ namespace Castle.DynamicProxy
 				throw new GeneratorException(string.Format("Can not create proxy for type {0} because type {1} is an open generic type.",
 															target.GetBestName(), type.GetBestName()));
 			}
-			if (IsPublic(type) == false && IsAccessible(type) == false)
+			if (ProxyUtil.IsAccessibleType(type) == false)
 			{
 				throw new GeneratorException(ExceptionMessageBuilder.CreateMessageForInaccessibleType(type, target));
 			}
@@ -143,25 +140,6 @@ namespace Castle.DynamicProxy
 					AssertValidType(t);
 				}
 			}
-		}
-
-		private bool IsAccessible(Type target)
-		{
-			return IsInternal(target) && target.GetTypeInfo().Assembly.IsInternalToDynamicProxy();
-		}
-
-		private bool IsPublic(Type target)
-		{
-			return target.GetTypeInfo().IsPublic || target.GetTypeInfo().IsNestedPublic;
-		}
-
-		private static bool IsInternal(Type target)
-		{
-			var isTargetNested = target.IsNested;
-			var isNestedAndInternal = isTargetNested && (target.GetTypeInfo().IsNestedAssembly || target.GetTypeInfo().IsNestedFamORAssem);
-			var isInternalNotNested = target.GetTypeInfo().IsVisible == false && isTargetNested == false;
-
-			return isInternalNotNested || isNestedAndInternal;
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
@@ -18,7 +18,6 @@ namespace Castle.DynamicProxy
 	using System.Reflection;
 
 	using Castle.Core.Internal;
-	using Castle.DynamicProxy.Internal;
 
 	internal static class ExceptionMessageBuilder
 	{
@@ -42,7 +41,7 @@ namespace Castle.DynamicProxy
 				typeToProxy.GetBestName(),
 				inaccessibleTypeDescription);
 
-			var instructions = InternalsUtil.CreateInstructionsToMakeVisible(targetAssembly);
+			var instructions = ProxyUtil.CreateInstructionsToMakeVisible(targetAssembly);
 
 			return message + instructions;
 		}

--- a/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
@@ -15,12 +15,56 @@
 namespace Castle.DynamicProxy
 {
 	using System;
+	using System.Linq;
 	using System.Reflection;
 
 	using Castle.Core.Internal;
+	using Castle.DynamicProxy.Generators.Emitters;
 
 	internal static class ExceptionMessageBuilder
 	{
+		/// <summary>
+		/// Provides instructions that a user could follow to make a type or method in <paramref name="targetAssembly"/>
+		/// visible to DynamicProxy.</summary>
+		/// <param name="targetAssembly">The assembly containing the type or method.</param>
+		/// <returns>Instructions that a user could follow to make a type or method visible to DynamicProxy.</returns>
+		internal static string CreateInstructionsToMakeVisible(Assembly targetAssembly)
+		{
+			string strongNamedOrNotIndicator = " not"; // assume not strong-named
+			string assemblyToBeVisibleTo = "\"DynamicProxyGenAssembly2\""; // appropriate for non-strong-named
+
+			if (targetAssembly.IsAssemblySigned())
+			{
+				strongNamedOrNotIndicator = "";
+				assemblyToBeVisibleTo = ReferencesCastleCore(targetAssembly)
+					? "InternalsVisible.ToDynamicProxyGenAssembly2"
+					: '"' + InternalsVisible.ToDynamicProxyGenAssembly2 + '"';
+			}
+
+			var instructionsFormat =
+				"Make it public, or internal and mark your assembly with " +
+				"[assembly: InternalsVisibleTo({0})] attribute, because assembly {1} " +
+				"is{2} strong-named.";
+
+			var instructions = String.Format(instructionsFormat,
+				assemblyToBeVisibleTo,
+				targetAssembly.GetName().Name,
+				strongNamedOrNotIndicator);
+			return instructions;
+
+			bool ReferencesCastleCore(Assembly ia)
+			{
+#if FEATURE_GET_REFERENCED_ASSEMBLIES
+				return ia.GetReferencedAssemblies()
+					.Any(r => r.FullName == Assembly.GetExecutingAssembly().FullName);
+#else
+				// .NET Core does not provide an API to do this, so we just fall back to the solution that will definitely work.
+				// After all it is just an exception message.
+				return false;
+#endif
+			}
+		}
+
 		/// <summary>
 		/// Creates a message to inform clients that a proxy couldn't be created due to reliance on an
 		/// inaccessible type (perhaps itself).
@@ -41,7 +85,7 @@ namespace Castle.DynamicProxy
 				typeToProxy.GetBestName(),
 				inaccessibleTypeDescription);
 
-			var instructions = ProxyUtil.CreateInstructionsToMakeVisible(targetAssembly);
+			var instructions = CreateInstructionsToMakeVisible(targetAssembly);
 
 			return message + instructions;
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -24,7 +24,6 @@ namespace Castle.DynamicProxy.Generators
 	using System.Xml.Serialization;
 #endif
 
-	using Castle.Core.Internal;
 	using Castle.Core.Logging;
 	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
@@ -426,7 +425,7 @@ namespace Castle.DynamicProxy.Generators
 			return constructor.IsPublic ||
 				constructor.IsFamily ||
 				constructor.IsFamilyOrAssembly ||
-				(constructor.IsAssembly && InternalsUtil.IsInternalToDynamicProxy(constructor.DeclaringType.GetTypeInfo().Assembly));
+				(constructor.IsAssembly && ProxyUtil.AreInternalsVisibleToDynamicProxy(constructor.DeclaringType.GetTypeInfo().Assembly));
 		}
 
 		private bool OverridesEqualsAndGetHashCode(Type type)

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -18,8 +18,6 @@ namespace Castle.DynamicProxy.Generators
 	using System.Diagnostics;
 	using System.Reflection;
 
-	using Castle.DynamicProxy.Internal;
-
 	[DebuggerDisplay("{Method}")]
 	public class MetaMethod : MetaTypeElement, IEquatable<MetaMethod>
 	{
@@ -123,8 +121,8 @@ namespace Castle.DynamicProxy.Generators
 			{
 				attributes |= MethodAttributes.HideBySig;
 			}
-			if (InternalsUtil.IsInternal(methodInfo) &&
-				InternalsUtil.IsInternalToDynamicProxy(methodInfo.DeclaringType.GetTypeInfo().Assembly))
+			if (ProxyUtil.IsInternal(methodInfo) &&
+			    ProxyUtil.AreInternalsVisibleToDynamicProxy(methodInfo.DeclaringType.GetTypeInfo().Assembly))
 			{
 				attributes |= MethodAttributes.Assembly;
 			}

--- a/src/Castle.Core/DynamicProxy/Internal/InternalsUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InternalsUtil.cs
@@ -28,6 +28,7 @@ namespace Castle.DynamicProxy.Internal
 		///   <c>true</c> if the specified method is internal; otherwise, <c>false</c>.
 		/// </returns>
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete]
 		public static bool IsInternal(this MethodBase method)
 		{
 			return ProxyUtil.IsInternal(method);
@@ -38,6 +39,7 @@ namespace Castle.DynamicProxy.Internal
 		/// </summary>
 		/// <param name = "asm">The assembly to inspect.</param>
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete]
 		public static bool IsInternalToDynamicProxy(this Assembly asm)
 		{
 			return ProxyUtil.AreInternalsVisibleToDynamicProxy(asm);
@@ -49,6 +51,8 @@ namespace Castle.DynamicProxy.Internal
 		/// <param name = "method"></param>
 		/// <returns></returns>
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("Use " + nameof(ProxyUtil) + "." + nameof(ProxyUtil.IsAccessible) + " instead, " +
+		          "which performs a more accurate accessibility check.")]
 		public static bool IsAccessible(this MethodBase method)
 		{
 			return ProxyUtil.IsAccessibleMethod(method);

--- a/src/Castle.Core/DynamicProxy/Internal/InternalsUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InternalsUtil.cs
@@ -15,19 +15,11 @@
 namespace Castle.DynamicProxy.Internal
 {
 	using System;
-	using System.Collections.Generic;
-	using System.Linq;
+	using System.ComponentModel;
 	using System.Reflection;
-	using System.Runtime.CompilerServices;
-
-	using Castle.Core.Internal;
-	using Castle.DynamicProxy.Generators.Emitters;
 
 	public static class InternalsUtil
 	{
-		private static readonly IDictionary<Assembly, bool> internalsToDynProxy = new Dictionary<Assembly, bool>();
-		private static readonly Lock internalsToDynProxyLock = Lock.Create();
-
 		/// <summary>
 		///   Determines whether the specified method is internal.
 		/// </summary>
@@ -35,43 +27,20 @@ namespace Castle.DynamicProxy.Internal
 		/// <returns>
 		///   <c>true</c> if the specified method is internal; otherwise, <c>false</c>.
 		/// </returns>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsInternal(this MethodBase method)
 		{
-			return method.IsAssembly || (method.IsFamilyAndAssembly
-			                             && !method.IsFamilyOrAssembly);
+			return ProxyUtil.IsInternal(method);
 		}
 
 		/// <summary>
 		///   Determines whether this assembly has internals visible to dynamic proxy.
 		/// </summary>
 		/// <param name = "asm">The assembly to inspect.</param>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsInternalToDynamicProxy(this Assembly asm)
 		{
-			using (var locker = internalsToDynProxyLock.ForReadingUpgradeable())
-			{
-				if (internalsToDynProxy.ContainsKey(asm))
-				{
-					return internalsToDynProxy[asm];
-				}
-
-				locker.Upgrade();
-
-				if (internalsToDynProxy.ContainsKey(asm))
-				{
-					return internalsToDynProxy[asm];
-				}
-
-				var internalsVisibleTo = asm.GetCustomAttributes<InternalsVisibleToAttribute>();
-				var found = internalsVisibleTo.Any(VisibleToDynamicProxy);
-
-				internalsToDynProxy.Add(asm, found);
-				return found;
-			}
-		}
-
-		private static bool VisibleToDynamicProxy(InternalsVisibleToAttribute attribute)
-		{
-			return attribute.AssemblyName.Contains(ModuleScope.DEFAULT_ASSEMBLY_NAME);
+			return ProxyUtil.AreInternalsVisibleToDynamicProxy(asm);
 		}
 
 		/// <summary>
@@ -79,71 +48,10 @@ namespace Castle.DynamicProxy.Internal
 		/// </summary>
 		/// <param name = "method"></param>
 		/// <returns></returns>
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsAccessible(this MethodBase method)
 		{
-			// Accessibility supported by the full framework and CoreCLR
-			if (method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly)
-			{
-				return true;
-			}
-
-			if (method.IsFamilyAndAssembly)
-			{
-				return true;
-			}
-
-			if (method.DeclaringType.GetTypeInfo().Assembly.IsInternalToDynamicProxy() && method.IsAssembly)
-			{
-				return true;
-			}
-			return false;
-		}
-
-		/// <summary>
-		/// Provides instructions that a user could follow to make a type or method in <paramref name="targetAssembly"/>
-		/// visible to DynamicProxyGenAssembly2.</summary>
-		/// <param name="targetAssembly">The assembly containing the type or method.</param>
-		/// <returns>Instructions that a user could follow to make a type or method visible to DynamicProxyGenAssembly2.</returns>
-		internal static string CreateInstructionsToMakeVisible(Assembly targetAssembly)
-		{
-			string strongNamedOrNotIndicator = " not"; // assume not strong-named
-			string assemblyToBeVisibleTo = "\"DynamicProxyGenAssembly2\""; // appropriate for non-strong-named
-
-			if (targetAssembly.IsAssemblySigned())
-			{
-				strongNamedOrNotIndicator = "";
-				assemblyToBeVisibleTo = ReferencesCastleCore(targetAssembly)
-					? "InternalsVisible.ToDynamicProxyGenAssembly2"
-					: '"' + InternalsVisible.ToDynamicProxyGenAssembly2 + '"';
-			}
-
-			var instructionsFormat =
-				"Make it public, or internal and mark your assembly with " +
-				"[assembly: InternalsVisibleTo({0})] attribute, because assembly {1} " +
-				"is{2} strong-named.";
-
-			var instructions = String.Format(instructionsFormat,
-				assemblyToBeVisibleTo,
-				GetAssemblyName(targetAssembly),
-				strongNamedOrNotIndicator);
-			return instructions;
-		}
-
-		private static string GetAssemblyName(Assembly targetAssembly)
-		{
-			return targetAssembly.GetName().Name;
-		}
-
-		private static bool ReferencesCastleCore(Assembly inspectedAssembly)
-		{
-#if FEATURE_GET_REFERENCED_ASSEMBLIES
-			return inspectedAssembly.GetReferencedAssemblies()
-				.Any(r => r.FullName == Assembly.GetExecutingAssembly().FullName);
-#else
-			// .NET Core does not provide an API to do this, so we just fall back to the solution that will definitely work.
-			// After all it is just an exception message.
-			return false;
-#endif
+			return ProxyUtil.IsAccessibleMethod(method);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -161,22 +161,24 @@ namespace Castle.DynamicProxy
 
 		internal static bool IsAccessibleType(Type target)
 		{
-			return IsPublic(target)
-				|| IsInternal(target) && AreInternalsVisibleToDynamicProxy(target.GetTypeInfo().Assembly);
+			var typeInfo = target.GetTypeInfo();
 
-			bool IsPublic(Type t)
+			var isPublic = typeInfo.IsPublic || typeInfo.IsNestedPublic;
+			if (isPublic)
 			{
-				return t.GetTypeInfo().IsPublic || t.GetTypeInfo().IsNestedPublic;
+				return true;
 			}
 
-			bool IsInternal(Type t)
+			var isTargetNested = target.IsNested;
+			var isNestedAndInternal = isTargetNested && (typeInfo.IsNestedAssembly || typeInfo.IsNestedFamORAssem);
+			var isInternalNotNested = typeInfo.IsVisible == false && isTargetNested == false;
+			var isInternal = isInternalNotNested || isNestedAndInternal;
+			if (isInternal && AreInternalsVisibleToDynamicProxy(typeInfo.Assembly))
 			{
-				var isTargetNested = t.IsNested;
-				var isNestedAndInternal = isTargetNested && (t.GetTypeInfo().IsNestedAssembly || t.GetTypeInfo().IsNestedFamORAssem);
-				var isInternalNotNested = t.GetTypeInfo().IsVisible == false && isTargetNested == false;
-
-				return isInternalNotNested || isNestedAndInternal;
+				return true;
 			}
+
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This should fix #289.

I tried to follow [@jonorossi's suggestions](https://github.com/castleproject/Core/issues/289#issuecomment-316034650) as closely as possible, but I might've done a few things too many here, or misunderstood something. If so, please let me know. See the commit notes for details. A few points regarding the code moves:

* I moved everything from `InternalsUtil` to `ProxyUtil`. The former class now only contains "forwarding" methods which are hidden from IntelliSense, but not marked as `[Obsolete]`; none of them has an exact correspondence with a public method in `ProxyUtil`. (I chose **not** to make the moved methods `public` right away as that would've led to additional duplicate methods in the public API.)

* [Those three methods from `DefaultProxyBuilder`](https://github.com/castleproject/Core/blob/v4.1.1/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs#L148-L165) become a single method `ProxyUtil.IsAccessibleType`. (One is a helper method, and the other two only ever get called together. Combining them also allows optimizing away repeated calls to `GetTypeInfo`.)

* Moving extension methods into the `public /* non-static */ class ProxyUtil` means they can no longer be extension methods. (I opted **not** to re-declare `ProxyUtil` as `static` right away.)