### PR TITLE
Fix for #299, NotifyPropertyChang(ed/ing) events not suppressed on CancelEditing

### DIFF
--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
@@ -1087,6 +1087,37 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.AreEqual(3, notifications);
 		}
 
+		/// <summary>
+		/// Test that a SuppressNotificationsBlock suppresses notification events which the rollback which CancelEdit does generates.
+		/// </summary>
+		[Test]
+		public void WillNotRaisePropertyChangedEventWhenCancelEditingAndSupressingNotifications()
+		{
+			var notifications = 0;
+			var mutableName = factory.GetAdapter<IMutableName>(dictionary);
+			mutableName.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName == nameof(IMutableName.FirstName))
+				{
+					++notifications;
+				}
+			};
+
+			// Suppress notifications
+			using (mutableName.SuppressNotificationsBlock())
+			{
+				// Start edit
+				mutableName.BeginEdit();
+				// Check a property, this should NOT generate notifications due to the suppress block
+				mutableName.FirstName = "Big";
+				// Rollback the changes property, this should NOT generate notifications due to the suppress block
+				mutableName.CancelEdit();
+			}
+
+			// Test if we really didn't get any notifications
+			Assert.AreEqual(0, notifications);
+		}
+
 		[Test]
 		public void CanInitializeTheDictionaryAdapterWithAttributes()
 		{

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
@@ -53,7 +53,7 @@ namespace Castle.Components.DictionaryAdapter
 
 		protected bool NotifyPropertyChanging(PropertyDescriptor property, object oldValue, object newValue)
 		{
-			if (property.SuppressNotifications)
+			if (property.SuppressNotifications || !ShouldNotify)
 				return true;
 
 			var propertyChanging = PropertyChanging;
@@ -67,7 +67,7 @@ namespace Castle.Components.DictionaryAdapter
 
 		protected void NotifyPropertyChanged(PropertyDescriptor property, object oldValue, object newValue)
 		{
-			if (property.SuppressNotifications)
+			if (property.SuppressNotifications) || !ShouldNotify)
 				return;
 
 			var propertyChanged = PropertyChanged;

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
@@ -67,7 +67,7 @@ namespace Castle.Components.DictionaryAdapter
 
 		protected void NotifyPropertyChanged(PropertyDescriptor property, object oldValue, object newValue)
 		{
-			if (property.SuppressNotifications) || !ShouldNotify)
+			if (property.SuppressNotifications || !ShouldNotify)
 				return;
 
 			var propertyChanged = PropertyChanged;


### PR DESCRIPTION
This PR fixex a problem where NotifyPropertyChanged and NotifyPropertyChanging events are generated although they should be suppressed, the test case called WillNotRaisePropertyChangedEventWhenCancelEditingAndSupressingNotifications covers the scenario.

I am not sure why the NotifyPropertyChang(ed/ing) didn't check the ShouldNotify, maybe there was a reason for this?