### PR TITLE
Fix MethodSignatureComparer to handle nested generics

### DIFF
--- a/src/Castle.Core.Tests/MethodComparerTestCase.cs
+++ b/src/Castle.Core.Tests/MethodComparerTestCase.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Tests
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Linq;
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
@@ -36,6 +37,26 @@ namespace Castle.DynamicProxy.Tests
 		{
 		}
 
+		public static T GenericMethod4<T>(T t)
+		{
+			return t;
+		}
+
+		public static IEnumerable<T> GenericMethod5<T>(T t)
+		{
+			return Enumerable.Empty<T>();
+		}
+
+		public static IEnumerable<IEnumerable<T>> GenericMethod6<T>(T t)
+		{
+			return Enumerable.Empty<IEnumerable<T>>();
+		}
+
+		public static IEnumerable<IEnumerable<int>> GenericMethod7()
+		{
+			return Enumerable.Empty<IEnumerable<int>>();
+		}
+
 		private class FakeScope
 		{
 			public static void GenericMethod()
@@ -51,6 +72,79 @@ namespace Castle.DynamicProxy.Tests
 		{
 			public static void GenericMethod3<T, H>(H t, T h)
 			{
+			}
+		}
+
+		private class Base
+		{
+			public virtual void GenericMethod()
+			{
+			}
+
+			public virtual void GenericMethod2<T>()
+			{
+			}
+
+			public virtual void GenericMethod3<T, H>(T t, H h)
+			{
+			}
+
+			public virtual T GenericMethod4<T>(T t)
+			{
+				return t;
+			}
+
+			public virtual IEnumerable<T> GenericMethod5<T>(T t)
+			{
+				return Enumerable.Empty<T>();
+			}
+
+			public virtual IEnumerable<IEnumerable<T>> GenericMethod6<T>(T t)
+			{
+				return Enumerable.Empty<IEnumerable<T>>();
+			}
+
+			public virtual IEnumerable<IEnumerable<int>> GenericMethod7()
+			{
+				return Enumerable.Empty<IEnumerable<int>>();
+			}
+		}
+
+		private class Inherited : Base
+		{
+			public override void GenericMethod()
+			{
+				base.GenericMethod();
+			}
+
+			public override void GenericMethod2<T>()
+			{
+				base.GenericMethod2<T>();
+			}
+
+			public override void GenericMethod3<T, H>(T t, H h)
+			{
+				base.GenericMethod3(t, h);
+			}
+
+			public override T GenericMethod4<T>(T t)
+			{
+				return base.GenericMethod4(t);
+			}
+
+			public override IEnumerable<T> GenericMethod5<T>(T t)
+			{
+				return base.GenericMethod5(t);
+			}
+
+			public override IEnumerable<IEnumerable<T>> GenericMethod6<T>(T t)
+			{
+				return base.GenericMethod6(t);
+			}
+
+			public override IEnumerable<IEnumerable<int>> GenericMethod7()
+			{
+				return base.GenericMethod7();
 			}
 		}
 
@@ -91,6 +185,7 @@ namespace Castle.DynamicProxy.Tests
 			                        typeof (MethodComparerTestCase).GetMethod("GenericMethod3")));
 			Assert.IsFalse(mc.Equals(typeof (MethodComparerTestCase).GetMethod("GenericMethod3"),
 			                         typeof (NewScope).GetMethod("GenericMethod3")));
+
 			Assert.IsTrue(
 				mc.Equals(typeof (MethodComparerTestCase).GetMethod("GenericMethod3").MakeGenericMethod(typeof (int), typeof (int)),
 				          typeof (NewScope).GetMethod("GenericMethod3").MakeGenericMethod(typeof (int), typeof (int))));
@@ -115,6 +210,150 @@ namespace Castle.DynamicProxy.Tests
 			                         typeof (Console).GetMethod("WriteLine", new Type[] {typeof (string), typeof (object[])})));
 			Assert.IsTrue(mc.Equals(typeof (Console).GetMethod("WriteLine", new Type[] {typeof (string), typeof (object[])}),
 			                        typeof (Console).GetMethod("WriteLine", new Type[] {typeof (string), typeof (object[])})));
+		}
+
+		[Test]
+		public void Compare_generic_parameter_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(MethodComparerTestCase).GetMethod("GenericMethod4"),
+				typeof(MethodComparerTestCase).GetMethod("GenericMethod4")));
+		}
+
+		[Test]
+		public void Compare_generic_parameter_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(MethodComparerTestCase).GetMethod("GenericMethod5"),
+				typeof(MethodComparerTestCase).GetMethod("GenericMethod5")));
+		}
+
+		[Test]
+		public void Compare_generic_parameter_double_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(MethodComparerTestCase).GetMethod("GenericMethod6"),
+				typeof(MethodComparerTestCase).GetMethod("GenericMethod6")));
+		}
+
+		[Test]
+		public void Compare_double_nested_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(MethodComparerTestCase).GetMethod("GenericMethod7"),
+				typeof(MethodComparerTestCase).GetMethod("GenericMethod7")));
+		}
+
+		[Test]
+		public void Compare_virtual_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod"),
+				typeof(Base).GetMethod("GenericMethod")));
+		}
+
+		[Test]
+		public void Compare_virtual_generic_parameter_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod2"),
+				typeof(Base).GetMethod("GenericMethod2")));
+		}
+
+		[Test]
+		public void Compare_virtual_mutiple_generic_parameter_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod3"),
+				typeof(Base).GetMethod("GenericMethod3")));
+		}
+
+		[Test]
+		public void Compare_virtual_generic_parameter_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod4"),
+				typeof(Base).GetMethod("GenericMethod4")));
+		}
+
+		[Test]
+		public void Compare_virtual_generic_parameter_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod5"),
+				typeof(Base).GetMethod("GenericMethod5")));
+		}
+
+		[Test]
+		public void Compare_virtual_generic_parameter_double_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod6"),
+				typeof(Base).GetMethod("GenericMethod6")));
+		}
+
+		[Test]
+		public void Compare_virtual_double_nested_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod7"),
+				typeof(Base).GetMethod("GenericMethod7")));
+		}
+
+		[Test]
+		public void Compare_inherited_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod"),
+				typeof(Inherited).GetMethod("GenericMethod")));
+		}
+
+		[Test]
+		public void Compare_inherited_generic_parameter_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod2"),
+				typeof(Inherited).GetMethod("GenericMethod2")));
+		}
+
+		[Test]
+		public void Compare_inherited_mutiple_generic_parameter_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod3"),
+				typeof(Inherited).GetMethod("GenericMethod3")));
+		}
+
+		[Test]
+		public void Compare_inherited_generic_parameter_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod4"),
+				typeof(Inherited).GetMethod("GenericMethod4")));
+		}
+
+		[Test]
+		public void Compare_inherited_generic_parameter_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod5"),
+				typeof(Inherited).GetMethod("GenericMethod5")));
+		}
+
+		[Test]
+		public void Compare_inherited_generic_parameter_double_nested_generic_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod6"),
+				typeof(Inherited).GetMethod("GenericMethod6")));
+		}
+
+		[Test]
+		public void Compare_inherited_double_nested_return_method()
+		{
+			MethodSignatureComparer mc = MethodSignatureComparer.Instance;
+			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod7"),
+				typeof(Inherited).GetMethod("GenericMethod7")));
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -91,9 +91,20 @@ namespace Castle.DynamicProxy.Generators
 					return false;
 				}
 			}
-			else if (x.GetGenericArguments().Length > 0)
+			else if (x.GetTypeInfo().IsGenericType)
 			{
-				return GenericArugmentsEqual(x, y);
+				var xArgs = x.GetGenericArguments();
+				var yArgs = y.GetGenericArguments();
+
+				if (xArgs.Length != yArgs.Length)
+				{
+					return false;
+				}
+
+				for (var i = 0; i < xArgs.Length; ++i)
+				{
+					 if(!EqualSignatureTypes(xArgs[i], yArgs[i])) return false;
+				}
 			}
 			else
 			{
@@ -131,37 +142,6 @@ namespace Castle.DynamicProxy.Generators
 		private bool EqualNames(MethodInfo x, MethodInfo y)
 		{
 			return x.Name == y.Name;
-		}
-
-		private bool GenericArugmentsEqual(Type x, Type y)
-		{
-			var xArgs = x.GetGenericArguments();
-			var yArgs = y.GetGenericArguments();
-
-			if (xArgs.Length != yArgs.Length)
-			{
-				return false;
-			}
-
-			for (var i = 0; i < xArgs.Length; ++i)
-			{
-				if (xArgs[i].GetTypeInfo().IsGenericParameter != yArgs[i].GetTypeInfo().IsGenericParameter)
-				{
-					return false;
-				}
-
-				if (xArgs[i].GetGenericArguments().Length > 0)
-				{
-					return GenericArugmentsEqual(xArgs[i], yArgs[i]);
-				}
-
-				if (!xArgs[i].GetTypeInfo().IsGenericParameter && !xArgs[i].Equals(yArgs[i]))
-				{
-					return false;
-				}
-			}
-
-			return true;
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -86,10 +86,14 @@ namespace Castle.DynamicProxy.Generators
 
 			if (x.GetTypeInfo().IsGenericParameter)
 			{
-				if (x.GenericParameterPosition != y.GenericParameterPosition)
+				if (x.GetTypeInfo().GenericParameterPosition != y.GetTypeInfo().GenericParameterPosition)
 				{
 					return false;
 				}
+			}
+			else if (x.GetGenericArguments().Length > 0)
+			{
+				return GenericArugmentsEqual(x, y);
 			}
 			else
 			{
@@ -114,9 +118,9 @@ namespace Castle.DynamicProxy.Generators
 			}
 
 			return EqualNames(x, y) &&
-			       EqualGenericParameters(x, y) &&
-			       EqualSignatureTypes(x.ReturnType, y.ReturnType) &&
-			       EqualParameters(x, y);
+				   EqualGenericParameters(x, y) &&
+				   EqualSignatureTypes(x.ReturnType, y.ReturnType) &&
+				   EqualParameters(x, y);
 		}
 
 		public int GetHashCode(MethodInfo obj)
@@ -127,6 +131,37 @@ namespace Castle.DynamicProxy.Generators
 		private bool EqualNames(MethodInfo x, MethodInfo y)
 		{
 			return x.Name == y.Name;
+		}
+
+		private bool GenericArugmentsEqual(Type x, Type y)
+		{
+			var xArgs = x.GetGenericArguments();
+			var yArgs = y.GetGenericArguments();
+
+			if (xArgs.Length != yArgs.Length)
+			{
+				return false;
+			}
+
+			for (var i = 0; i < xArgs.Length; ++i)
+			{
+				if (xArgs[i].GetTypeInfo().IsGenericParameter != yArgs[i].GetTypeInfo().IsGenericParameter)
+				{
+					return false;
+				}
+
+				if (xArgs[i].GetGenericArguments().Length > 0)
+				{
+					return GenericArugmentsEqual(xArgs[i], yArgs[i]);
+				}
+
+				if (!xArgs[i].GetTypeInfo().IsGenericParameter && !xArgs[i].Equals(yArgs[i]))
+				{
+					return false;
+				}
+			}
+
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
I added test cases that demonstrate the issue in the first commit and a potential fix in the second commit.