### PR TITLE
Add missing equality checks to `MethodSignatureComparer.EqualSignatureTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Bugfixes:
+- Add missing equality checks in `MethodSignatureComparer.EqualSignatureTypes` to fix `TypeLoadException`s ("Method does not have an implementation") (@stakx, #310)
+
 ## 4.2.0 (2017-09-28)
 
 Enhancements:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitInterfaceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitInterfaceTestCase.cs
@@ -176,6 +176,13 @@ namespace Castle.DynamicProxy.Tests
 
 			Assert.AreEqual(5, result);
 		}
+
+		[Test]
+		public void CreateClassProxy_GivenAdditionalInterfaceWithOverloadedGenericMethodsHavingGenericParameter_SuccessfullyCreatesProxyInstance()
+		{
+			var instance = generator.CreateClassProxy(typeof(object), new Type[] { typeof(InterfaceWithOverloadedGenericMethod) }, interceptor);
+			Assert.NotNull(instance);
+		}
 	}
 
 	public class ExplicitInterfaceWithPropertyImplementation : ISimpleInterfaceWithProperty
@@ -184,5 +191,19 @@ namespace Castle.DynamicProxy.Tests
 		{
 			get { throw new NotImplementedException(); }
 		}
+	}
+
+	public interface InterfaceWithOverloadedGenericMethod
+	{
+		void GenericMethod<T>(GenericClass1<T> arg);
+		void GenericMethod<T>(GenericClass2<T> arg);
+	}
+
+	public class GenericClass1<T>
+	{
+	}
+
+	public class GenericClass2<T>
+	{
 	}
 }

--- a/src/Castle.Core.Tests/MethodComparerTestCase.cs
+++ b/src/Castle.Core.Tests/MethodComparerTestCase.cs
@@ -355,5 +355,28 @@ namespace Castle.DynamicProxy.Tests
 			Assert.IsTrue(mc.Equals(typeof(Base).GetMethod("GenericMethod7"),
 				typeof(Inherited).GetMethod("GenericMethod7")));
 		}
+
+		[Test]
+		public void Compare_two_method_overloads_with_generic_arg_types()
+		{
+			var mc = MethodSignatureComparer.Instance;
+			var methods = typeof(IHaveOverloadedGenericMethod).GetMethods();
+			var firstOverload = methods[0];
+			var secondOverload = methods[1];
+
+			// The overloads must obviously have different signatures, or we could never even have
+			// compiled this test code successfully. The arguments must have a different type:
+			Assert.IsFalse(mc.Equals(firstOverload, secondOverload));
+		}
+
+		private interface IHaveOverloadedGenericMethod
+		{
+			void GenericMethod<T>(GenericClass1<T> arg);
+			void GenericMethod<T>(GenericClass2<T> arg);
+		}
+
+		private class GenericClass1<T> { }
+
+		private class GenericClass2<T> { }
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -79,19 +79,22 @@ namespace Castle.DynamicProxy.Generators
 
 		public bool EqualSignatureTypes(Type x, Type y)
 		{
-			if (x.GetTypeInfo().IsGenericParameter != y.GetTypeInfo().IsGenericParameter)
+			var xti = x.GetTypeInfo();
+			var yti = y.GetTypeInfo();
+
+			if (xti.IsGenericParameter != yti.IsGenericParameter)
 			{
 				return false;
 			}
 
-			if (x.GetTypeInfo().IsGenericParameter)
+			if (xti.IsGenericParameter)
 			{
-				if (x.GetTypeInfo().GenericParameterPosition != y.GetTypeInfo().GenericParameterPosition)
+				if (xti.GenericParameterPosition != yti.GenericParameterPosition)
 				{
 					return false;
 				}
 			}
-			else if (x.GetTypeInfo().IsGenericType)
+			else if (xti.IsGenericType)
 			{
 				var xArgs = x.GetGenericArguments();
 				var yArgs = y.GetGenericArguments();

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -86,6 +86,10 @@ namespace Castle.DynamicProxy.Generators
 			{
 				return false;
 			}
+			else if (xti.IsGenericType != yti.IsGenericType)
+			{
+				return false;
+			}
 
 			if (xti.IsGenericParameter)
 			{
@@ -96,6 +100,14 @@ namespace Castle.DynamicProxy.Generators
 			}
 			else if (xti.IsGenericType)
 			{
+				var xGenericTypeDef = xti.GetGenericTypeDefinition();
+				var yGenericTypeDef = yti.GetGenericTypeDefinition();
+
+				if (xGenericTypeDef != yGenericTypeDef)
+				{
+					return false;
+				}
+
 				var xArgs = x.GetGenericArguments();
 				var yArgs = y.GetGenericArguments();
 


### PR DESCRIPTION
Given two generic types, `EqualSignatureTypes` only checks whether their generic type arguments match, but it doesn't check whether the actual generic type definition (i.e. the "open" generic type) matches. This PR adds those missing checks.

This should fix #309.

Please beware: I was a bit pressed for time when I put this PR together, so my understanding of `MethodSignatureComparer`'s purpose and exact uses is incomplete. I've relied mostly on the unit test suite to tell me whether I'm introducing any breaking change or not.