### PR TITLE
Only write back modified invocation arguments to by-ref parameters of intercepted method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Enhancements:
+- Captured variables can be changed during an interception even when they are passed to the intercepted method via a by-ref parameter (@stakx, #316)
+
 ## 4.2.1 (2017-10-11)
 
 Bugfixes:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AbstractInvocationTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AbstractInvocationTestCase.cs
@@ -1,0 +1,106 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Reflection;
+
+	using Castle.DynamicProxy.Tests.Interceptors;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AbstractInvocationTestCase
+	{
+		[Test]
+		public void CouldArgumentValueHaveChanged_DoesNotTrackModifications_IfMethodHasNoByRefParameters()
+		{
+			// For methods where all parameters are passed by value, `CouldArgumentValueHaveChanged` will always
+			// returns true, even when we haven't do anything at all with the invocation. This allows us to
+			// optimize for this very common case.
+
+			var invocation = GetAbstractInvocationFor(nameof(FakeProxy.MethodIII), 1, 2, 3);
+
+			Assert.True(invocation.CouldArgumentValueHaveChanged(0));
+			Assert.True(invocation.CouldArgumentValueHaveChanged(1));
+			Assert.True(invocation.CouldArgumentValueHaveChanged(2));
+		}
+
+		[Test]
+		public void CouldArgumentValueHaveChanged_TracksModifications_IfMethodHasByRefParameters()
+		{
+			// For methods where at least one parameter is passed by reference, `CouldArgumentValueHaveChanged`
+			// can compare whether invocation arguments were modified since the start of the invocation. This
+			// test demonstrates that if arguments are not modified, then this can be detected unlike in the
+			// above test:
+
+			var invocation = GetAbstractInvocationFor(nameof(FakeProxy.MethodIRO), 1, 2, 3);
+
+			Assert.False(invocation.CouldArgumentValueHaveChanged(0));
+			Assert.False(invocation.CouldArgumentValueHaveChanged(1));
+			Assert.False(invocation.CouldArgumentValueHaveChanged(2));
+		}
+
+		[Test]
+		public void CouldArgumentValueHaveChanged_TracksModificatonsViaArgumentsAndSetArgumentValue_IfMethodHasByRefParameters()
+		{
+			// This demonstrates that is doesn't matter how an argument is modified (either through `Arguments`
+			// or with `SetArgumentValue`):
+
+			var invocation = GetAbstractInvocationFor(nameof(FakeProxy.MethodIRO), 1, 2, 3);
+
+			invocation.SetArgumentValue(0, 11);
+			invocation.Arguments[1] = 22;
+			invocation.SetArgumentValue(2, 33);
+
+			Assert.True(invocation.CouldArgumentValueHaveChanged(0));
+			Assert.True(invocation.CouldArgumentValueHaveChanged(1));
+			Assert.True(invocation.CouldArgumentValueHaveChanged(2));
+		}
+
+		private static AbstractInvocation GetAbstractInvocationFor(string methodName, params object[] arguments)
+		{
+			var proxy = new FakeProxy();
+			var interceptors = new IInterceptor[] { new DoNothingInterceptor() };
+			var proxiedMethod = typeof(FakeProxy).GetMethod(methodName);
+			return new SomeAbstractInvocation(proxy, interceptors, proxiedMethod, arguments);
+		}
+
+		public class FakeProxy
+		{
+			public virtual void MethodIII(int arg1, int arg2, int arg3) { }
+			public virtual void MethodIRO(int arg1, ref int arg2, out int arg3) { arg3 = default(int); }
+		}
+
+		public sealed class SomeAbstractInvocation : AbstractInvocation
+		{
+			public SomeAbstractInvocation(object proxy, IInterceptor[] interceptors, MethodInfo proxiedMethod, object[] arguments)
+				: base(proxy, interceptors, proxiedMethod, arguments)
+			{
+			}
+
+			public override object InvocationTarget => throw new NotSupportedException();
+
+			public override Type TargetType => throw new NotSupportedException();
+
+			public override MethodInfo MethodInvocationTarget => throw new NotSupportedException();
+
+			protected override void InvokeMethodOnTarget()
+			{
+				throw new NotSupportedException();
+			}
+		}
+	}
+}

--- a/src/Castle.Core.Tests/Interceptors/ActionInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/ActionInterceptor.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interceptors
+{
+	using System;
+
+	public sealed class ActionInterceptor : IInterceptor
+	{
+		private Action<IInvocation> intercept;
+
+		public ActionInterceptor(Action<IInvocation> intercept)
+		{
+			this.intercept = intercept;
+		}
+
+		public void Intercept(IInvocation invocation)
+		{
+			this.intercept?.Invoke(invocation);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/OutRefParamsTestCase.cs
+++ b/src/Castle.Core.Tests/OutRefParamsTestCase.cs
@@ -355,5 +355,34 @@ namespace CastleTests
 			Assert.AreEqual(23, param1);
 			Assert.AreEqual("23", param2);
 		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public void InterceptorCanModifyCapturedVariable(bool passCapturedVariableByRef)
+		{
+			int capturedVariable = 0;
+			var interceptor = new ActionInterceptor(invocation =>
+			{
+				capturedVariable = 1;
+			});
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithRefParameter>(interceptor);
+
+			if (passCapturedVariableByRef)
+			{
+				proxy.Method(ref capturedVariable);
+			}
+			else
+			{
+				int otherVariable = 0;
+				proxy.Method(ref otherVariable);
+			}
+
+			Assert.AreEqual(1, capturedVariable);
+		}
+
+		public interface IHaveMethodWithRefParameter
+		{
+			void Method(ref int arg);
+		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfStatement.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2004-2017 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
+{
+	using System.Reflection.Emit;
+
+	public class IfStatement : Statement
+	{
+		private readonly Expression condition;
+		private readonly Statement then;
+
+		public IfStatement(Expression condition, Statement then)
+		{
+			this.condition = condition;
+			this.then = then;
+		}
+
+		public override void Emit(IMemberEmitter member, ILGenerator gen)
+		{
+			var fi = gen.DefineLabel();
+			condition.Emit(member, gen);
+			gen.Emit(OpCodes.Brfalse_S, fi);
+			then.Emit(member, gen);
+			gen.MarkLabel(fi);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -40,7 +40,10 @@ namespace Castle.DynamicProxy.Generators
 					continue;
 				}
 
-				emitter.CodeBuilder.AddStatement(AssignArgument(dereferencedArguments, i, arguments));
+				emitter.CodeBuilder.AddStatement(
+					new IfStatement(
+						condition: new MethodInvocationExpression(invocation, InvocationMethods.CouldArgumentValueHaveChanged, new LiteralIntExpression(i)),
+						then: AssignArgument(dereferencedArguments, i, arguments)));
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
@@ -48,6 +48,9 @@ namespace Castle.DynamicProxy.Tokens
 		public static readonly MethodInfo GetReturnValue =
 			typeof(AbstractInvocation).GetMethod("get_ReturnValue");
 
+		public static readonly MethodInfo CouldArgumentValueHaveChanged =
+			typeof(AbstractInvocation).GetMethod(nameof(AbstractInvocation.CouldArgumentValueHaveChanged));
+
 		public static readonly ConstructorInfo InheritanceInvocationConstructor =
 			typeof(InheritanceInvocation).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null,
 			                                             new[]


### PR DESCRIPTION
This fixes #311, as far as is possible. I'll admit that I've come to question whether this is a good enhancement to implement, for these two reasons:

1. It is only a partial fix for the problem described in #311, because changes to a captured variable (that is passed to an intercepted method via a `ref` parameter) won't be reflected in the arguments seen via `IInvocation`, simply because arguments are only read once (at the beginning of an interception) and then "buffered" in an `arguments` array; they don't get "refreshed" from the original arguments. This can't be easily changed, so we will see differences in variable capture / modification behaviour of regular C# vs. DynamicProxy intercepted methods even after this is merged.

2. The price we pay (in `AbstractInvocation`) for the feature added here is quite large: We need to keep a second copy of the passed-in `arguments` array around (`originalArguments`) just so we can later compare whether any arguments were changed in the meantime. Granted, this copy is only made if there are any by-ref parameters, but still.

   My first approach (which would've been way more efficient and perfectly sufficent for most real-world scenarios) was to have an additional `int argumentDirtyFlags` field in `AbstractInvocation` storing a "dirty" flag for the first 32 parameters. (Any additional parameters would be considered "dirty" by default. This is a tradeoff between correctness and efficiency.) `SetArgumentValue` would then set those "dirty" flags. Unfortunately, this method can be bypassed by setting arguments directly via the `object[] Arguments` property.

   It would still be possible to go with a "dirty" flags approach by setting *all* dirty flags if someone queries the `Arguments` property (because once someone has a reference to the `arguments` array, any and all modifications could happen to parameters without us tracking them, so we'd need to assume the worst).

I fully understand if you don't want to merge this after you've read the above.

However, if you'd like to see this go through, I'm happy to refine this some more.