### PR TITLE
Fixing #334 by making AttributesToAvoidReplicating thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Bugfixes:
 - Fix Castle.Services.Logging.Log4netIntegration assembly file name casing which breaks on Linux (@beginor, #324)
+- Fix Castle.DynamicProxy.Generators.AttributesToAvoidReplicating not being thread safe (InvalidOperationException "Collection was modified; enumeration operation may not execute.") (@BrunoJuchli, #334)
 
 ## 4.2.1 (2017-10-11)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
@@ -17,6 +17,8 @@ namespace Castle.DynamicProxy.Tests
 	using System;
 	using System.Linq;
 	using System.Reflection;
+
+	using Castle.DynamicProxy.Generators;
 #if FEATURE_SECURITY_PERMISSIONS
 	using System.Security.Permissions;
 #endif
@@ -28,6 +30,22 @@ namespace Castle.DynamicProxy.Tests
 	[TestFixture]
 	public class AttributesToAvoidReplicatingTestCase : BasePEVerifyTestCase
 	{
+		[Test]
+		public void After_adding_attribute_must_be_listed_as_contained()
+		{
+			AttributesToAvoidReplicating.Add<string>();
+			bool contains = AttributesToAvoidReplicating.Contains(typeof(string));
+			Assert.IsTrue(contains);
+		}
+
+		[Test]
+		public void After_adding_attribute_must_still_contain_original_attributes()
+		{
+			AttributesToAvoidReplicating.Add<string>();
+			bool contains = AttributesToAvoidReplicating.Contains(typeof(System.Runtime.InteropServices.ComImportAttribute));
+			Assert.IsTrue(contains);
+		}
+
 		[Test]
 		public void NonInheritableAttribute_should_be_replicated_as_it_is_not_inherited()
 		{


### PR DESCRIPTION
This PR fixes #334 by making `AttributesToAvoidReplicating` thread safe by replacing the backing collection instead of updating it (...while consumers are enumerating it...).

It employs `Interlocked.CompareExchange` to replace the collection if it's still the same as the original. If replacing fails (because another thread has already exchanged the collection) it retries until it succeeds.

Alternative would have been to replace the backing collection but to `lock` the `Add` method so concurrent `Add`-ing would be sequentialised.