### PR TITLE
Example: Added tests to show a race condition when intercepting an async method

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests
+{
+	using System;
+	using System.Linq;
+	using System.Reflection;
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy;
+	using Castle.DynamicProxy.Tests;
+
+	using CastleTests.DynamicProxy.Tests.Classes;
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+	using CastleTests.Interceptors;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AsyncInterceptorTestCase : BasePEVerifyTestCase
+	{
+	    [Test]
+	    public async Task Should_Intercept_Asynchronous_Methods_With_An_Async_Operations_Prior_To_Calling_Proceed()
+	    {
+			// Arrange
+		    IInterfaceWithAsynchronousMethod target = new ClassWithAsynchronousMethod();
+			IInterceptor interceptor = new AsyncInterceptor();
+
+		    IInterfaceWithAsynchronousMethod proxy =
+			    generator.CreateInterfaceProxyWithTargetInterface(target, interceptor);
+
+			// Act
+		    await proxy.Method().ConfigureAwait(false);
+	    }
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Classes
+{
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+
+	public class ClassWithAsynchronousMethod : IInterfaceWithAsynchronousMethod
+	{
+		public async Task Method()
+		{
+			Console.WriteLine(
+				$"Before Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+
+			await Task.Delay(10).ConfigureAwait(false);
+
+			Console.WriteLine(
+				$"After Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Interfaces
+{
+	using System.Threading.Tasks;
+
+	public interface IInterfaceWithAsynchronousMethod
+	{
+		Task Method();
+	}
+}

--- a/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.Interceptors
+{
+	using System.Threading.Tasks;
+	using Castle.DynamicProxy;
+
+	public class AsyncInterceptor : IInterceptor
+	{
+		public void Intercept(IInvocation invocation)
+		{
+			invocation.ReturnValue = InterceptAsyncMethod(invocation);
+		}
+
+		private static async Task InterceptAsyncMethod(IInvocation invocation)
+		{
+			// It all falls down when executing async before calling Proceed().
+			await Task.Delay(10).ConfigureAwait(false);
+
+			invocation.Proceed();
+
+			// Hmmmmm, now with it simplified down to this, I see the glaring hole that is the return value being set
+			// in two situations.
+			Task returnValue = (Task)invocation.ReturnValue;
+
+			await returnValue.ConfigureAwait(false);
+		}
+	}
+}


### PR DESCRIPTION
This is not a functional PR, just an attempt to demonstrate a race condition in [AbstractInvocation](https://github.com/castleproject/Core/blob/v4.2.1/src/Castle.Core/DynamicProxy/AbstractInvocation.cs#L23-L25 "class AbstractInvocation").

This demonstrates the issue I outlined in #145, specifically [this comment](https://github.com/castleproject/Core/issues/145#issuecomment-365404690).