### PR TITLE
Enable default LoggerLevel in TraceLoggerFactory

### DIFF
--- a/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
@@ -23,11 +23,26 @@ namespace Castle.Core.Logging
 	/// </summary>
 	public class TraceLoggerFactory : AbstractLoggerFactory
 	{
+		private readonly LoggerLevel? level;
+
+		public TraceLoggerFactory()
+		{
+		}
+
+		public TraceLoggerFactory(LoggerLevel level)
+		{
+			this.level = level;
+		}
+
 #if FEATURE_SECURITY_PERMISSIONS && DOTNET40
 		[SecuritySafeCritical]
 #endif
 		public override ILogger Create(string name)
 		{
+			if (level.HasValue)
+			{
+				return Create(name, level.Value);
+			}
 			return InternalCreate(name);
 		}
 


### PR DESCRIPTION
Similar to https://github.com/castleproject/Core/commit/5f5c2814cb1591578bd83461258573dc36c09751

Resolves: [How to make Castle Windsor TraceLoggerFactory output to Visual Studio output window?](https://stackoverflow.com/a/49745406/8601760)