### PR TITLE
Fix typos in XML documentation and other comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ Bugfixes:
 - implemented #42 - move complicated BuildInternalsVisibleMessageForType method out of DynamicProxyBuilder - contributed by Blair Conrad (@blairconrad)
 - fixed #47 - Calling DynamicProxy proxy methods with multidimensional array parameters - contributed by  Ed Parcell (@edparcell)
 - fixed #44 - DictionaryAdapter FetchAttribute on type has no effect
-- fixed #34 and #39 - inaccessible type parameters should give better error messsages - contributed by Blair Conrad (@blairconrad)
+- fixed #34 and #39 - inaccessible type parameters should give better error messages - contributed by Blair Conrad (@blairconrad)
 
 ## 3.2.2 (2013-11-30)
 - fixed #35 - ParameterBuilder.SetConstant fails when using a default value of null - contributed by (@jonasro)
@@ -156,7 +156,7 @@ Bugfixes:
 
 ## 3.1.0 RC (2012-07-08)
 - support multiple inheritance of DA attributes on interfaces.
-- BREAKING CHANGE: removed propogate child notifications as it violated INotifyPropertyChanged contract
+- BREAKING CHANGE: removed propagated child notifications as it violated INotifyPropertyChanged contract
 - improved DictionaryAdapter performance
 - generalized IBindingList support for DictionaryAdapters
 - added reference support to XmlAdapter
@@ -214,11 +214,11 @@ Breaking Changes:
 	  will still filter them out though.
   * fix - whenever custom IProxyGenerationHook is used, user should account for System.Object's
 	  members being now passed to ShouldInterceptMethod and NonVirtualMemberNotification methods
-	  and if neccessary update the code to handle them appropriately.
+	  and if necessary update the code to handle them appropriately.
 
 Bugfixes:
 - fixed CORE-37 - TAB characters in the XML Configuration of a component parameter is read as String.Empty
-- fixed DYNPROXY-161 - Strong Named DynamicProxy Assembly Not Available in Silverligh
+- fixed DYNPROXY-161 - Strong Named DynamicProxy Assembly Not Available in Silverlight
 - fixed DYNPROXY-159 - Sorting MemberInfo array for serialization has side effects
 - fixed DYNPROXY-158 - Can't create class proxy with target and without target in same ProxyGenerator
 - fixed DYNPROXY-153 - When proxying a generic interface which has an interface as GenericType . No proxy can be created
@@ -230,7 +230,7 @@ Bugfixes:
 ## 2.5.2 (2010-11-15)
 - fixed DYNPROXY-150 - Finalizer should not be proxied
 - implemented DYNPROXY-149 - Make AllMethodsHook members virtual so it can be used as a base class
-- fixed DYNPROXY-147 - Can't crete class proxies with two non-public methods having same argument types but different return type
+- fixed DYNPROXY-147 - Can't create class proxies with two non-public methods having same argument types but different return type
 - fixed DYNPROXY-145 Unable to proxy System.Threading.SynchronizationContext (.NET 4.0)
 - fixed DYNPROXY-144 - params argument not supported in constructor
 - fixed DYNPROXY-143 - Permit call to reach "non-proxied" methods of inherited interfaces
@@ -246,7 +246,7 @@ Bugfixes:
 - Interface proxy with target Interface now accepts null as a valid target value (which can be replaced at a later stage).
 - DictionaryAdapter behavior overrides are now ordered with all other behaviors
 - BREAKING CHANGE: removed web logger so that by default Castle.Core works in .NET 4 client profile
-- added paramter to ModuleScope disabling usage of signed modules. This is to workaround issue DYNPROXY-134. Also a descriptive exception message is being thrown now when the issue is detected.
+- added parameter to ModuleScope disabling usage of signed modules. This is to workaround issue DYNPROXY-134. Also a descriptive exception message is being thrown now when the issue is detected.
 - Added IDictionaryBehaviorBuilder to allow grouping behaviors
 - Added GenericDictionaryAdapter to simplify generic value sources
 - fixed issue DYNPROXY-138 - Error message missing space
@@ -255,10 +255,10 @@ Bugfixes:
 
 ## 2.5.0 (2010-08-21)
 - DynamicProxy will now not replicate non-public attribute types
-- Applied patch from Kenneth Siewers M�ller which adds parameterless constructor to DefaultSmtpSender implementation, to be able to configure the inner SmtpClient from the application configuration file (system.net.smtp).
+- Applied patch from Kenneth Siewers Møller which adds parameterless constructor to DefaultSmtpSender implementation, to be able to configure the inner SmtpClient from the application configuration file (system.net.smtp).
 - added support for .NET 4 and Silverlight 4, updated solution to VisualStudio 2010
 - Removed obsolete overload of CreateClassProxy
-- Added class proxy with taget
+- Added class proxy with target
 - Added ability to intercept explicitly implemented generic interface methods on class proxy.
 - DynamicProxy does not disallow intercepting members of System.Object anymore. AllMethodsHook will still filter them out though.
 - Added ability to intercept explicitly implemented interface members on class proxy. Does not support generic members.

--- a/buildscripts/readme.txt
+++ b/buildscripts/readme.txt
@@ -4,7 +4,7 @@ You can find full list of changes in CHANGELOG.md
 Documentation (work in progress, contributions appreciated):
 DictionaryAdapter:  https://github.com/castleproject/Core/blob/master/docs/dictionaryadapter.md
 DynamicProxy:       https://github.com/castleproject/Core/blob/master/docs/dynamicproxy.md
-Discusssion group:  http://groups.google.com/group/castle-project-users
+Discussion group:   http://groups.google.com/group/castle-project-users
 StackOverflow tags: castle-dynamicproxy, castle-dictionaryadapter, castle
 
 Issue tracker:      https://github.com/castleproject/Core/issues

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterVisitor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterVisitor.cs
@@ -17,7 +17,7 @@ namespace Castle.Components.DictionaryAdapter
 	using System;
 
 	/// <summary>
-	/// Conract for traversing a <see cref="IDictionaryAdapter"/>.
+	/// Contract for traversing a <see cref="IDictionaryAdapter"/>.
 	/// </summary>
 	public interface IDictionaryAdapterVisitor
 	{

--- a/src/Castle.Core/Components.DictionaryAdapter/PropertyDescriptor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/PropertyDescriptor.cs
@@ -65,7 +65,7 @@ namespace Castle.Components.DictionaryAdapter
 		}
 
 		/// <summary>
-		///  Copies an existinginstance of the <see cref="PropertyDescriptor"/> class.
+		///  Copies an existing instance of the <see cref="PropertyDescriptor"/> class.
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="copyBehaviors"></param>

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlAdapter.cs
@@ -377,7 +377,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 
 		void IVirtual.Realize()
 		{
-			throw new NotSupportedException("XmlAdapter does not support realization ssvia IVirtual.Realize().");
+			throw new NotSupportedException("XmlAdapter does not support realization via IVirtual.Realize().");
 		}
 
 		public event EventHandler Realized;

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
@@ -268,7 +268,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 			}
 			else
 			{
-				// Replaceing primary with no references; reuse entry
+				// Replacing primary with no references; reuse entry
 				PrepareForReuse(entry);
 				return entry;
 			}

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessor.cs
@@ -206,7 +206,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 			if (hasValue || isNillable)
 			{
 				if (hasCurrent)
-					Coerce(cursor, clrType, !hasValue && cursor.IsAttribute); // TODO: Refactor. (NB: && isNillable is emplied)
+					Coerce(cursor, clrType, !hasValue && cursor.IsAttribute); // TODO: Refactor. (NB: && isNillable is implied)
 				else
 					cursor.Create(clrType);
 			}

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Error.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Error.cs
@@ -122,7 +122,7 @@ namespace Castle.Components.DictionaryAdapter.Xml
 
 		internal static Exception CursorNotInCoercibleState()
 		{
-			var message = "The currsor cannot change node types in its current state.";
+			var message = "The cursor cannot change node types in its current state.";
 			return new InvalidOperationException(message);
 		}
 

--- a/src/Castle.Core/Core/Internal/CollectionExtensions.cs
+++ b/src/Castle.Core/Core/Internal/CollectionExtensions.cs
@@ -34,7 +34,7 @@ namespace Castle.Core.Internal
 		}
 
 		/// <summary>
-		///   Checks whether or not collection is null or empty. Assumes colleciton can be safely enumerated multiple times.
+		///   Checks whether or not collection is null or empty. Assumes collection can be safely enumerated multiple times.
 		/// </summary>
 		/// <param name = "this"></param>
 		/// <returns></returns>

--- a/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
+++ b/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
@@ -25,7 +25,7 @@ namespace Castle.Core.Logging
 #endif
 
 	/// <summary>
-	/// The Level Filtered Logger class.  This is a base clase which
+	/// The Level Filtered Logger class.  This is a base class which
 	/// provides a LogLevel attribute and reroutes all functions into
 	/// one Log method.
 	/// </summary>

--- a/src/Castle.Core/Core/Logging/StreamLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/StreamLoggerFactory.cs
@@ -19,7 +19,7 @@ namespace Castle.Core.Logging
 	using System.Text;
 
 	/// <summary>
-	///   Creates <see cref = "StreamLogger" /> outputing 
+	///   Creates <see cref = "StreamLogger" /> outputting
 	///   to files. The name of the file is derived from the log name
 	///   plus the 'log' extension.
 	/// </summary>

--- a/src/Castle.Core/Core/Logging/TraceLogger.cs
+++ b/src/Castle.Core/Core/Logging/TraceLogger.cs
@@ -115,7 +115,7 @@ namespace Castle.Core.Logging
 			lock (cache)
 			{
 				// because TraceSource is meant to be used as a static member, and because
-				// building up the configuraion inheritance is non-trivial, the instances
+				// building up the configuration inheritance is non-trivial, the instances
 				// themselves are cached for so multiple TraceLogger instances will reuse
 				// the named TraceSources which have been created
 

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -368,7 +368,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			else
 			{
-				// this can technicaly never happen
+				// this can technically never happen
 				message = string.Format("It looks like we have a bug with regards to how we handle {0}. Please report it.",
 				                        interfaceName);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -342,7 +342,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				}
 
 				var message =
-					"This is a DynamicProxy2 error: It looks like you enoutered a bug in Visual Studio debugger, " +
+					"This is a DynamicProxy2 error: It looks like you encountered a bug in Visual Studio debugger, " +
 					"which causes this exception when proxying types with generic methods having constraints on their generic arguments." +
 					"This code will work just fine without the debugger attached. " +
 					"If you wish to use debugger you may have to switch to Visual Studio 2010 where this bug was fixed.";

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -209,7 +209,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				}
 				catch (NotSupportedException)
 				{
-					// Doesnt matter
+					// Doesn't matter
 
 					newGenericParameters[i].SetGenericParameterAttributes(GenericParameterAttributes.None);
 				}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
@@ -44,7 +44,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 		{
 			if (Position == -1)
 			{
-				throw new ProxyGenerationException("ArgumentReference unitialized");
+				throw new ProxyGenerationException("ArgumentReference uninitialized");
 			}
 			switch (Position)
 			{
@@ -70,7 +70,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 		{
 			if (Position == -1)
 			{
-				throw new ProxyGenerationException("ArgumentReference unitialized");
+				throw new ProxyGenerationException("ArgumentReference uninitialized");
 			}
 			gen.Emit(OpCodes.Starg, Position);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/INamingScope.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/INamingScope.cs
@@ -15,7 +15,7 @@
 namespace Castle.DynamicProxy.Generators
 {
 	/// <summary>
-	///   Represents the scope of uniquenes of names for types and their members
+	///   Represents the scope of uniqueness of names for types and their members
 	/// </summary>
 	public interface INamingScope
 	{
@@ -36,7 +36,7 @@ namespace Castle.DynamicProxy.Generators
 		string GetUniqueName(string suggestedName);
 
 		/// <summary>
-		///   Returns new, disposable naming scope. It is responsibilty of the caller to make sure that no naming collision
+		///   Returns new, disposable naming scope. It is responsibility of the caller to make sure that no naming collision
 		///   with enclosing scope, or other subscopes is possible.
 		/// </summary>
 		/// <returns>New naming scope.</returns>

--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -31,7 +31,7 @@ namespace Castle.DynamicProxy.Generators
 		///   Initializes a new instance of the <see cref = "MetaEvent" /> class.
 		/// </summary>
 		/// <param name = "name">The name.</param>
-		/// <param name = "declaringType">Type declaring the original event being overriten, or null.</param>
+		/// <param name = "declaringType">Type declaring the original event being overridden, or null.</param>
 		/// <param name = "eventDelegateType"></param>
 		/// <param name = "adder">The add method.</param>
 		/// <param name = "remover">The remove method.</param>

--- a/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
@@ -45,7 +45,7 @@ namespace Castle.DynamicProxy.Generators
 				item.SwitchToExplicitImplementation();
 				if (Contains(item))
 				{
-					// there is something reaaaly wrong going on here
+					// there is something *really* wrong going on here
 					throw new ProxyGenerationException("Duplicate element: " + item);
 				}
 			}

--- a/src/Castle.Core/DynamicProxy/ModuleScope.cs
+++ b/src/Castle.Core/DynamicProxy/ModuleScope.cs
@@ -538,7 +538,7 @@ namespace Castle.DynamicProxy
 		///    cref = "SaveAssembly(bool)" /> or
 		///   <see cref = "SaveAssembly()" />, or it must have the <see cref = "CacheMappingsAttribute" /> manually applied.</param>
 		/// <remarks>
-		///   This method can be used to load previously generated and persisted proxy types from disk into this scope's type cache, eg. in order
+		///   This method can be used to load previously generated and persisted proxy types from disk into this scope's type cache, e.g. in order
 		///   to avoid the performance hit associated with proxy generation.
 		/// </remarks>
 		public void LoadAssemblyIntoCache(Assembly assembly)


### PR DESCRIPTION
This fixes several typos across the whole solution. Correcting grammatical errors is left to a future PR. (Would such a PR be welcome at all?)