### PR TITLE
Add support for `in` parameter modifier on .NET Core by adding .NET Standard 1.5 as additional target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: csharp
 solution: Castle.Core.sln
 
 install:
-    - # Automatic package restore disabled. Packages will be restored by the build script.
+    - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.6
 
 mono: 5.10.1
 
-dotnet: 1.0.4
+dotnet: 2.1.105
 
 sudo: required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Enhancements:
 - Added .NET Standard/.NET Core support for NLog (@snakefoot, #200)
 - Added .NET Standard/.NET Core support for log4net (@snakefoot, #201)
+- Add .NET Standard 1.5 as additional target to NuGet package. This adds support for `in` parameter modifiers on e.g. .NET Core (@stakx, #339)
 
 Bugfixes:
 - Fix Castle.Services.Logging.Log4netIntegration assembly file name casing which breaks on Linux (@beginor, #324)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Enhancements:
 - Added .NET Standard/.NET Core support for NLog (@snakefoot, #200)
 - Added .NET Standard/.NET Core support for log4net (@snakefoot, #201)
-- Add .NET Standard 1.5 as additional target to NuGet package. This adds support for `in` parameter modifiers on e.g. .NET Core (@stakx, #339)
+- DynamicProxy supported C# `in` parameter modifiers only on the .NET Framework up until now. Adding .NET Standard 1.5 as an additional target to the NuGet package makes them work on .NET Core, too (@stakx, #339)
 
 Bugfixes:
 - Fix Castle.Services.Logging.Log4netIntegration assembly file name casing which breaks on Linux (@beginor, #324)

--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,8 @@ echo --------------------
 echo Running NET461 Tests
 echo --------------------
 
-./src/Castle.Core.Tests/bin/Release/net461/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3
-./src/Castle.Core.Tests.WeakNamed/bin/Release/net461/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3
+mono ./src/Castle.Core.Tests/bin/Release/net461/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3
+mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net461/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3
 
 echo ---------------------------
 echo Running NETCOREAPP1.1 Tests

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -40,7 +40,8 @@
 
 	<PropertyGroup>
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
-		<NetStandardConstants>TRACE;FEATURE_NETCORE_REFLECTION_API;FEATURE_TEST_SERILOGINTEGRATION</NetStandardConstants>
+		<NetStandard13Constants>TRACE;FEATURE_NETCORE_REFLECTION_API;FEATURE_TEST_SERILOGINTEGRATION</NetStandard13Constants>
+		<NetStandard15Constants>$(NetStandard13Constants);FEATURE_EMIT_CUSTOMMODIFIERS</NetStandard15Constants>
 		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_BINDINGLIST;FEATURE_DICTIONARYADAPTER_XML;FEATURE_EMIT_CUSTOMMODIFIERS;FEATURE_EVENTLOG;FEATURE_GAC;FEATURE_GET_REFERENCED_ASSEMBLIES;FEATURE_IDATAERRORINFO;FEATURE_ISUPPORTINITIALIZE;FEATURE_LISTSORT;FEATURE_REMOTING;FEATURE_SECURITY_PERMISSIONS;FEATURE_SERIALIZATION;FEATURE_SMTP;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TARGETEXCEPTION;FEATURE_TEST_COM;FEATURE_TEST_SERILOGINTEGRATION</CommonDesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants);__MonoCS__</DesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants)</DesktopClrConstants>
@@ -79,19 +80,27 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.3|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(NetStandardConstants)</DefineConstants>
+		<DefineConstants>$(DiagnosticsConstants);$(NetStandard13Constants)</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.3|Release'">
-		<DefineConstants>$(NetStandardConstants)</DefineConstants>
+		<DefineConstants>$(NetStandard13Constants)</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.5|Debug'">
+		<DefineConstants>$(DiagnosticsConstants);$(NetStandard15Constants)</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard1.5|Release'">
+		<DefineConstants>$(NetStandard15Constants)</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.1|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(NetStandardConstants)</DefineConstants>
+		<DefineConstants>$(DiagnosticsConstants);$(NetStandard15Constants)</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp1.1|Release'">
-		<DefineConstants>$(NetStandardConstants)</DefineConstants>
+		<DefineConstants>$(NetStandard15Constants)</DefineConstants>
 	</PropertyGroup>
 
 </Project>

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -23,6 +23,7 @@
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\buildscripts\CastleKey.snk</AssemblyOriginatorKeyFile>
 		<PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
+		<LangVersion>7.2</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">

--- a/src/Castle.Core.Tests/CustomModifiersTestCase.cs
+++ b/src/Castle.Core.Tests/CustomModifiersTestCase.cs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#if FEATURE_EMIT_CUSTOMMODIFIERS
+#if FEATURE_EMIT_CUSTOMMODIFIERS && FEATURE_ASSEMBLYBUILDER_SAVE
 
 namespace Castle.DynamicProxy.Tests
 {

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Tests
 	// that was introduced with C# language version 7.2.
 	[TestFixture]
 	public class ValueTypeReferenceSemanticsTestCase : BasePEVerifyTestCase
-    {
+	{
 		// This test isn't interesting by itself. It only establishes a reference "baseline" for the next test.
 		[Test]
 		public void Can_proxy_method_having_valuetyped_parameter_without_in_modifier()
@@ -86,5 +86,5 @@ namespace Castle.DynamicProxy.Tests
 		{
 			void Method(in ReadOnlyStruct readOnlyStruct);
 		}
-    }
+	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
@@ -1,0 +1,90 @@
+﻿// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.f
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using Castle.DynamicProxy.Tests.Interceptors;
+
+	using NUnit.Framework;
+
+	// The purpose of this test fixture is to ensure that DynamicProxy can handle the `in` parameter modifier
+	// that was introduced with C# language version 7.2.
+	[TestFixture]
+	public class ValueTypeReferenceSemanticsTestCase : BasePEVerifyTestCase
+    {
+		// This test isn't interesting by itself. It only establishes a reference "baseline" for the next test.
+		[Test]
+		public void Can_proxy_method_having_valuetyped_parameter_without_in_modifier()
+		{
+			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IWithoutInModifier>(new DoNothingInterceptor());
+			var readOnlyStruct = new ReadOnlyStruct();
+			proxy.Method(readOnlyStruct);
+		}
+
+#if FEATURE_EMIT_CUSTOMMODIFIERS
+
+		// ^^^
+		// Because the `in` parameter modifier gets encoded as a modreq,
+		// tests involving it can only ever succeed on platforms supporting them.
+
+		[Test]
+		public void Can_proxy_method_having_valuetyped_parameter_with_in_modifier()
+		{
+			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IWithInModifier>(new DoNothingInterceptor());
+			var readOnlyStruct = new ReadOnlyStruct();
+			proxy.Method(in readOnlyStruct);
+		}
+
+		[Test]
+		public void Can_intercept_method_having_valuetypes_parameter_with_in_modifier()
+		{
+			const int expectedValue = 42;
+
+			object receivedArg = null;
+			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IWithInModifier>(
+				new WithCallbackInterceptor(invocation =>
+				{
+					receivedArg = invocation.Arguments[0];
+				}));
+			var readOnlyStruct = new ReadOnlyStruct(expectedValue);
+
+			proxy.Method(in readOnlyStruct);
+
+			Assert.IsAssignableFrom<ReadOnlyStruct>(receivedArg);
+			Assert.AreEqual(expectedValue, ((ReadOnlyStruct)receivedArg).Value);
+		}
+
+#endif
+
+		public readonly struct ReadOnlyStruct
+		{
+			public ReadOnlyStruct(int value)
+			{
+				this.Value = value;
+			}
+
+			public int Value { get; }
+		}
+
+		public interface IWithoutInModifier
+		{
+			void Method(ReadOnlyStruct readOnlyStruct);
+		}
+
+		public interface IWithInModifier
+		{
+			void Method(in ReadOnlyStruct readOnlyStruct);
+		}
+    }
+}

--- a/src/Castle.Core/Castle.Core.csproj
+++ b/src/Castle.Core/Castle.Core.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net35;net40;net45;netstandard1.3</TargetFrameworks>
+		<TargetFrameworks>net35;net40;net45;netstandard1.3;netstandard1.5</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -32,7 +32,7 @@
 		<Reference Include="System.Configuration" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'OR'$(TargetFramework)'=='netstandard1.5'">
 		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />


### PR DESCRIPTION
This is an attempt at solving #339.

It would be good if someone who's intimately familiar with the build process could take a closer look at what I've done in order to add the additional `netstandard1.5` target:

* Have I done all that's required when adding a new TFM, or did I miss something, somewhere?
* Should the 3 logging integration projects also get the new `netstandard1.5` target to stay in-sync with Castle.Core?