### PR TITLE
Replicate custom attributes on constructor parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Enhancements:
 - Added .NET Standard/.NET Core support for NLog (@snakefoot, #200)
 - Added .NET Standard/.NET Core support for log4net (@snakefoot, #201)
 - DynamicProxy supported C# `in` parameter modifiers only on the .NET Framework up until now. Adding .NET Standard 1.5 as an additional target to the NuGet package makes them work on .NET Core, too (@stakx, #339)
+- Replicate custom attributes on constructor parameters in the generated proxy type constructors to fulfill introspection of constructors. This does not change the proxying behavior. (@stakx, #341)
 - Improve performance of InvocationHelper cache lookups (@tangdf, #358)
 
 Bugfixes:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnConstructorParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnConstructorParameters.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	public class ClassWithAttributesOnConstructorParameters
+	{
+		public ClassWithAttributesOnConstructorParameters([Required(1)] int intParam, [Required("test")] string stringParam)
+		{
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ConstructorWithAttributesOnParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ConstructorWithAttributesOnParametersTestCase.cs
@@ -1,0 +1,57 @@
+// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System.Linq;
+	using System.Reflection;
+
+	using Castle.DynamicProxy.Tests.Classes;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class ConstructorWithAttributesOnParametersTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public void CustomAttributesOnParametersAreCopiedToProxiedObjectConstructor()
+		{
+			var requiredObj = generator.CreateClassProxy(typeof(ClassWithAttributesOnConstructorParameters), new object[] { 10,"" });
+			var constructor = requiredObj.GetType().GetConstructors().First();
+
+			// There should be exactly two parameters with a `RequiredAttribute`:
+			var paramWithRequiredAttributeCount =
+				constructor.GetParameters().Where(p => p.IsDefined(typeof(RequiredAttribute), true)).Count();
+			Assert.AreEqual(2, paramWithRequiredAttributeCount);
+
+			// There should be exactly one parameter named `intParam`:
+			var intParam = constructor.GetParameters().SingleOrDefault(p => p.Name == "intParam");
+			Assert.NotNull(intParam);
+
+			// That parameter should have exactly one `RequiredAttribute` carrying the value 1.
+			var intParamRequiredAttrs = intParam.GetCustomAttributes<RequiredAttribute>(inherit: true);
+			Assert.AreEqual(1, intParamRequiredAttrs.Count());
+			Assert.AreEqual(1, intParamRequiredAttrs.Single().DefaultValue);
+
+			// There should be exactly one parameter named `stringParam`:
+			var stringParam = constructor.GetParameters().SingleOrDefault(p => p.Name == "stringParam");
+			Assert.NotNull(intParam);
+
+			// That parameter should have exactly one `RequiredAttribute` carrying the value "test".
+			var stringParamRequiredAttrs = stringParam.GetCustomAttributes<RequiredAttribute>(inherit: true);
+			Assert.AreEqual(1, stringParamRequiredAttrs.Count());
+			Assert.AreEqual("test", stringParamRequiredAttrs.Single().DefaultValue);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -239,12 +239,14 @@ namespace Castle.DynamicProxy.Generators
 			var constructor = emitter.CreateConstructor(args);
 			if (baseConstructorParams != null && baseConstructorParams.Length != 0)
 			{
-				var last = baseConstructorParams.Last();
-				if (last.ParameterType.GetTypeInfo().IsArray && last.IsDefined(typeof(ParamArrayAttribute)))
+				var offset = 1 + fields.Length;
+				for (int i = 0, n = baseConstructorParams.Length; i < n; ++i)
 				{
-					var parameter = constructor.ConstructorBuilder.DefineParameter(args.Length, ParameterAttributes.None, last.Name);
-					var info = AttributeUtil.CreateInfo<ParamArrayAttribute>();
-					parameter.SetCustomAttribute(info.Builder);
+					var parameterBuilder = constructor.ConstructorBuilder.DefineParameter(offset + i, baseConstructorParams[i].Attributes, baseConstructorParams[i].Name);
+					foreach (var attribute in baseConstructorParams[i].GetNonInheritableAttributes())
+					{
+						parameterBuilder.SetCustomAttribute(attribute.Builder);
+					}
 				}
 			}
 


### PR DESCRIPTION
This is an attempt at resolving #341.

The gist of this PR is to change code in the following location where custom attribute reproduction happens (currently only for `ParamArrayAttribute`):

https://github.com/castleproject/Core/blob/980752ca2c309ab86278b0100fa8f2e52de00efd/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs#L240-L249

This gets changed to replicate *all* custom attributes of all parameters.

There's a catch, however: Because constructors in the generated proxy type have different signatures (additional parameters e.g. for the interceptor array), the constructors' signatures do not match with those in the base class. This means that custom attribute inheritance would never work with these constructor parameters, which is why we need to disregard `[AttributeTargets(Inherited = true)]` and reproduce even those attributes.

Can you think of any scenario(s) where replicating additional, "inheritable" custom attributes on ctors could cause negative side effects in downstream libraries?

Finally, take note that AFAIK even the updated code **does not yet reproduce custom modifiers** (modopts, modreqs) because that would have to happen in a different code location and because that's not what #341 is about. Eventually, we should reproduce custom modifiers as well, otherwise we might get confronted with something like #339, but for ctors.