### PR TITLE
Re-enable four skipped tests by moving them to weak-named test project

### DIFF
--- a/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -1,0 +1,91 @@
+﻿// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Reflection;
+
+	using Castle.DynamicProxy.Generators.Emitters;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class BasicClassProxyTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public void ProxyForBaseTypeFromUnsignedAssembly()
+		{
+			Assert.False(TestAssemblySigned());
+			Type t = typeof(Class);
+			Assert.False(StrongNameUtil.IsAssemblySigned(t.GetTypeInfo().Assembly));
+			object proxy = generator.CreateClassProxy(t, new StandardInterceptor());
+			Assert.False(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
+		}
+
+		[Test]
+		public void ProxyForBaseTypeAndInterfaceFromUnsignedAssembly()
+		{
+			Assert.False(TestAssemblySigned());
+			Type t1 = typeof(Class);
+			Type t2 = typeof(IInterface);
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
+			object proxy = generator.CreateClassProxy(t1, new Type[] { t2 }, new StandardInterceptor());
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
+		}
+
+		[Test]
+		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies1()
+		{
+			Assert.False(TestAssemblySigned());
+			Type t1 = typeof(Class);
+			Type t2 = typeof(IServiceProvider);
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
+			Assert.IsTrue(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
+			object proxy = generator.CreateClassProxy(t1, new Type[] { t2 }, new StandardInterceptor());
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
+		}
+
+		[Test]
+		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies2()
+		{
+			Assert.False(TestAssemblySigned());
+			Type t1 = typeof(List<int>);
+			Type t2 = typeof(IInterface);
+			Assert.IsTrue(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
+			object proxy = generator.CreateClassProxy(t1, new Type[] { t2 }, new StandardInterceptor());
+			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
+		}
+
+		private bool TestAssemblySigned()
+		{
+			return StrongNameUtil.IsAssemblySigned(GetType().GetTypeInfo().Assembly);
+		}
+
+		public abstract class Class
+		{
+			public abstract void ClassMethod();
+			public abstract void Method();
+		}
+
+		public interface IInterface
+		{
+			void InterfaceMethod();
+			void Method();
+		}
+	}
+}

--- a/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -28,7 +28,6 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void ProxyForBaseTypeFromUnsignedAssembly()
 		{
-			Assert.False(TestAssemblySigned());
 			Type t = typeof(Class);
 			Assert.False(StrongNameUtil.IsAssemblySigned(t.GetTypeInfo().Assembly));
 			object proxy = generator.CreateClassProxy(t, new StandardInterceptor());
@@ -38,7 +37,6 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void ProxyForBaseTypeAndInterfaceFromUnsignedAssembly()
 		{
-			Assert.False(TestAssemblySigned());
 			Type t1 = typeof(Class);
 			Type t2 = typeof(IInterface);
 			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
@@ -50,7 +48,6 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies1()
 		{
-			Assert.False(TestAssemblySigned());
 			Type t1 = typeof(Class);
 			Type t2 = typeof(IServiceProvider);
 			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
@@ -62,18 +59,12 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies2()
 		{
-			Assert.False(TestAssemblySigned());
 			Type t1 = typeof(List<int>);
 			Type t2 = typeof(IInterface);
 			Assert.IsTrue(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
 			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
 			object proxy = generator.CreateClassProxy(t1, new Type[] { t2 }, new StandardInterceptor());
 			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
-		}
-
-		private bool TestAssemblySigned()
-		{
-			return StrongNameUtil.IsAssemblySigned(GetType().GetTypeInfo().Assembly);
 		}
 
 		public abstract class Class

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -328,69 +328,6 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void ProxyForBaseTypeFromUnsignedAssembly()
-		{
-			if(TestAssemblySigned())
-			{
-				Assert.Ignore("To get this running, the Tests project must not be signed.");
-			}
-			Type t = typeof (MyClass);
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t.GetTypeInfo().Assembly));
-			object proxy = generator.CreateClassProxy(t, new StandardInterceptor());
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
-		}
-
-		private bool TestAssemblySigned()
-		{
-			return StrongNameUtil.IsAssemblySigned(GetType().GetTypeInfo().Assembly);
-		}
-
-		[Test]
-		public void ProxyForBaseTypeAndInterfaceFromUnsignedAssembly()
-		{
-			if(TestAssemblySigned())
-			{
-				Assert.Ignore("To get this running, the Tests project must not be signed.");
-			}
-			Type t1 = typeof (MyClass);
-			Type t2 = typeof (IService);
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
-			object proxy = generator.CreateClassProxy(t1, new Type[] {t2}, new StandardInterceptor());
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
-		}
-
-		[Test]
-		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies1()
-		{
-			if(TestAssemblySigned())
-			{
-				Assert.Ignore("To get this running, the Tests project must not be signed.");
-			}
-			Type t1 = typeof (MyClass);
-			Type t2 = typeof (IServiceProvider);
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
-			Assert.IsTrue(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
-			object proxy = generator.CreateClassProxy(t1, new Type[] {t2}, new StandardInterceptor());
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
-		}
-
-		[Test]
-		public void ProxyForBaseTypeAndInterfaceFromSignedAndUnsignedAssemblies2()
-		{
-			if (TestAssemblySigned())
-			{
-				Assert.Ignore("To get this running, the Tests project must not be signed.");
-			}
-			Type t1 = typeof (List<int>);
-			Type t2 = typeof (IService);
-			Assert.IsTrue(StrongNameUtil.IsAssemblySigned(t1.GetTypeInfo().Assembly));
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(t2.GetTypeInfo().Assembly));
-			object proxy = generator.CreateClassProxy(t1, new Type[] {t2}, new StandardInterceptor());
-			Assert.IsFalse(StrongNameUtil.IsAssemblySigned(proxy.GetType().GetTypeInfo().Assembly));
-		}
-
-		[Test]
 		public void VirtualCallFromCtor()
 		{
 			StandardInterceptor interceptor = new StandardInterceptor();


### PR DESCRIPTION
Now that we have a weak-named project, we can re-enable four tests that verify whether proxy types end up in the right module (weak vs strong named).