### PR TITLE
Resolve System.Xml.ReaderWriter downgrade error

### DIFF
--- a/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
+++ b/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
@@ -34,7 +34,7 @@
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
 		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
+		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
 		<PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -54,7 +54,7 @@
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
 		<PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
+		<PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
 		<PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
 		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />


### PR DESCRIPTION
Installing the newly released .NET Core SDK 2.1 appears to have the side effect of breaking our build:

```
Castle.Core\src\Castle.Core.Tests\Castle.Core.Tests.csproj : error NU1605:
Detected package downgrade: System.Xml.ReaderWriter from 4.3.1 to 4.3.0. Reference the package directly from the project to select a different version.
 Castle.Core.Tests -> Microsoft.NETCore.App 1.1.8 -> System.Xml.ReaderWriter (>= 4.3.1)
 Castle.Core.Tests -> System.Xml.ReaderWriter (>= 4.3.0)
```

This PR resolves the downgrade error.