### PR TITLE
Synchronize read/write accesses to `NamingScope.GetUniqueName`

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -396,9 +396,9 @@ namespace Castle.DynamicProxy.Generators
 			}
 
 			// This is to avoid generating duplicate types under heavy multithreaded load.
-			using (var locker = Scope.Lock.ForReadingUpgradeable())
+			using (var locker = Scope.Lock.ForWriting())
 			{
-				// Only one thread at a time may enter an upgradable read lock.
+				// Only one thread at a time may enter a write lock.
 				// See if an earlier lock holder populated the cache.
 				cacheType = GetFromCache(cacheKey);
 				if (cacheType != null)
@@ -414,11 +414,8 @@ namespace Castle.DynamicProxy.Generators
 				var name = Scope.NamingScope.GetUniqueName("Castle.Proxies." + targetType.Name + "Proxy");
 				var proxyType = factory.Invoke(name, Scope.NamingScope.SafeSubScope());
 
-				// Upgrade the lock to a write lock. 
-				using (locker.Upgrade())
-				{
-					AddToCache(cacheKey, proxyType);
-				}
+				AddToCache(cacheKey, proxyType);
+
 				return proxyType;
 			}
 		}


### PR DESCRIPTION
`NamingScope.GetUniqueName` maintains and updates counters in an unsynchronized `Dictionary<,>`. This writing method is currently called from a location that allows several concurrent readers.

This changes `BaseProxyGenerator.ObtainProxyType` so that it goes from a read lock straight to a write lock. There seems little point in taking an upgradeable lock first if we're going to need a write lock anyway for all of the work. (Taking an upgradeable read lock first would only benefit the second, repeated cache check.)