### PR TITLE
Remove orphaned backing field from `ProxyGenerationOptions`

### DIFF
--- a/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
@@ -36,7 +36,6 @@ namespace Castle.DynamicProxy
 		public static readonly ProxyGenerationOptions Default = new ProxyGenerationOptions();
 
 		private List<object> mixins;
-		internal readonly IList<Attribute> attributesToAddToGeneratedTypes = new List<Attribute>();
 		private readonly IList<CustomAttributeInfo> additionalAttributes = new List<CustomAttributeInfo>();
 
 #if FEATURE_SERIALIZATION


### PR DESCRIPTION
Attention, baby PR ahead. 👶🍼

I noticed an unused field in `ProxyGenerationOptions` that should have been removed [in `692d82f`](https://github.com/castleproject/Core/commit/692d82fb917d8568da56601db6d45a891babe090#diff-ad3089af8109829f561062fe11a12d92), along with the property to which it originally belonged.

(...or was this intentionally kept around for serialization backwards compatibility?)