### PR TITLE
Remove redundant call to EmitCallEnsureValidTarget

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -112,7 +112,7 @@ namespace Castle.DynamicProxy.Contributors
 			}
 			return new InvocationWithGenericDelegateContributor(@delegate,
 			                                                    method,
-			                                                    new FieldReference(InvocationMethods.Target));
+			                                                    new FieldReference(InvocationMethods.CompositionInvocationTarget));
 		}
 
 		private Type GetDelegateType(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options)

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -54,7 +54,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected override FieldReference GetTargetReference()
 		{
-			return new FieldReference(InvocationMethods.Target);
+			return new FieldReference(InvocationMethods.CompositionInvocationTarget);
 		}
 
 		protected override void ImplementInvokeMethodOnTarget(AbstractTypeEmitter invocation, ParameterInfo[] parameters,
@@ -62,7 +62,7 @@ namespace Castle.DynamicProxy.Generators
 		{
 			invokeMethodOnTarget.CodeBuilder.AddStatement(
 				new ExpressionStatement(
-					new MethodInvocationExpression(SelfReference.Self, InvocationMethods.EnsureValidTarget)));
+					new MethodInvocationExpression(SelfReference.Self, InvocationMethods.CompositionInvocationEnsureValidTarget)));
 			base.ImplementInvokeMethodOnTarget(invocation, parameters, invokeMethodOnTarget, targetField);
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -114,11 +114,6 @@ namespace Castle.DynamicProxy.Generators
 				return;
 			}
 
-			if (canChangeTarget)
-			{
-				EmitCallEnsureValidTarget(invokeMethodOnTarget);
-			}
-
 			var args = new Expression[parameters.Length];
 
 			// Idea: instead of grab parameters one by one
@@ -232,13 +227,6 @@ namespace Castle.DynamicProxy.Generators
 				return invocation.CreateConstructor(baseCtorArguments);
 			}
 			return contributor.CreateConstructor(baseCtorArguments, invocation);
-		}
-
-		private AbstractCodeBuilder EmitCallEnsureValidTarget(MethodEmitter invokeMethodOnTarget)
-		{
-			return invokeMethodOnTarget.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(SelfReference.Self, InvocationMethods.EnsureValidTarget)));
 		}
 
 		private void EmitCallThrowOnNoTarget(MethodEmitter invokeMethodOnTarget)

--- a/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
@@ -36,7 +36,7 @@ namespace Castle.DynamicProxy.Tokens
 			                                             },
 			                                             null);
 
-		public static readonly MethodInfo EnsureValidTarget =
+		public static readonly MethodInfo CompositionInvocationEnsureValidTarget =
 			typeof(CompositionInvocation).GetMethod("EnsureValidTarget", BindingFlags.Instance | BindingFlags.NonPublic);
 
 		public static readonly MethodInfo GetArgumentValue =
@@ -89,10 +89,15 @@ namespace Castle.DynamicProxy.Tokens
 		public static readonly MethodInfo SetReturnValue =
 			typeof(AbstractInvocation).GetMethod("set_ReturnValue");
 
-		public static readonly FieldInfo Target =
+		public static readonly FieldInfo CompositionInvocationTarget =
 			typeof(CompositionInvocation).GetField("target", BindingFlags.Instance | BindingFlags.NonPublic);
 
 		public static readonly MethodInfo ThrowOnNoTarget =
 			typeof(AbstractInvocation).GetMethod("ThrowOnNoTarget", BindingFlags.Instance | BindingFlags.NonPublic);
+
+		// The following two fields are not used internally, but kept for back-compatibility
+		// because we renamed the public fields `EnsureValidTarget` and `Target`:
+		public static readonly MethodInfo EnsureValidTarget = CompositionInvocationEnsureValidTarget;
+		public static readonly FieldInfo Target = CompositionInvocationTarget;
 	}
 }


### PR DESCRIPTION
This fixes #295. See https://github.com/castleproject/Core/issues/295#issuecomment-399751655 for an explanation of the proposed change. (I'd say this doesn't deserve a changelog entry, it's basically just a small optimization.)