### PR TITLE
Make AST construction more efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Deprecations:
    - `Castle.DynamicProxy.Generators.CacheKey` (class)
    - `Castle.DynamicProxy.Serialization.CacheMappingsAttribute.ApplyTo` (method)
    - `Castle.DynamicProxy.Serialization.CacheMappingsAttribute.GetDeserializedMappings` (method)
+- The following AST node types have been deprecated:
+   - `Castle.DynamicProxy.Generators.Emitters.SimpleAST.ConstReference` (class)
+   - `Castle.DynamicProxy.Generators.Emitters.SimpleAST.ExpressionStatement` (class)
 
 ## 4.3.1 (2018-06-21)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassEmitterTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassEmitterTestCase.cs
@@ -48,7 +48,7 @@ namespace Castle.DynamicProxy.Tests
 			                                        Type.EmptyTypes);
 			MethodEmitter methodEmitter = emitter.CreateMethod("StaticMethod", MethodAttributes.Public | MethodAttributes.Static,
 			                                                   typeof (string), typeof (string));
-			methodEmitter.CodeBuilder.AddStatement(new ReturnStatement(methodEmitter.Arguments[0]));
+			methodEmitter.CodeBuilder.Add(new ReturnStatement(methodEmitter.Arguments[0]));
 			Type t = emitter.BuildType();
 			Assert.AreEqual("five", t.GetMethod("StaticMethod").Invoke(null, new object[] {"five"}));
 		}
@@ -60,7 +60,7 @@ namespace Castle.DynamicProxy.Tests
 			                                        Type.EmptyTypes);
 			MethodEmitter methodEmitter = emitter.CreateMethod("InstanceMethod", MethodAttributes.Public,
 			                                                   typeof (string), typeof (string));
-			methodEmitter.CodeBuilder.AddStatement(new ReturnStatement(methodEmitter.Arguments[0]));
+			methodEmitter.CodeBuilder.Add(new ReturnStatement(methodEmitter.Arguments[0]));
 			Type t = emitter.BuildType();
 			object instance = Activator.CreateInstance(t);
 			Assert.AreEqual("six", t.GetMethod("InstanceMethod").Invoke(instance, new object[] {"six"}));

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -82,12 +82,11 @@ namespace Castle.DynamicProxy.Contributors
 		protected override void CustomizeGetObjectData(AbstractCodeBuilder codebuilder, ArgumentReference serializationInfo,
 		                                               ArgumentReference streamingContext, ClassEmitter emitter)
 		{
-			codebuilder.AddStatement(new ExpressionStatement(
-			                         	new MethodInvocationExpression(
-			                         		serializationInfo,
-			                         		SerializationInfoMethods.AddValue_Bool,
-			                         		new LiteralStringExpression("__delegateToBase"),
-			                         		new LiteralBoolExpression(delegateToBaseGetObjectData))));
+			codebuilder.AddExpression(new MethodInvocationExpression(
+			                          	serializationInfo,
+			                          	SerializationInfoMethods.AddValue_Bool,
+			                          	new LiteralStringExpression("__delegateToBase"),
+			                          	new LiteralBoolExpression(delegateToBaseGetObjectData)));
 
 			if (delegateToBaseGetObjectData == false)
 			{
@@ -128,7 +127,7 @@ namespace Castle.DynamicProxy.Contributors
 				SerializationInfoMethods.AddValue_Object,
 				new LiteralStringExpression("__data"),
 				data.ToExpression());
-			codebuilder.AddStatement(new ExpressionStatement(addValue));
+			codebuilder.AddExpression(addValue);
 		}
 
 		private void EmitCallToBaseGetObjectData(AbstractCodeBuilder codebuilder, ArgumentReference serializationInfo,
@@ -137,10 +136,9 @@ namespace Castle.DynamicProxy.Contributors
 			var baseGetObjectData = targetType.GetMethod("GetObjectData",
 			                                             new[] { typeof(SerializationInfo), typeof(StreamingContext) });
 
-			codebuilder.AddStatement(new ExpressionStatement(
-			                         	new MethodInvocationExpression(baseGetObjectData,
-			                         	                               serializationInfo.ToExpression(),
-			                         	                               streamingContext.ToExpression())));
+			codebuilder.AddExpression(new MethodInvocationExpression(baseGetObjectData,
+			                                                         serializationInfo.ToExpression(),
+			                                                         streamingContext.ToExpression()));
 		}
 
 		private void Constructor(ClassEmitter emitter)

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -86,9 +86,8 @@ namespace Castle.DynamicProxy.Contributors
 			                         	new MethodInvocationExpression(
 			                         		serializationInfo,
 			                         		SerializationInfoMethods.AddValue_Bool,
-			                         		new ConstReference("__delegateToBase").ToExpression(),
-			                         		new ConstReference(delegateToBaseGetObjectData).
-			                         			ToExpression())));
+			                         		new LiteralStringExpression("__delegateToBase"),
+			                         		new LiteralBoolExpression(delegateToBaseGetObjectData))));
 
 			if (delegateToBaseGetObjectData == false)
 			{
@@ -127,7 +126,7 @@ namespace Castle.DynamicProxy.Contributors
 			var addValue = new MethodInvocationExpression(
 				serializationInfo,
 				SerializationInfoMethods.AddValue_Object,
-				new ConstReference("__data").ToExpression(),
+				new LiteralStringExpression("__data"),
 				data.ToExpression());
 			codebuilder.AddStatement(new ExpressionStatement(addValue));
 		}
@@ -169,7 +168,7 @@ namespace Castle.DynamicProxy.Contributors
 			{
 				var getValue = new MethodInvocationExpression(serializationInfo,
 				                                              SerializationInfoMethods.GetValue,
-				                                              new ConstReference(field.Reference.Name).ToExpression(),
+				                                              new LiteralStringExpression(field.Reference.Name),
 				                                              new TypeTokenExpression(field.Reference.FieldType));
 				ctor.CodeBuilder.AddStatement(new AssignStatement(
 				                              	field,

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -176,7 +176,7 @@ namespace Castle.DynamicProxy.Contributors
 				                              	                      typeof(object),
 				                              	                      getValue)));
 			}
-			ctor.CodeBuilder.AddStatement(new ReturnStatement());
+			ctor.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private bool VerifyIfBaseImplementsGetObjectData(Type baseType, IList<MethodInfo> methodsToSkip)

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -82,11 +82,11 @@ namespace Castle.DynamicProxy.Contributors
 		protected override void CustomizeGetObjectData(AbstractCodeBuilder codebuilder, ArgumentReference serializationInfo,
 		                                               ArgumentReference streamingContext, ClassEmitter emitter)
 		{
-			codebuilder.AddExpression(new MethodInvocationExpression(
-			                          	serializationInfo,
-			                          	SerializationInfoMethods.AddValue_Bool,
-			                          	new LiteralStringExpression("__delegateToBase"),
-			                          	new LiteralBoolExpression(delegateToBaseGetObjectData)));
+			codebuilder.Add(new MethodInvocationExpression(
+			                serializationInfo,
+			                SerializationInfoMethods.AddValue_Bool,
+			                new LiteralStringExpression("__delegateToBase"),
+			                new LiteralBoolExpression(delegateToBaseGetObjectData)));
 
 			if (delegateToBaseGetObjectData == false)
 			{
@@ -106,28 +106,28 @@ namespace Castle.DynamicProxy.Contributors
 				null,
 				FormatterServicesMethods.GetSerializableMembers,
 				new TypeTokenExpression(targetType));
-			codebuilder.AddStatement(new AssignStatement(members, getSerializableMembers));
+			codebuilder.Add(new AssignStatement(members, getSerializableMembers));
 
 			// Sort to keep order on both serialize and deserialize side the same, c.f DYNPROXY-ISSUE-127
 			var callSort = new MethodInvocationExpression(
 				null,
 				TypeUtilMethods.Sort,
 				members.ToExpression());
-			codebuilder.AddStatement(new AssignStatement(members, callSort));
+			codebuilder.Add(new AssignStatement(members, callSort));
 
 			var getObjectData = new MethodInvocationExpression(
 				null,
 				FormatterServicesMethods.GetObjectData,
 				SelfReference.Self.ToExpression(),
 				members.ToExpression());
-			codebuilder.AddStatement(new AssignStatement(data, getObjectData));
+			codebuilder.Add(new AssignStatement(data, getObjectData));
 
 			var addValue = new MethodInvocationExpression(
 				serializationInfo,
 				SerializationInfoMethods.AddValue_Object,
 				new LiteralStringExpression("__data"),
 				data.ToExpression());
-			codebuilder.AddExpression(addValue);
+			codebuilder.Add(addValue);
 		}
 
 		private void EmitCallToBaseGetObjectData(AbstractCodeBuilder codebuilder, ArgumentReference serializationInfo,
@@ -136,9 +136,9 @@ namespace Castle.DynamicProxy.Contributors
 			var baseGetObjectData = targetType.GetMethod("GetObjectData",
 			                                             new[] { typeof(SerializationInfo), typeof(StreamingContext) });
 
-			codebuilder.AddExpression(new MethodInvocationExpression(baseGetObjectData,
-			                                                         serializationInfo.ToExpression(),
-			                                                         streamingContext.ToExpression()));
+			codebuilder.Add(new MethodInvocationExpression(baseGetObjectData,
+			                                               serializationInfo.ToExpression(),
+			                                               streamingContext.ToExpression()));
 		}
 
 		private void Constructor(ClassEmitter emitter)
@@ -157,7 +157,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			var ctor = emitter.CreateConstructor(serializationInfo, streamingContext);
 
-			ctor.CodeBuilder.AddStatement(
+			ctor.CodeBuilder.Add(
 				new ConstructorInvocationStatement(serializationConstructor,
 				                                   serializationInfo.ToExpression(),
 				                                   streamingContext.ToExpression()));
@@ -168,13 +168,12 @@ namespace Castle.DynamicProxy.Contributors
 				                                              SerializationInfoMethods.GetValue,
 				                                              new LiteralStringExpression(field.Reference.Name),
 				                                              new TypeTokenExpression(field.Reference.FieldType));
-				ctor.CodeBuilder.AddStatement(new AssignStatement(
-				                              	field,
-				                              	new ConvertExpression(field.Reference.FieldType,
-				                              	                      typeof(object),
-				                              	                      getValue)));
+				ctor.CodeBuilder.Add(new AssignStatement(field,
+				                                         new ConvertExpression(field.Reference.FieldType,
+				                                                               typeof(object),
+				                                                               getValue)));
 			}
-			ctor.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			ctor.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private bool VerifyIfBaseImplementsGetObjectData(Type baseType, IList<MethodInfo> methodsToSkip)

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -126,7 +126,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			// invocation on base class
 
-			callBackMethod.CodeBuilder.AddStatement(
+			callBackMethod.CodeBuilder.Add(
 				new ReturnStatement(
 					new MethodInvocationExpression(SelfReference.Self,
 					                               targetMethod,

--- a/src/Castle.Core/DynamicProxy/Contributors/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ForwardingMethodGenerator.cs
@@ -35,11 +35,11 @@ namespace Castle.DynamicProxy.Contributors
 			var targetReference = getTargetReference(@class, MethodToOverride);
 			var arguments = ArgumentsUtil.ConvertToArgumentReferenceExpression(MethodToOverride.GetParameters());
 
-			emitter.CodeBuilder.AddStatement(new ReturnStatement(
-			                                 	new MethodInvocationExpression(
-			                                 		targetReference,
-			                                 		MethodToOverride,
-			                                 		arguments) { VirtualCall = true }));
+			emitter.CodeBuilder.Add(new ReturnStatement(
+			                        	new MethodInvocationExpression(
+			                        		targetReference,
+			                        		MethodToOverride,
+			                        		arguments) { VirtualCall = true }));
 			return emitter;
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
@@ -39,13 +39,13 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var targetField = emitter.GetField("__target");
 
-			codebuilder.AddExpression(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                                                         new LiteralStringExpression("__targetFieldType"),
-			                                                         new LiteralStringExpression(targetField.Reference.FieldType.AssemblyQualifiedName)));
+			codebuilder.Add(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
+			                                               new LiteralStringExpression("__targetFieldType"),
+			                                               new LiteralStringExpression(targetField.Reference.FieldType.AssemblyQualifiedName)));
 
-			codebuilder.AddExpression(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                                                         new LiteralStringExpression("__theInterface"),
-			                                                         new LiteralStringExpression(targetType.AssemblyQualifiedName)));
+			codebuilder.Add(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
+			                                               new LiteralStringExpression("__theInterface"),
+			                                               new LiteralStringExpression(targetType.AssemblyQualifiedName)));
 		}
 #endif
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
@@ -41,16 +41,13 @@ namespace Castle.DynamicProxy.Contributors
 
 			codebuilder.AddStatement(new ExpressionStatement(
 			                         	new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                         	                               new ConstReference("__targetFieldType").ToExpression(),
-			                         	                               new ConstReference(
-			                         	                               	targetField.Reference.FieldType.AssemblyQualifiedName).
-			                         	                               	ToExpression())));
+			                         	                               new LiteralStringExpression("__targetFieldType"),
+			                         	                               new LiteralStringExpression(targetField.Reference.FieldType.AssemblyQualifiedName))));
 
 			codebuilder.AddStatement(new ExpressionStatement(
 			                         	new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                         	                               new ConstReference("__theInterface").ToExpression(),
-			                         	                               new ConstReference(targetType.AssemblyQualifiedName).
-			                         	                               	ToExpression())));
+			                         	                               new LiteralStringExpression("__theInterface"),
+			                         	                               new LiteralStringExpression(targetType.AssemblyQualifiedName))));
 		}
 #endif
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
@@ -39,15 +39,13 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var targetField = emitter.GetField("__target");
 
-			codebuilder.AddStatement(new ExpressionStatement(
-			                         	new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                         	                               new LiteralStringExpression("__targetFieldType"),
-			                         	                               new LiteralStringExpression(targetField.Reference.FieldType.AssemblyQualifiedName))));
+			codebuilder.AddExpression(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
+			                                                         new LiteralStringExpression("__targetFieldType"),
+			                                                         new LiteralStringExpression(targetField.Reference.FieldType.AssemblyQualifiedName)));
 
-			codebuilder.AddStatement(new ExpressionStatement(
-			                         	new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
-			                         	                               new LiteralStringExpression("__theInterface"),
-			                         	                               new LiteralStringExpression(targetType.AssemblyQualifiedName))));
+			codebuilder.AddExpression(new MethodInvocationExpression(serializationInfo, SerializationInfoMethods.AddValue_Object,
+			                                                         new LiteralStringExpression("__theInterface"),
+			                                                         new LiteralStringExpression(targetType.AssemblyQualifiedName)));
 		}
 #endif
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
@@ -46,7 +46,7 @@ namespace Castle.DynamicProxy.Contributors
 			var constructor = invocation.CreateConstructor(arguments);
 
 			var delegateField = invocation.CreateField("delegate", delegateType);
-			constructor.CodeBuilder.AddStatement(new AssignStatement(delegateField, new ReferenceExpression(arguments[0])));
+			constructor.CodeBuilder.Add(new AssignStatement(delegateField, new ReferenceExpression(arguments[0])));
 			return constructor;
 		}
 
@@ -84,7 +84,7 @@ namespace Castle.DynamicProxy.Contributors
 				new MethodTokenExpression(method.MethodOnTarget));
 			var bindDelegate = new AssignStatement(callback, new ConvertExpression(delegateType, createDelegate));
 
-			proxy.ClassConstructor.CodeBuilder.AddStatement(bindDelegate);
+			proxy.ClassConstructor.CodeBuilder.Add(bindDelegate);
 			return callback;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Contributors
 			var localReference = invokeMethodOnTarget.CodeBuilder.DeclareLocal(closedDelegateType);
 			var closedMethodOnTarget = method.MethodOnTarget.MakeGenericMethod(genericTypeParameters);
 			var localTarget = new ReferenceExpression(targetReference);
-			invokeMethodOnTarget.CodeBuilder.AddStatement(
+			invokeMethodOnTarget.CodeBuilder.Add(
 				SetDelegate(localReference, localTarget, closedDelegateType, closedMethodOnTarget));
 			return localReference;
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/MinimialisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MinimialisticMethodGenerator.cs
@@ -34,11 +34,11 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (emitter.ReturnType == typeof(void))
 			{
-				emitter.CodeBuilder.AddStatement(ReturnStatement.Instance);
+				emitter.CodeBuilder.Add(ReturnStatement.Instance);
 			}
 			else
 			{
-				emitter.CodeBuilder.AddStatement(new ReturnStatement(new DefaultValueExpression(emitter.ReturnType)));
+				emitter.CodeBuilder.Add(new ReturnStatement(new DefaultValueExpression(emitter.ReturnType)));
 			}
 
 			return emitter;
@@ -51,7 +51,7 @@ namespace Castle.DynamicProxy.Contributors
 				var parameter = parameters[index];
 				if (parameter.IsOut)
 				{
-					emitter.CodeBuilder.AddStatement(
+					emitter.CodeBuilder.Add(
 						new AssignArgumentStatement(new ArgumentReference(parameter.ParameterType, index + 1),
 						                            new DefaultValueExpression(parameter.ParameterType)));
 				}

--- a/src/Castle.Core/DynamicProxy/Contributors/MinimialisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MinimialisticMethodGenerator.cs
@@ -34,7 +34,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (emitter.ReturnType == typeof(void))
 			{
-				emitter.CodeBuilder.AddStatement(new ReturnStatement());
+				emitter.CodeBuilder.AddStatement(ReturnStatement.Instance);
 			}
 			else
 			{

--- a/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
@@ -38,9 +38,8 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var targetReference = getTargetReference(@class, MethodToOverride);
 
-			emitter.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new IfNullExpression(targetReference, IfNull(emitter.ReturnType), IfNotNull(targetReference))));
+			emitter.CodeBuilder.AddExpression(
+				new IfNullExpression(targetReference, IfNull(emitter.ReturnType), IfNotNull(targetReference)));
 			return emitter;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
@@ -38,7 +38,7 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var targetReference = getTargetReference(@class, MethodToOverride);
 
-			emitter.CodeBuilder.AddExpression(
+			emitter.CodeBuilder.Add(
 				new IfNullExpression(targetReference, IfNull(emitter.ReturnType), IfNotNull(targetReference)));
 			return emitter;
 		}
@@ -48,11 +48,11 @@ namespace Castle.DynamicProxy.Contributors
 			var expression = new MultiStatementExpression();
 			var arguments = ArgumentsUtil.ConvertToArgumentReferenceExpression(MethodToOverride.GetParameters());
 
-			expression.AddStatement(new ReturnStatement(
-			                        	new MethodInvocationExpression(
-			                        		targetReference,
-			                        		MethodToOverride,
-			                        		arguments) { VirtualCall = true }));
+			expression.Add(new ReturnStatement(
+			               	new MethodInvocationExpression(
+			               		targetReference,
+			               		MethodToOverride,
+			               		arguments) { VirtualCall = true }));
 			return expression;
 		}
 
@@ -63,11 +63,11 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (returnType == typeof(void))
 			{
-				expression.AddStatement(ReturnStatement.Instance);
+				expression.Add(ReturnStatement.Instance);
 			}
 			else
 			{
-				expression.AddStatement(new ReturnStatement(new DefaultValueExpression(returnType)));
+				expression.Add(new ReturnStatement(new DefaultValueExpression(returnType)));
 			}
 			return expression;
 		}
@@ -79,7 +79,7 @@ namespace Castle.DynamicProxy.Contributors
 				var parameter = parameters[index];
 				if (parameter.IsOut)
 				{
-					expression.AddStatement(
+					expression.Add(
 						new AssignArgumentStatement(new ArgumentReference(parameter.ParameterType, index + 1),
 						                            new DefaultValueExpression(parameter.ParameterType)));
 				}

--- a/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/OptionallyForwardingMethodGenerator.cs
@@ -64,7 +64,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (returnType == typeof(void))
 			{
-				expression.AddStatement(new ReturnStatement());
+				expression.AddStatement(ReturnStatement.Instance);
 			}
 			else
 			{

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
@@ -113,12 +113,11 @@ namespace Castle.DynamicProxy.Contributors
 						new LiteralBoolExpression(true),
 						new LiteralBoolExpression(false))));
 
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(
-						info,
-						SerializationInfoMethods.SetType,
-						typeLocal.ToExpression())));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(
+					info,
+					SerializationInfoMethods.SetType,
+					typeLocal.ToExpression()));
 
 			foreach (var field in emitter.GetAllFields())
 			{
@@ -149,36 +148,32 @@ namespace Castle.DynamicProxy.Contributors
 						new LiteralStringExpression(interfaces[i].AssemblyQualifiedName)));
 			}
 
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(
-						info,
-						SerializationInfoMethods.AddValue_Object,
-						new LiteralStringExpression("__interfaces"),
-						interfacesLocal.ToExpression())));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(
+					info,
+					SerializationInfoMethods.AddValue_Object,
+					new LiteralStringExpression("__interfaces"),
+					interfacesLocal.ToExpression()));
 
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(
-						info,
-						SerializationInfoMethods.AddValue_Object,
-						new LiteralStringExpression("__baseType"),
-						new LiteralStringExpression(emitter.BaseType.AssemblyQualifiedName))));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(
+					info,
+					SerializationInfoMethods.AddValue_Object,
+					new LiteralStringExpression("__baseType"),
+					new LiteralStringExpression(emitter.BaseType.AssemblyQualifiedName)));
 
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(
-						info,
-						SerializationInfoMethods.AddValue_Object,
-						new LiteralStringExpression("__proxyGenerationOptions"),
-						emitter.GetField("proxyGenerationOptions").ToExpression())));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(
+					info,
+					SerializationInfoMethods.AddValue_Object,
+					new LiteralStringExpression("__proxyGenerationOptions"),
+					emitter.GetField("proxyGenerationOptions").ToExpression()));
 
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(info,
-					                               SerializationInfoMethods.AddValue_Object,
-					                               new LiteralStringExpression("__proxyTypeId"),
-					                               new LiteralStringExpression(proxyTypeId))));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(info,
+					                            SerializationInfoMethods.AddValue_Object,
+					                            new LiteralStringExpression("__proxyTypeId"),
+					                            new LiteralStringExpression(proxyTypeId)));
 
 			CustomizeGetObjectData(getObjectData.CodeBuilder, info, getObjectData.Arguments[1], emitter);
 
@@ -188,13 +183,12 @@ namespace Castle.DynamicProxy.Contributors
 		protected virtual void AddAddValueInvocation(ArgumentReference serializationInfo, MethodEmitter getObjectData,
 		                                             FieldReference field)
 		{
-			getObjectData.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(
-						serializationInfo,
-						SerializationInfoMethods.AddValue_Object,
-						new LiteralStringExpression(field.Reference.Name),
-						field.ToExpression())));
+			getObjectData.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(
+					serializationInfo,
+					SerializationInfoMethods.AddValue_Object,
+					new LiteralStringExpression(field.Reference.Name),
+					field.ToExpression()));
 			return;
 		}
 

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
@@ -67,7 +67,7 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var dynProxyGetTarget = emitter.CreateMethod("DynProxyGetTarget", typeof(object));
 
-			dynProxyGetTarget.CodeBuilder.AddStatement(
+			dynProxyGetTarget.CodeBuilder.Add(
 				new ReturnStatement(new ConvertExpression(typeof(object), targetType, GetTargetReferenceExpression(emitter))));
 
 			var dynProxySetTarget = emitter.CreateMethod("DynProxySetTarget", typeof(void), typeof(object));
@@ -76,21 +76,21 @@ namespace Castle.DynamicProxy.Contributors
 			var targetField = GetTargetReference(emitter) as FieldReference;
 			if (targetField != null)
 			{
-				dynProxySetTarget.CodeBuilder.AddStatement(
+				dynProxySetTarget.CodeBuilder.Add(
 					new AssignStatement(targetField,
 						new ConvertExpression(targetField.Fieldbuilder.FieldType, dynProxySetTarget.Arguments[0].ToExpression())));
 			}
 			else
 			{
-				dynProxySetTarget.CodeBuilder.AddStatement(
+				dynProxySetTarget.CodeBuilder.Add(
 					new ThrowStatement(typeof(InvalidOperationException), "Cannot change the target of the class proxy."));
 			}
 
-			dynProxySetTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			dynProxySetTarget.CodeBuilder.Add(ReturnStatement.Instance);
 
 			var getInterceptors = emitter.CreateMethod("GetInterceptors", typeof(IInterceptor[]));
 
-			getInterceptors.CodeBuilder.AddStatement(
+			getInterceptors.CodeBuilder.Add(
 				new ReturnStatement(interceptorsField));
 		}
 
@@ -103,7 +103,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			var typeLocal = getObjectData.CodeBuilder.DeclareLocal(typeof(Type));
 
-			getObjectData.CodeBuilder.AddStatement(
+			getObjectData.CodeBuilder.Add(
 				new AssignStatement(
 					typeLocal,
 					new MethodInvocationExpression(
@@ -113,7 +113,7 @@ namespace Castle.DynamicProxy.Contributors
 						new LiteralBoolExpression(true),
 						new LiteralBoolExpression(false))));
 
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(
 					info,
 					SerializationInfoMethods.SetType,
@@ -134,42 +134,42 @@ namespace Castle.DynamicProxy.Contributors
 
 			var interfacesLocal = getObjectData.CodeBuilder.DeclareLocal(typeof(string[]));
 
-			getObjectData.CodeBuilder.AddStatement(
+			getObjectData.CodeBuilder.Add(
 				new AssignStatement(
 					interfacesLocal,
 					new NewArrayExpression(interfaces.Length, typeof(string))));
 
 			for (var i = 0; i < interfaces.Length; i++)
 			{
-				getObjectData.CodeBuilder.AddStatement(
+				getObjectData.CodeBuilder.Add(
 					new AssignArrayStatement(
 						interfacesLocal,
 						i,
 						new LiteralStringExpression(interfaces[i].AssemblyQualifiedName)));
 			}
 
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(
 					info,
 					SerializationInfoMethods.AddValue_Object,
 					new LiteralStringExpression("__interfaces"),
 					interfacesLocal.ToExpression()));
 
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(
 					info,
 					SerializationInfoMethods.AddValue_Object,
 					new LiteralStringExpression("__baseType"),
 					new LiteralStringExpression(emitter.BaseType.AssemblyQualifiedName)));
 
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(
 					info,
 					SerializationInfoMethods.AddValue_Object,
 					new LiteralStringExpression("__proxyGenerationOptions"),
 					emitter.GetField("proxyGenerationOptions").ToExpression()));
 
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(info,
 					                            SerializationInfoMethods.AddValue_Object,
 					                            new LiteralStringExpression("__proxyTypeId"),
@@ -177,13 +177,13 @@ namespace Castle.DynamicProxy.Contributors
 
 			CustomizeGetObjectData(getObjectData.CodeBuilder, info, getObjectData.Arguments[1], emitter);
 
-			getObjectData.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			getObjectData.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		protected virtual void AddAddValueInvocation(ArgumentReference serializationInfo, MethodEmitter getObjectData,
 		                                             FieldReference field)
 		{
-			getObjectData.CodeBuilder.AddExpression(
+			getObjectData.CodeBuilder.Add(
 				new MethodInvocationExpression(
 					serializationInfo,
 					SerializationInfoMethods.AddValue_Object,

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
@@ -109,9 +109,9 @@ namespace Castle.DynamicProxy.Contributors
 					new MethodInvocationExpression(
 						null,
 						TypeMethods.StaticGetType,
-						new ConstReference(typeof(ProxyObjectReference).AssemblyQualifiedName).ToExpression(),
-						new ConstReference(1).ToExpression(),
-						new ConstReference(0).ToExpression())));
+						new LiteralStringExpression(typeof(ProxyObjectReference).AssemblyQualifiedName),
+						new LiteralBoolExpression(true),
+						new LiteralBoolExpression(false))));
 
 			getObjectData.CodeBuilder.AddStatement(
 				new ExpressionStatement(
@@ -146,7 +146,7 @@ namespace Castle.DynamicProxy.Contributors
 					new AssignArrayStatement(
 						interfacesLocal,
 						i,
-						new ConstReference(interfaces[i].AssemblyQualifiedName).ToExpression()));
+						new LiteralStringExpression(interfaces[i].AssemblyQualifiedName)));
 			}
 
 			getObjectData.CodeBuilder.AddStatement(
@@ -154,7 +154,7 @@ namespace Castle.DynamicProxy.Contributors
 					new MethodInvocationExpression(
 						info,
 						SerializationInfoMethods.AddValue_Object,
-						new ConstReference("__interfaces").ToExpression(),
+						new LiteralStringExpression("__interfaces"),
 						interfacesLocal.ToExpression())));
 
 			getObjectData.CodeBuilder.AddStatement(
@@ -162,23 +162,23 @@ namespace Castle.DynamicProxy.Contributors
 					new MethodInvocationExpression(
 						info,
 						SerializationInfoMethods.AddValue_Object,
-						new ConstReference("__baseType").ToExpression(),
-						new ConstReference(emitter.BaseType.AssemblyQualifiedName).ToExpression())));
+						new LiteralStringExpression("__baseType"),
+						new LiteralStringExpression(emitter.BaseType.AssemblyQualifiedName))));
 
 			getObjectData.CodeBuilder.AddStatement(
 				new ExpressionStatement(
 					new MethodInvocationExpression(
 						info,
 						SerializationInfoMethods.AddValue_Object,
-						new ConstReference("__proxyGenerationOptions").ToExpression(),
+						new LiteralStringExpression("__proxyGenerationOptions"),
 						emitter.GetField("proxyGenerationOptions").ToExpression())));
 
 			getObjectData.CodeBuilder.AddStatement(
 				new ExpressionStatement(
 					new MethodInvocationExpression(info,
 					                               SerializationInfoMethods.AddValue_Object,
-					                               new ConstReference("__proxyTypeId").ToExpression(),
-					                               new ConstReference(proxyTypeId).ToExpression())));
+					                               new LiteralStringExpression("__proxyTypeId"),
+					                               new LiteralStringExpression(proxyTypeId))));
 
 			CustomizeGetObjectData(getObjectData.CodeBuilder, info, getObjectData.Arguments[1], emitter);
 
@@ -193,7 +193,7 @@ namespace Castle.DynamicProxy.Contributors
 					new MethodInvocationExpression(
 						serializationInfo,
 						SerializationInfoMethods.AddValue_Object,
-						new ConstReference(field.Reference.Name).ToExpression(),
+						new LiteralStringExpression(field.Reference.Name),
 						field.ToExpression())));
 			return;
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
@@ -86,7 +86,7 @@ namespace Castle.DynamicProxy.Contributors
 					new ThrowStatement(typeof(InvalidOperationException), "Cannot change the target of the class proxy."));
 			}
 
-			dynProxySetTarget.CodeBuilder.AddStatement(new ReturnStatement());
+			dynProxySetTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 
 			var getInterceptors = emitter.CreateMethod("GetInterceptors", typeof(IInterceptor[]));
 
@@ -182,7 +182,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			CustomizeGetObjectData(getObjectData.CodeBuilder, info, getObjectData.Arguments[1], emitter);
 
-			getObjectData.CodeBuilder.AddStatement(new ReturnStatement());
+			getObjectData.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		protected virtual void AddAddValueInvocation(ArgumentReference serializationInfo, MethodEmitter getObjectData,

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -146,7 +146,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected void CompleteInitCacheMethod(ConstructorCodeBuilder constCodeBuilder)
 		{
-			constCodeBuilder.AddStatement(ReturnStatement.Instance);
+			constCodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		protected virtual void CreateFields(ClassEmitter emitter)
@@ -252,7 +252,7 @@ namespace Castle.DynamicProxy.Generators
 
 			for (var i = 0; i < fields.Length; i++)
 			{
-				constructor.CodeBuilder.AddStatement(new AssignStatement(fields[i], args[i].ToExpression()));
+				constructor.CodeBuilder.Add(new AssignStatement(fields[i], args[i].ToExpression()));
 			}
 
 			// Invoke base constructor
@@ -271,7 +271,7 @@ namespace Castle.DynamicProxy.Generators
 				constructor.CodeBuilder.InvokeBaseConstructor();
 			}
 
-			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			constructor.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		protected void GenerateConstructors(ClassEmitter emitter, Type baseType, params FieldReference[] fields)
@@ -318,16 +318,16 @@ namespace Castle.DynamicProxy.Generators
 
 			// initialize fields with an empty interceptor
 
-			constructor.CodeBuilder.AddStatement(new AssignStatement(interceptorField,
-			                                                         new NewArrayExpression(1, typeof(IInterceptor))));
-			constructor.CodeBuilder.AddStatement(
+			constructor.CodeBuilder.Add(new AssignStatement(interceptorField,
+			                                                new NewArrayExpression(1, typeof(IInterceptor))));
+			constructor.CodeBuilder.Add(
 				new AssignArrayStatement(interceptorField, 0, new NewInstanceExpression(typeof(StandardInterceptor), new Type[0])));
 
 			// Invoke base constructor
 
 			constructor.CodeBuilder.InvokeBaseConstructor(defaultConstructor);
 
-			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			constructor.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		protected ConstructorEmitter GenerateStaticConstructor(ClassEmitter emitter)

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -146,7 +146,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected void CompleteInitCacheMethod(ConstructorCodeBuilder constCodeBuilder)
 		{
-			constCodeBuilder.AddStatement(new ReturnStatement());
+			constCodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		protected virtual void CreateFields(ClassEmitter emitter)
@@ -271,7 +271,7 @@ namespace Castle.DynamicProxy.Generators
 				constructor.CodeBuilder.InvokeBaseConstructor();
 			}
 
-			constructor.CodeBuilder.AddStatement(new ReturnStatement());
+			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		protected void GenerateConstructors(ClassEmitter emitter, Type baseType, params FieldReference[] fields)
@@ -327,7 +327,7 @@ namespace Castle.DynamicProxy.Generators
 
 			constructor.CodeBuilder.InvokeBaseConstructor(defaultConstructor);
 
-			constructor.CodeBuilder.AddStatement(new ReturnStatement());
+			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		protected ConstructorEmitter GenerateStaticConstructor(ClassEmitter emitter)

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -60,9 +60,8 @@ namespace Castle.DynamicProxy.Generators
 		protected override void ImplementInvokeMethodOnTarget(AbstractTypeEmitter invocation, ParameterInfo[] parameters,
 		                                                      MethodEmitter invokeMethodOnTarget, Reference targetField)
 		{
-			invokeMethodOnTarget.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(SelfReference.Self, InvocationMethods.CompositionInvocationEnsureValidTarget)));
+			invokeMethodOnTarget.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(SelfReference.Self, InvocationMethods.CompositionInvocationEnsureValidTarget));
 			base.ImplementInvokeMethodOnTarget(invocation, parameters, invokeMethodOnTarget, targetField);
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -60,7 +60,7 @@ namespace Castle.DynamicProxy.Generators
 		protected override void ImplementInvokeMethodOnTarget(AbstractTypeEmitter invocation, ParameterInfo[] parameters,
 		                                                      MethodEmitter invokeMethodOnTarget, Reference targetField)
 		{
-			invokeMethodOnTarget.CodeBuilder.AddExpression(
+			invokeMethodOnTarget.CodeBuilder.Add(
 				new MethodInvocationExpression(SelfReference.Self, InvocationMethods.CompositionInvocationEnsureValidTarget));
 			base.ImplementInvokeMethodOnTarget(invocation, parameters, invokeMethodOnTarget, targetField);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/AbstractCodeBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/AbstractCodeBuilder.cs
@@ -24,13 +24,13 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 	{
 		private readonly ILGenerator generator;
 		private readonly List<Reference> ilmarkers;
-		private readonly List<Statement> stmts;
+		private readonly List<IILEmitter> emitters;
 		private bool isEmpty;
 
 		protected AbstractCodeBuilder(ILGenerator generator)
 		{
 			this.generator = generator;
-			stmts = new List<Statement>();
+			emitters = new List<IILEmitter>();
 			ilmarkers = new List<Reference>();
 			isEmpty = true;
 		}
@@ -48,14 +48,20 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 
 		public AbstractCodeBuilder AddExpression(Expression expression)
 		{
-			return AddStatement(new ExpressionStatement(expression));
+			Add(expression);
+			return this;
 		}
 
 		public AbstractCodeBuilder AddStatement(Statement stmt)
 		{
-			SetNonEmpty();
-			stmts.Add(stmt);
+			Add(stmt);
 			return this;
+		}
+
+		internal void Add(IILEmitter emitter)
+		{
+			SetNonEmpty();
+			emitters.Add(emitter);
 		}
 
 		public LocalReference DeclareLocal(Type type)
@@ -77,9 +83,9 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 				local.Generate(il);
 			}
 
-			foreach (var stmt in stmts)
+			foreach (var emitter in emitters)
 			{
-				stmt.Emit(member, il);
+				emitter.Emit(member, il);
 			}
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/ConstructorCodeBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/ConstructorCodeBuilder.cs
@@ -46,14 +46,13 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 
 		public void InvokeBaseConstructor(ConstructorInfo constructor)
 		{
-			AddStatement(new ConstructorInvocationStatement(constructor));
+			Add(new ConstructorInvocationStatement(constructor));
 		}
 
 		public void InvokeBaseConstructor(ConstructorInfo constructor, params ArgumentReference[] arguments)
 		{
-			AddStatement(
-				new ConstructorInvocationStatement(constructor,
-				                                   ArgumentsUtil.ConvertArgumentReferenceToExpression(arguments)));
+			Add(new ConstructorInvocationStatement(constructor,
+			                                       ArgumentsUtil.ConvertArgumentReferenceToExpression(arguments)));
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
@@ -89,7 +89,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
 				CodeBuilder.InvokeBaseConstructor();
-				CodeBuilder.AddStatement(ReturnStatement.Instance);
+				CodeBuilder.Add(ReturnStatement.Instance);
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
@@ -89,7 +89,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
 				CodeBuilder.InvokeBaseConstructor();
-				CodeBuilder.AddStatement(new ReturnStatement());
+				CodeBuilder.AddStatement(ReturnStatement.Instance);
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -138,7 +138,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
 				CodeBuilder.AddStatement(new NopStatement());
-				CodeBuilder.AddStatement(new ReturnStatement());
+				CodeBuilder.AddStatement(ReturnStatement.Instance);
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -137,8 +137,8 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		{
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
-				CodeBuilder.AddStatement(new NopStatement());
-				CodeBuilder.AddStatement(ReturnStatement.Instance);
+				CodeBuilder.Add(new NopStatement());
+				CodeBuilder.Add(ReturnStatement.Instance);
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
@@ -15,14 +15,15 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
-	using System.Diagnostics;
+	using System.ComponentModel;
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	[DebuggerDisplay("{value}")]
+	[Obsolete] // TODO: Remove this class.
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ConstReference : TypeReference
 	{
-		private readonly object value;
+		internal readonly object value;
 
 		public ConstReference(object value)
 			: base(value.GetType())
@@ -51,7 +52,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		public override void StoreReference(ILGenerator gen)
 		{
-			throw new NotImplementedException("ConstReference.StoreReference");
+			throw new NotSupportedException();
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ExpressionStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ExpressionStatement.cs
@@ -14,8 +14,12 @@
 
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
+	using System;
+	using System.ComponentModel;
 	using System.Reflection.Emit;
 
+	[Obsolete] // TODO: Remove this class.
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class ExpressionStatement : Statement
 	{
 		private readonly Expression expression;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
@@ -1,11 +1,11 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
-// 
+// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,30 +14,20 @@
 
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
-	using System;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
-	public class ThrowStatement : Statement
+	internal sealed class LiteralBoolExpression : Expression
 	{
-		private readonly string errorMessage;
-		private readonly Type exceptionType;
+		private bool value;
 
-		public ThrowStatement(Type exceptionType, String errorMessage)
+		public LiteralBoolExpression(bool value)
 		{
-			this.exceptionType = exceptionType;
-			this.errorMessage = errorMessage;
+			this.value = value;
 		}
 
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{
-			var ci = exceptionType.GetConstructor(new[] { typeof(String) });
-
-			var creationStmt = new NewInstanceExpression(ci, new LiteralStringExpression(errorMessage));
-
-			creationStmt.Emit(member, gen);
-
-			gen.Emit(OpCodes.Throw);
+			gen.Emit(value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
@@ -1,11 +1,11 @@
-// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
-// 
+// Copyright 2004-2018 Castle Project - http://www.castleproject.org/
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,30 +14,23 @@
 
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
-	using System;
-	using System.Reflection;
+	using System.Diagnostics;
 	using System.Reflection.Emit;
 
-	public class ThrowStatement : Statement
+	internal sealed class LiteralStringExpression : Expression
 	{
-		private readonly string errorMessage;
-		private readonly Type exceptionType;
+		private string value;
 
-		public ThrowStatement(Type exceptionType, String errorMessage)
+		public LiteralStringExpression(string value)
 		{
-			this.exceptionType = exceptionType;
-			this.errorMessage = errorMessage;
+			Debug.Assert(value != null);
+
+			this.value = value;
 		}
 
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{
-			var ci = exceptionType.GetConstructor(new[] { typeof(String) });
-
-			var creationStmt = new NewInstanceExpression(ci, new LiteralStringExpression(errorMessage));
-
-			creationStmt.Emit(member, gen);
-
-			gen.Emit(OpCodes.Throw);
+			gen.Emit(OpCodes.Ldstr, value);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadArrayElementExpression.cs
@@ -15,30 +15,33 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
+	using System.ComponentModel;
 	using System.Reflection.Emit;
 
 	public class LoadArrayElementExpression : Expression
 	{
 		private readonly Reference arrayReference;
-		private readonly ConstReference index;
+		private readonly int index;
 		private readonly Type returnType;
 
 		public LoadArrayElementExpression(int index, Reference arrayReference, Type returnType)
-			: this(new ConstReference(index), arrayReference, returnType)
-		{
-		}
-
-		public LoadArrayElementExpression(ConstReference index, Reference arrayReference, Type returnType)
 		{
 			this.index = index;
 			this.arrayReference = arrayReference;
 			this.returnType = returnType;
 		}
 
+		[Obsolete] // TODO: Remove this method.
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public LoadArrayElementExpression(ConstReference index, Reference arrayReference, Type returnType)
+			: this(Convert.ToInt32(index.value), arrayReference, returnType)
+		{
+		}
+
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{
 			ArgumentsUtil.EmitLoadOwnerAndReference(arrayReference, gen);
-			ArgumentsUtil.EmitLoadOwnerAndReference(index, gen);
+			OpCodeUtil.EmitLoadOpCodeForConstantValue(gen, index);
 			gen.Emit(OpCodes.Ldelem, returnType);
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
@@ -14,28 +14,32 @@
 
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
+	using System;
+	using System.ComponentModel;
 	using System.Reflection.Emit;
 
 	public class LoadRefArrayElementExpression : Expression
 	{
 		private readonly Reference arrayReference;
-		private readonly ConstReference index;
+		private readonly int index;
 
 		public LoadRefArrayElementExpression(int index, Reference arrayReference)
-			: this(new ConstReference(index), arrayReference)
-		{
-		}
-
-		public LoadRefArrayElementExpression(ConstReference index, Reference arrayReference)
 		{
 			this.index = index;
 			this.arrayReference = arrayReference;
 		}
 
+		[Obsolete] // TODO: Remove this method.
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public LoadRefArrayElementExpression(ConstReference index, Reference arrayReference)
+			: this(Convert.ToInt32(index.value), arrayReference)
+		{
+		}
+
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{
 			ArgumentsUtil.EmitLoadOwnerAndReference(arrayReference, gen);
-			ArgumentsUtil.EmitLoadOwnerAndReference(index, gen);
+			OpCodeUtil.EmitLoadOpCodeForConstantValue(gen, index);
 			gen.Emit(OpCodes.Ldelem_Ref);
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MultiStatementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MultiStatementExpression.cs
@@ -19,23 +19,28 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	public class MultiStatementExpression : Expression
 	{
-		private readonly List<Statement> statements = new List<Statement>();
+		private readonly List<IILEmitter> emitters = new List<IILEmitter>();
 
 		public void AddStatement(Statement statement)
 		{
-			statements.Add(statement);
+			Add(statement);
 		}
 
 		public void AddExpression(Expression expression)
 		{
-			AddStatement(new ExpressionStatement(expression));
+			Add(expression);
+		}
+
+		internal void Add(IILEmitter emitter)
+		{
+			emitters.Add(emitter);
 		}
 
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{
-			foreach (Statement s in statements)
+			foreach (var emitter in emitters)
 			{
-				s.Emit(member, gen);
+				emitter.Emit(member, gen);
 			}
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
@@ -18,6 +18,8 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	public class ReturnStatement : Statement
 	{
+		public static readonly ReturnStatement Instance = new ReturnStatement();
+
 		private readonly Expression expression;
 		private readonly Reference reference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
@@ -27,7 +27,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		{
 			if (CodeBuilder.IsEmpty)
 			{
-				CodeBuilder.AddStatement(new ReturnStatement());
+				CodeBuilder.AddStatement(ReturnStatement.Instance);
 			}
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
@@ -27,7 +27,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		{
 			if (CodeBuilder.IsEmpty)
 			{
-				CodeBuilder.AddStatement(ReturnStatement.Instance);
+				CodeBuilder.Add(ReturnStatement.Instance);
 			}
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -39,7 +39,7 @@ namespace Castle.DynamicProxy.Generators
 			{
 				if (IsByRef(parameters[i]) && !IsReadOnly(parameters[i]))
 				{
-					emitter.CodeBuilder.AddStatement(AssignArgument(dereferencedArguments, i, arguments));
+					emitter.CodeBuilder.Add(AssignArgument(dereferencedArguments, i, arguments));
 				}
 			}
 
@@ -115,7 +115,7 @@ namespace Castle.DynamicProxy.Generators
 		private static LocalReference StoreInvocationArgumentsInLocal(MethodEmitter emitter, LocalReference invocation)
 		{
 			var invocationArgs = emitter.CodeBuilder.DeclareLocal(typeof(object[]));
-			emitter.CodeBuilder.AddStatement(GetArguments(invocationArgs, invocation));
+			emitter.CodeBuilder.Add(GetArguments(invocationArgs, invocation));
 			return invocationArgs;
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -180,7 +180,7 @@ namespace Castle.DynamicProxy.Generators
 				invokeMethodOnTarget.CodeBuilder.AddStatement(new ExpressionStatement(setRetVal));
 			}
 
-			invokeMethodOnTarget.CodeBuilder.AddStatement(new ReturnStatement());
+			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private void AssignBackByRefArguments(MethodEmitter invokeMethodOnTarget, Dictionary<int, LocalReference> byRefArguments)
@@ -217,7 +217,7 @@ namespace Castle.DynamicProxy.Generators
 
 			var constructor = CreateConstructor(invocation, baseCtorArguments);
 			constructor.CodeBuilder.InvokeBaseConstructor(baseConstructor, baseCtorArguments);
-			constructor.CodeBuilder.AddStatement(new ReturnStatement());
+			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private ConstructorEmitter CreateConstructor(AbstractTypeEmitter invocation, ArgumentReference[] baseCtorArguments)
@@ -234,7 +234,7 @@ namespace Castle.DynamicProxy.Generators
 			var throwOnNoTarget = new ExpressionStatement(new MethodInvocationExpression(InvocationMethods.ThrowOnNoTarget));
 
 			invokeMethodOnTarget.CodeBuilder.AddStatement(throwOnNoTarget);
-			invokeMethodOnTarget.CodeBuilder.AddStatement(new ReturnStatement());
+			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private MethodInfo GetCallbackMethod(AbstractTypeEmitter invocation)
@@ -279,7 +279,7 @@ namespace Castle.DynamicProxy.Generators
 			changeInvocationTarget.CodeBuilder.AddStatement(
 				new AssignStatement(targetField,
 				                    new ConvertExpression(targetType, changeInvocationTarget.Arguments[0].ToExpression())));
-			changeInvocationTarget.CodeBuilder.AddStatement(new ReturnStatement());
+			changeInvocationTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private void ImplementChangeProxyTarget(AbstractTypeEmitter invocation, ClassEmitter @class)
@@ -301,7 +301,7 @@ namespace Castle.DynamicProxy.Generators
 						VirtualCall = true
 					}));
 
-			changeProxyTarget.CodeBuilder.AddStatement(new ReturnStatement());
+			changeProxyTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
 		private void ImplementChangeProxyTargetInterface(ClassEmitter @class, AbstractTypeEmitter invocation,

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -165,7 +165,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			else
 			{
-				invokeMethodOnTarget.CodeBuilder.AddStatement(new ExpressionStatement(methodOnTargetInvocationExpression));
+				invokeMethodOnTarget.CodeBuilder.AddExpression(methodOnTargetInvocationExpression);
 			}
 
 			AssignBackByRefArguments(invokeMethodOnTarget, byRefArguments);
@@ -177,7 +177,7 @@ namespace Castle.DynamicProxy.Generators
 					                               InvocationMethods.SetReturnValue,
 					                               new ConvertExpression(typeof(object), returnValue.Type, returnValue.ToExpression()));
 
-				invokeMethodOnTarget.CodeBuilder.AddStatement(new ExpressionStatement(setRetVal));
+				invokeMethodOnTarget.CodeBuilder.AddExpression(setRetVal);
 			}
 
 			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
@@ -195,17 +195,15 @@ namespace Castle.DynamicProxy.Generators
 			{
 				var index = byRefArgument.Key;
 				var localReference = byRefArgument.Value;
-				invokeMethodOnTarget.CodeBuilder.AddStatement(
-					new ExpressionStatement(
-						new MethodInvocationExpression(
-							SelfReference.Self,
-							InvocationMethods.SetArgumentValue,
-							new LiteralIntExpression(index),
-							new ConvertExpression(
-								typeof(object),
-								localReference.Type,
-								new ReferenceExpression(localReference)))
-						));
+				invokeMethodOnTarget.CodeBuilder.AddExpression(
+					new MethodInvocationExpression(
+						SelfReference.Self,
+						InvocationMethods.SetArgumentValue,
+						new LiteralIntExpression(index),
+						new ConvertExpression(
+							typeof(object),
+							localReference.Type,
+							new ReferenceExpression(localReference))));
 			}
 			invokeMethodOnTarget.CodeBuilder.AddStatement(new EndExceptionBlockStatement());
 		}
@@ -231,9 +229,9 @@ namespace Castle.DynamicProxy.Generators
 
 		private void EmitCallThrowOnNoTarget(MethodEmitter invokeMethodOnTarget)
 		{
-			var throwOnNoTarget = new ExpressionStatement(new MethodInvocationExpression(InvocationMethods.ThrowOnNoTarget));
+			var throwOnNoTarget = new MethodInvocationExpression(InvocationMethods.ThrowOnNoTarget);
 
-			invokeMethodOnTarget.CodeBuilder.AddStatement(throwOnNoTarget);
+			invokeMethodOnTarget.CodeBuilder.AddExpression(throwOnNoTarget);
 			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}
 
@@ -294,12 +292,11 @@ namespace Castle.DynamicProxy.Generators
 
 			var dynSetProxy = typeof(IProxyTargetAccessor).GetMethod(nameof(IProxyTargetAccessor.DynProxySetTarget));
 
-			changeProxyTarget.CodeBuilder.AddStatement(
-				new ExpressionStatement(
-					new MethodInvocationExpression(localProxy, dynSetProxy, changeProxyTarget.Arguments[0].ToExpression())
-					{
-						VirtualCall = true
-					}));
+			changeProxyTarget.CodeBuilder.AddExpression(
+				new MethodInvocationExpression(localProxy, dynSetProxy, changeProxyTarget.Arguments[0].ToExpression())
+				{
+					VirtualCall = true
+				});
 
 			changeProxyTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -128,13 +128,12 @@ namespace Castle.DynamicProxy.Generators
 				if (paramType.IsByRef)
 				{
 					var localReference = invokeMethodOnTarget.CodeBuilder.DeclareLocal(paramType.GetElementType());
-					invokeMethodOnTarget.CodeBuilder
-						.AddStatement(
-							new AssignStatement(localReference,
-							                    new ConvertExpression(paramType.GetElementType(),
-							                                          new MethodInvocationExpression(SelfReference.Self,
-							                                                                         InvocationMethods.GetArgumentValue,
-							                                                                         new LiteralIntExpression(i)))));
+					invokeMethodOnTarget.CodeBuilder.Add(
+						new AssignStatement(localReference,
+						                    new ConvertExpression(paramType.GetElementType(),
+						                                          new MethodInvocationExpression(SelfReference.Self,
+						                                                                         InvocationMethods.GetArgumentValue,
+						                                                                         new LiteralIntExpression(i)))));
 					var byRefReference = new ByRefReference(localReference);
 					args[i] = new ReferenceExpression(byRefReference);
 					byRefArguments[i] = localReference;
@@ -151,7 +150,7 @@ namespace Castle.DynamicProxy.Generators
 
 			if (byRefArguments.Count > 0)
 			{
-				invokeMethodOnTarget.CodeBuilder.AddStatement(new TryStatement());
+				invokeMethodOnTarget.CodeBuilder.Add(new TryStatement());
 			}
 
 			var methodOnTargetInvocationExpression = GetCallbackMethodInvocation(invocation, args, callbackMethod, targetField, invokeMethodOnTarget);
@@ -161,11 +160,11 @@ namespace Castle.DynamicProxy.Generators
 			{
 				var returnType = invocation.GetClosedParameterType(callbackMethod.ReturnType);
 				returnValue = invokeMethodOnTarget.CodeBuilder.DeclareLocal(returnType);
-				invokeMethodOnTarget.CodeBuilder.AddStatement(new AssignStatement(returnValue, methodOnTargetInvocationExpression));
+				invokeMethodOnTarget.CodeBuilder.Add(new AssignStatement(returnValue, methodOnTargetInvocationExpression));
 			}
 			else
 			{
-				invokeMethodOnTarget.CodeBuilder.AddExpression(methodOnTargetInvocationExpression);
+				invokeMethodOnTarget.CodeBuilder.Add(methodOnTargetInvocationExpression);
 			}
 
 			AssignBackByRefArguments(invokeMethodOnTarget, byRefArguments);
@@ -177,10 +176,10 @@ namespace Castle.DynamicProxy.Generators
 					                               InvocationMethods.SetReturnValue,
 					                               new ConvertExpression(typeof(object), returnValue.Type, returnValue.ToExpression()));
 
-				invokeMethodOnTarget.CodeBuilder.AddExpression(setRetVal);
+				invokeMethodOnTarget.CodeBuilder.Add(setRetVal);
 			}
 
-			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			invokeMethodOnTarget.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private void AssignBackByRefArguments(MethodEmitter invokeMethodOnTarget, Dictionary<int, LocalReference> byRefArguments)
@@ -190,12 +189,12 @@ namespace Castle.DynamicProxy.Generators
 				return;
 			}
 
-			invokeMethodOnTarget.CodeBuilder.AddStatement(new FinallyStatement());
+			invokeMethodOnTarget.CodeBuilder.Add(new FinallyStatement());
 			foreach (var byRefArgument in byRefArguments)
 			{
 				var index = byRefArgument.Key;
 				var localReference = byRefArgument.Value;
-				invokeMethodOnTarget.CodeBuilder.AddExpression(
+				invokeMethodOnTarget.CodeBuilder.Add(
 					new MethodInvocationExpression(
 						SelfReference.Self,
 						InvocationMethods.SetArgumentValue,
@@ -205,7 +204,7 @@ namespace Castle.DynamicProxy.Generators
 							localReference.Type,
 							new ReferenceExpression(localReference))));
 			}
-			invokeMethodOnTarget.CodeBuilder.AddStatement(new EndExceptionBlockStatement());
+			invokeMethodOnTarget.CodeBuilder.Add(new EndExceptionBlockStatement());
 		}
 
 		private void CreateConstructor(AbstractTypeEmitter invocation, ProxyGenerationOptions options)
@@ -215,7 +214,7 @@ namespace Castle.DynamicProxy.Generators
 
 			var constructor = CreateConstructor(invocation, baseCtorArguments);
 			constructor.CodeBuilder.InvokeBaseConstructor(baseConstructor, baseCtorArguments);
-			constructor.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			constructor.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private ConstructorEmitter CreateConstructor(AbstractTypeEmitter invocation, ArgumentReference[] baseCtorArguments)
@@ -231,8 +230,8 @@ namespace Castle.DynamicProxy.Generators
 		{
 			var throwOnNoTarget = new MethodInvocationExpression(InvocationMethods.ThrowOnNoTarget);
 
-			invokeMethodOnTarget.CodeBuilder.AddExpression(throwOnNoTarget);
-			invokeMethodOnTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			invokeMethodOnTarget.CodeBuilder.Add(throwOnNoTarget);
+			invokeMethodOnTarget.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private MethodInfo GetCallbackMethod(AbstractTypeEmitter invocation)
@@ -274,10 +273,10 @@ namespace Castle.DynamicProxy.Generators
 		private void ImplementChangeInvocationTarget(AbstractTypeEmitter invocation, FieldReference targetField)
 		{
 			var changeInvocationTarget = invocation.CreateMethod("ChangeInvocationTarget", typeof(void), new[] { typeof(object) });
-			changeInvocationTarget.CodeBuilder.AddStatement(
+			changeInvocationTarget.CodeBuilder.Add(
 				new AssignStatement(targetField,
 				                    new ConvertExpression(targetType, changeInvocationTarget.Arguments[0].ToExpression())));
-			changeInvocationTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			changeInvocationTarget.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private void ImplementChangeProxyTarget(AbstractTypeEmitter invocation, ClassEmitter @class)
@@ -286,19 +285,19 @@ namespace Castle.DynamicProxy.Generators
 
 			var proxyObject = new FieldReference(InvocationMethods.ProxyObject);
 			var localProxy = changeProxyTarget.CodeBuilder.DeclareLocal(typeof(IProxyTargetAccessor));
-			changeProxyTarget.CodeBuilder.AddStatement(
+			changeProxyTarget.CodeBuilder.Add(
 				new AssignStatement(localProxy,
 					new ConvertExpression(localProxy.Type, proxyObject.ToExpression())));
 
 			var dynSetProxy = typeof(IProxyTargetAccessor).GetMethod(nameof(IProxyTargetAccessor.DynProxySetTarget));
 
-			changeProxyTarget.CodeBuilder.AddExpression(
+			changeProxyTarget.CodeBuilder.Add(
 				new MethodInvocationExpression(localProxy, dynSetProxy, changeProxyTarget.Arguments[0].ToExpression())
 				{
 					VirtualCall = true
 				});
 
-			changeProxyTarget.CodeBuilder.AddStatement(ReturnStatement.Instance);
+			changeProxyTarget.CodeBuilder.Add(ReturnStatement.Instance);
 		}
 
 		private void ImplementChangeProxyTargetInterface(ClassEmitter @class, AbstractTypeEmitter invocation,

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -119,8 +119,8 @@ namespace Castle.DynamicProxy.Generators
 				emitter.CodeBuilder.AddStatement(new TryStatement());
 			}
 
-			var proceed = new ExpressionStatement(new MethodInvocationExpression(invocationLocal, InvocationMethods.Proceed));
-			emitter.CodeBuilder.AddStatement(proceed);
+			var proceed = new MethodInvocationExpression(invocationLocal, InvocationMethods.Proceed);
+			emitter.CodeBuilder.AddExpression(proceed);
 
 			if (hasByRefArguments)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -153,7 +153,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			else
 			{
-				emitter.CodeBuilder.AddStatement(new ReturnStatement());
+				emitter.CodeBuilder.AddStatement(ReturnStatement.Instance);
 			}
 
 			return emitter;


### PR DESCRIPTION
**More to come. Please don't merge yet.**

The few commits in this PR make the construction of ASTs (which represent the code in intercepted method bodies) more efficient by getting rid of unnecessary object instantiations.

Two AST node types, `ConstReference` and `ExpressionStatement`, are rendered superfluous and therefore marked as obsolete.

There's almost certainly potential for further optimizations, those covered here are probably just the easiest ones to find.

See commit messages for further details.