### PR TITLE
Add missing NuGet package `System.Runtime.InteropServices.RuntimeInformation` to test projects

### DIFF
--- a/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
+++ b/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
@@ -43,6 +43,7 @@
 		<PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -63,6 +63,7 @@
 		<PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />


### PR DESCRIPTION
The machinery behind the `[ExcludeOnFramework]` attribute (used on unit test methods) relies on the `System.Runtime.InteropServices.RuntimeInformation` type to perform framework detection. This type is actually unavailable on one of the test projects' target frameworks (`net461`). Interestingly, the `net461` build so far works fine despite this! (The type somehow gets pulled in from a `netstandard1.1` assembly, but I haven't been able to get this to work in a fresh `net461` project.)

I have also noticed in a fresh Mono setup that Mono does not always correctly report itself as being the current framework via `RuntimeInformation.FrameworkDescription` (which we use [here](https://github.com/castleproject/Core/blob/4f741f578746e5a0cbdd87da3e7d2774c877bfe1/src/Castle.Core.Tests/Framework.cs#L89)), which means tests will end up running that ought to be skipped on Mono, making the build fail.

Adding this NuGet package should fix both of these potential issues.

(As a small aside, I am adding the package to both unit test projects even though it might only be required in the main test project. This is to keep them in sync; `Castle.Core.Tests.WeakNamed.csproj` largely duplicates the contents of `Castle.Core.Tests.csproj`, which is largely unnecessary, but perhaps something to be improved on another day.)