### PR TITLE
NLogFactory - Removed explicit loading of nlog.config by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Deprecations:
 
 Enhancements:
  - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
- - NLogFactory will no longer load NLog.config by default, since NLog does it automatically (@snakefoot, #419)
+ - NLogFactory and ExtendedNLogFactory default constructor will no longer load NLog.config, since NLog does it automatically (@snakefoot, #419)
 
 ## 4.3.1 (2018-06-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Deprecations:
 
 Enhancements:
  - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
+ - NLogFactory will no longer load NLog.config by default, since NLog does it automatically (@snakefoot, #419)
 
 ## 4.3.1 (2018-06-21)
 

--- a/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogFactory.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogFactory.cs
@@ -28,17 +28,14 @@ namespace Castle.Services.Logging.NLogIntegration
 	{
 		/// <summary>
 		///   Initializes a new instance of the <see cref="ExtendedNLogFactory" /> class.
-		///   Configures NLog with a config file name 'nlog.config' 
-		///   <seealso cref="Create(string)" />
 		/// </summary>
 		public ExtendedNLogFactory()
-			: this(NLogFactory.defaultConfigFileName)
+			: this(true)
 		{
 		}
 
 		/// <summary>
-		///   Initializes a new instance of the <see cref="ExtendedNLogFactory" /> class with the configfile specified by <paramref
-		///    name="configFile" />
+		///   Initializes a new instance of the <see cref="ExtendedNLogFactory" /> class.
 		/// </summary>
 		/// <param name="configFile"> The config file. </param>
 		public ExtendedNLogFactory(string configFile)
@@ -50,7 +47,7 @@ namespace Castle.Services.Logging.NLogIntegration
 		/// <summary>
 		///   Initializes a new instance of the <see cref="ExtendedNLogFactory" /> class.
 		/// </summary>
-		/// <param name="configuredExternally"> If <c>true</c> . Skips the initialization of log4net assuming it will happen externally. Useful if you're using another framework that wants to take over configuration of NLog. </param>
+		/// <param name="configuredExternally">If <c>true</c>. Skips the initialization of NLog assuming it will happen externally (or automatically by NLog).</param>
 		public ExtendedNLogFactory(bool configuredExternally)
 		{
 			if (configuredExternally)

--- a/src/Castle.Services.Logging.NLogIntegration/NLogFactory.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/NLogFactory.cs
@@ -32,14 +32,14 @@ namespace Castle.Services.Logging.NLogIntegration
 		///   Initializes a new instance of the <see cref="NLogFactory" /> class.
 		/// </summary>
 		public NLogFactory()
-			: this(defaultConfigFileName)
+			: this(true)
 		{
 		}
 
 		/// <summary>
 		///   Initializes a new instance of the <see cref="NLogFactory" /> class.
 		/// </summary>
-		/// <param name="configuredExternally">If <c>true</c>. Skips the initialization of log4net assuming it will happen externally. Useful if you're using another framework that wants to take over configuration of NLog.</param>
+		/// <param name="configuredExternally">If <c>true</c>. Skips the initialization of NLog assuming it will happen externally (or automatically by NLog).</param>
 		public NLogFactory(bool configuredExternally)
 		{
 			if (configuredExternally)


### PR DESCRIPTION
Since NLog will automatically load its configuration. Resolves #418 

See also: https://github.com/nlog/NLog/wiki/Configuration-file#configuration-file-locations