### PR TITLE
Expose overloads of GetAdapter with NameValueCollection parameter

### DIFF
--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterFactory.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterFactory.cs
@@ -17,10 +17,7 @@ namespace Castle.Components.DictionaryAdapter
 {
 	using System;
 	using System.Collections;
-#if FEATURE_DICTIONARYADAPTER_XML
 	using System.Collections.Specialized;
-	using System.Xml.XPath;
-#endif
 
 	/// <summary>
 	/// Defines the contract for building typed dictionary adapters.
@@ -61,7 +58,6 @@ namespace Castle.Components.DictionaryAdapter
 		/// </remarks>
 		object GetAdapter(Type type, IDictionary dictionary, PropertyDescriptor descriptor);
 
-#if FEATURE_DICTIONARYADAPTER_XML
 		/// <summary>
 		/// Gets a typed adapter bound to the <see cref="NameValueCollection"/>.
 		/// </summary>
@@ -84,6 +80,7 @@ namespace Castle.Components.DictionaryAdapter
 		/// </remarks>
 		object GetAdapter(Type type, NameValueCollection nameValues);
 
+#if FEATURE_DICTIONARYADAPTER_XML
 		/// <summary>
 		/// Gets a typed adapter bound to the <see cref="System.Xml.XmlNode"/>.
 		/// </summary>


### PR DESCRIPTION
Since the DictionaryAdapterFactory doesn't shield implementation behind FEATURE_DICTIONARYADAPTER_XML, it's now exposed on the interface too.

Fixes #422