### PR TITLE
Fix async problem calling await before Proceed - Breaking Change

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Linq;
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy.Tests.Classes;
+	using Castle.DynamicProxy.Tests.Interfaces;
+	using Castle.DynamicProxy.Tests.Interceptors;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AsyncInterceptorTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public async Task Should_Intercept_Asynchronous_Methods_With_An_Async_Operations_Prior_To_Calling_Proceed()
+		{
+			// Arrange
+			IInterfaceWithAsynchronousMethod target = new ClassWithAsynchronousMethod();
+			IInterceptor interceptor = new AsyncInterceptor();
+
+			IInterfaceWithAsynchronousMethod proxy =
+				generator.CreateInterfaceProxyWithTargetInterface(target, interceptor);
+
+			// Act
+			await proxy.Method().ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -448,7 +448,7 @@ namespace Castle.DynamicProxy.Tests
 
 		public class ResultModifierInterceptor : StandardInterceptor
 		{
-			protected override void PostProceed(IInvocation invocation)
+			protected override void PostProceed(IInvocation invocation, InvocationDelegate proceed)
 			{
 				object returnValue = invocation.ReturnValue;
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetInterceptor.cs
@@ -25,12 +25,12 @@ namespace Castle.DynamicProxy.Tests
 			this.target = target;
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			var targetAccessor = invocation.Proxy as IProxyTargetAccessor;
 			Assert.IsNotNull(targetAccessor);
 			targetAccessor.DynProxySetTarget(target);
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetTestCase.cs
@@ -28,7 +28,7 @@ namespace Castle.DynamicProxy.Tests
 
 		private Lazy<T> LazyTarget { get; }
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			var target = invocation.InvocationTarget as T;
 			if (target == null)
@@ -37,7 +37,7 @@ namespace Castle.DynamicProxy.Tests
 				((IProxyTargetAccessor)invocation.Proxy).DynProxySetTarget(LazyTarget.Value);
 			}
 
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 
@@ -51,7 +51,7 @@ namespace Castle.DynamicProxy.Tests
 
 		private Lazy<T> LazyTarget { get; }
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			var target = invocation.InvocationTarget as T;
 			if (target == null)
@@ -62,7 +62,7 @@ namespace Castle.DynamicProxy.Tests
 #pragma warning restore CS0618 // obsolete
 			}
 
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy.Tests.Interfaces;
+
+	public class ClassWithAsynchronousMethod : IInterfaceWithAsynchronousMethod
+	{
+		public async Task Method()
+		{
+			Console.WriteLine(
+				$"Before Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+
+			await Task.Delay(10).ConfigureAwait(false);
+
+			Console.WriteLine(
+				$"After Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTargetTypeTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTargetTypeTestCase.cs
@@ -173,7 +173,7 @@ namespace Castle.DynamicProxy.Tests
 		{
 			public Type ReceivedTargetType { get; private set; }
 
-			public void Intercept(IInvocation invocation)
+			public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 			{
 				ReceivedTargetType = invocation.TargetType;
 			}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AddTwoInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AddTwoInterceptor.cs
@@ -23,9 +23,9 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 	{
 		#region IInterceptor Members
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
-			invocation.Proceed();
+			proceed(invocation);
 			var ret = (int) invocation.ReturnValue;
 			ret += 2;
 			invocation.ReturnValue = ret;

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCanChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCanChangeTargetInterceptor.cs
@@ -20,10 +20,10 @@ namespace Castle.DynamicProxy.Tests.Interceptors
     {
         #region IInterceptor Members
 
-        public void Intercept(IInvocation invocation)
+        public void Intercept(IInvocation invocation, InvocationDelegate proceed)
         {
             Assert.IsInstanceOf(typeof (IChangeProxyTarget), invocation);
-            invocation.Proceed();
+            proceed(invocation);
         }
 
         #endregion

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCannotChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCannotChangeTargetInterceptor.cs
@@ -18,10 +18,10 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 
 	public class AssertCannotChangeTargetInterceptor : IInterceptor
 	{
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			Assert.IsNotInstanceOf<IChangeProxyTarget>(invocation);
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AsyncInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AsyncInterceptor.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interceptors
+{
+	using System.Threading.Tasks;
+
+	public class AsyncInterceptor : IInterceptor
+	{
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
+		{
+			invocation.ReturnValue = InterceptAsyncMethod(invocation, proceed);
+		}
+
+		private static async Task InterceptAsyncMethod(IInvocation invocation, InvocationDelegate proceed)
+		{
+			// It all falls down when executing async before calling Proceed().
+			await Task.Delay(10).ConfigureAwait(false);
+
+			proceed(invocation);
+
+			// Hmmmmm, now with it simplified down to this, I see the glaring hole that is the return value being set
+			// in two situations.
+			Task returnValue = (Task)invocation.ReturnValue;
+
+			await returnValue.ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/CallCountingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/CallCountingInterceptor.cs
@@ -30,10 +30,10 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 
 		#region IInterceptor Members
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			count++;
-			invocation.Proceed();
+			proceed(invocation);
 		}
 
 		#endregion

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ChangeTargetInterceptor.cs
@@ -23,11 +23,11 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			this.target = target;
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			IChangeProxyTarget changeTarget = (IChangeProxyTarget) invocation;
 			changeTarget.ChangeInvocationTarget(target);
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/DoNothingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/DoNothingInterceptor.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 {
 	public class DoNothingInterceptor : IInterceptor
     {
-        public void Intercept(IInvocation invocation)
+        public void Intercept(IInvocation invocation, InvocationDelegate proceed)
         {
         }
     }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/IInterfaceWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/IInterfaceWithAsynchronousMethod.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	using System.Threading.Tasks;
+
+	public interface IInterfaceWithAsynchronousMethod
+	{
+		Task Method();
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/KeepDataInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/KeepDataInterceptor.cs
@@ -26,14 +26,14 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			get { return invocation; }
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			this.invocation = invocation;
 			var concreteMethod = invocation.GetConcreteMethod();
 
 			if (invocation.MethodInvocationTarget != null)
 			{
-				invocation.Proceed();
+				proceed(invocation);
 			}
 			else if (concreteMethod.ReturnType.GetTypeInfo().IsValueType && !concreteMethod.ReturnType.Equals(typeof(void)))
 				// ensure valid return value

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/LogInvocationInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/LogInvocationInterceptor.cs
@@ -27,18 +27,18 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 
 		public bool Proceed = true;
 
-		protected override void PreProceed(IInvocation invocation)
+		protected override void PreProceed(IInvocation invocation, InvocationDelegate proceed)
 		{
 			invocations.Add(invocation.Method.Name);
 
 			sb.Append(String.Format("{0} ", invocation.Method.Name));
 		}
 
-		protected override void PerformProceed (IInvocation invocation)
+		protected override void PerformProceed (IInvocation invocation, InvocationDelegate proceed)
 		{
 			if (Proceed)
 			{
-				base.PerformProceed (invocation);
+				base.PerformProceed (invocation, proceed);
 			}
 			else if (invocation.Method.ReturnType.GetTypeInfo().IsValueType && invocation.Method.ReturnType != typeof (void))
 			{

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedNTimesInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedNTimesInterceptor.cs
@@ -23,13 +23,13 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			this.retries = retries;
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			for (var i = 0; i < retries; i++)
 			{
 				try
 				{
-					invocation.Proceed();
+					proceed(invocation);
 				}
 				catch
 				{

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedOnTypeInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedOnTypeInterceptor.cs
@@ -27,12 +27,12 @@ namespace Castle.DynamicProxy.Tests.Interceptors
             this.type = type;
         }
 
-        public void Intercept(IInvocation invocation)
+        public void Intercept(IInvocation invocation, InvocationDelegate proceed)
         {
             type = typeof(IBarFoo);
             if (invocation.Method.DeclaringType != type)
             {
-                invocation.Proceed();
+                proceed(invocation);
             }
         }
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/RequiredParamInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/RequiredParamInterceptor.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 
 	public class RequiredParamInterceptor : IInterceptor
 	{
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			ParameterInfo[] parameters = invocation.Method.GetParameters();
 
@@ -42,7 +42,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 				}
 			}
 
-			invocation.Proceed();
+			proceed(invocation);
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetArgumentValueInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetArgumentValueInterceptor.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			this.value = value;
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			invocation.SetArgumentValue(index, value);
 		}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetReturnValueInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetReturnValueInterceptor.cs
@@ -24,7 +24,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
         }
 
 
-        public void Intercept(IInvocation invocation)
+        public void Intercept(IInvocation invocation, InvocationDelegate proceed)
         {
             invocation.ReturnValue = value;
         }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptor.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 {
 	public class ThrowingInterceptor : IInterceptor
 	{
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			throw new ThrowingInterceptorException("Because I feel like it");
 		}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/WithCallbackInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/WithCallbackInterceptor.cs
@@ -23,11 +23,11 @@ namespace Castle.DynamicProxy.Tests.Interceptors
 			callback = interceptorCallback;
 		}
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
-			callback(invocation);
+			callback(invocation, proceed);
 		}
 
-		public delegate void InterceptorCallback(IInvocation invocation);
+		public delegate void InterceptorCallback(IInvocation invocation, InvocationDelegate proceed);
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorsMustReturnNonNullValueTypesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorsMustReturnNonNullValueTypesTestCase.cs
@@ -92,11 +92,11 @@ namespace Castle.DynamicProxy.Tests
 
 		public class SwallowExceptionInterceptor : IInterceptor
 		{
-			public void Intercept(IInvocation invocation)
+			public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 			{
 				try
 				{
-					invocation.Proceed();
+					proceed(invocation);
 				}
 				catch (Exception)
 				{
@@ -107,9 +107,9 @@ namespace Castle.DynamicProxy.Tests
 
 		public class ReturnNullValueInterceptor : IInterceptor
 		{
-			public void Intercept(IInvocation invocation)
+			public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 			{
-				invocation.Proceed(); // If this throws, ReturnValue will remain null
+				proceed(invocation); // If this throws, ReturnValue will remain null
 				invocation.ReturnValue = null;
 			}
 		}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationMethodInvocationTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationMethodInvocationTargetTestCase.cs
@@ -101,16 +101,16 @@ namespace Castle.DynamicProxy.Tests
 			var proxy = generator.CreateInterfaceProxyWithTargetInterface(
 			            	typeof(IService),
 			            	target1,
-			            	new WithCallbackInterceptor(i =>
+			            	new WithCallbackInterceptor((i, p) =>
 			            	{
 			            		invocationTarget1 = i.MethodInvocationTarget;
-			            		i.Proceed();
+			            		p(i);
 			            	}),
 			            	new ChangeTargetInterceptor(target2),
-			            	new WithCallbackInterceptor(i =>
+			            	new WithCallbackInterceptor((i, p) =>
 			            	{
 			            		invocationTarget2 = i.MethodInvocationTarget;
-			            		i.Proceed();
+			            		p(i);
 			            	})) as IService;
 
 			proxy.Sum(2, 2);

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
@@ -32,12 +32,12 @@ namespace Castle.DynamicProxy.Tests
 			public object proxy;
 			public object mixin;
 
-			protected override void PreProceed(IInvocation invocation)
+			protected override void PreProceed(IInvocation invocation, InvocationDelegate proceed)
 			{
 				Invoked = true;
 				mixin = invocation.InvocationTarget;
 				proxy = invocation.Proxy;
-				base.PreProceed(invocation);
+				base.PreProceed(invocation, proceed);
 			}
 		}
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/OrderOfInterfacePrecedenceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/OrderOfInterfacePrecedenceTestCase.cs
@@ -39,7 +39,7 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void Same_Interface_on_proxy_withouth_target_and_mixin_should_forward_to_null_target()
 		{
-			var interceptor = new WithCallbackInterceptor(i =>
+			var interceptor = new WithCallbackInterceptor((i, p) =>
 			                                              	{
 			                                              		Assert.IsNull(i.InvocationTarget);
 			                                              		i.ReturnValue = 0;
@@ -63,7 +63,7 @@ namespace Castle.DynamicProxy.Tests
 		{
 			var target = new ServiceImpl();
 			var mixin = new ServiceImpl();
-			IInterceptor interceptor = new WithCallbackInterceptor(i=>
+			IInterceptor interceptor = new WithCallbackInterceptor((i, p)=>
 			                                                       	{
 			                                                       		Assert.AreSame(target,i.InvocationTarget);
 			                                                       		i.ReturnValue = 0;

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/OutRefParamsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/OutRefParamsTestCase.cs
@@ -52,11 +52,11 @@ namespace Castle.DynamicProxy.Tests
 		{
 			public Exception Exception { get; set; }
 
-			protected override void PerformProceed(IInvocation invocation)
+			protected override void PerformProceed(IInvocation invocation, InvocationDelegate proceed)
 			{
 				try
 				{
-					base.PerformProceed(invocation);
+					base.PerformProceed(invocation, proceed);
 				}
 				catch (Exception e)
 				{
@@ -97,7 +97,7 @@ namespace Castle.DynamicProxy.Tests
 		{
 			int i;
 			var interceptor =
-				new WithCallbackInterceptor(delegate(IInvocation invocation) { invocation.Arguments[0] = 5; });
+				new WithCallbackInterceptor(delegate(IInvocation invocation, InvocationDelegate proceed) { invocation.Arguments[0] = 5; });
 			var proxy = (IWithRefOut)generator.CreateInterfaceProxyWithoutTarget(typeof(IWithRefOut), interceptor);
 			proxy.Do(out i);
 			Assert.AreEqual(5, i);
@@ -118,7 +118,7 @@ namespace Castle.DynamicProxy.Tests
 			var i = 3;
 			var s1 = "2";
 			string s2;
-			var interceptor = new WithCallbackInterceptor(delegate(IInvocation invocation)
+			var interceptor = new WithCallbackInterceptor(delegate(IInvocation invocation, InvocationDelegate proceed)
 			{
 				invocation.Arguments[0] = 5;
 				invocation.Arguments[1] = "aaa";
@@ -144,7 +144,7 @@ namespace Castle.DynamicProxy.Tests
 		{
 			var i = 3;
 			var interceptor =
-				new WithCallbackInterceptor(delegate(IInvocation invocation) { invocation.Arguments[0] = 5; });
+				new WithCallbackInterceptor(delegate(IInvocation invocation, InvocationDelegate proceed) { invocation.Arguments[0] = 5; });
 			var proxy = (IWithRefOut)generator.CreateInterfaceProxyWithoutTarget(typeof(IWithRefOut), interceptor);
 			proxy.Did(ref i);
 			Assert.AreEqual(5, i);

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
@@ -37,7 +37,7 @@ namespace Castle.DynamicProxy.Tests
 		{
 			#region IInterceptor Members
 
-			public void Intercept(IInvocation invocation)
+			public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 			{
 				invocation.Arguments[0] = IntPtr.Zero;
 				invocation.ReturnValue = 5;
@@ -392,7 +392,7 @@ namespace Castle.DynamicProxy.Tests
 
 		#region IInterceptor Members
 
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
 			invocation.Arguments[0] = x;
 		}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
@@ -53,7 +53,7 @@ namespace Castle.DynamicProxy.Tests
 
 			object receivedArg = null;
 			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IWithInModifier>(
-				new WithCallbackInterceptor(invocation =>
+				new WithCallbackInterceptor((invocation, proceed) =>
 				{
 					receivedArg = invocation.Arguments[0];
 				}));

--- a/src/Castle.Core/DynamicProxy/IInterceptor.cs
+++ b/src/Castle.Core/DynamicProxy/IInterceptor.cs
@@ -19,6 +19,8 @@ namespace Castle.DynamicProxy
 	/// </summary>
 	public interface IInterceptor
 	{
-		void Intercept(IInvocation invocation);
+		/// <param name="invocation">Invocation information.</param>
+		/// <param name="proceed">Proceeds the call to the next interceptor in line, and ultimately to the target method.</param>
+		void Intercept(IInvocation invocation, InvocationDelegate proceed);
 	}
 }

--- a/src/Castle.Core/DynamicProxy/IInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocation.cs
@@ -105,16 +105,6 @@ namespace Castle.DynamicProxy
 		MethodInfo GetConcreteMethodInvocationTarget();
 
 		/// <summary>
-		///   Proceeds the call to the next interceptor in line, and ultimately to the target method.
-		/// </summary>
-		/// <remarks>
-		///   Since interface proxies without a target don't have the target implementation to proceed to,
-		///   it is important, that the last interceptor does not call this method, otherwise a
-		///   <see cref = "NotImplementedException" /> will be thrown.
-		/// </remarks>
-		void Proceed();
-
-		/// <summary>
 		///   Overrides the value of an argument at the given <paramref name = "index" /> with the
 		///   new <paramref name = "value" /> provided.
 		/// </summary>

--- a/src/Castle.Core/DynamicProxy/InvocationDelegate.cs
+++ b/src/Castle.Core/DynamicProxy/InvocationDelegate.cs
@@ -1,0 +1,4 @@
+﻿namespace Castle.DynamicProxy
+{
+	public delegate void InvocationDelegate(IInvocation invocation);
+}

--- a/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
+++ b/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
@@ -25,23 +25,23 @@ namespace Castle.DynamicProxy
 #endif
 		IInterceptor
 	{
-		public void Intercept(IInvocation invocation)
+		public void Intercept(IInvocation invocation, InvocationDelegate proceed)
 		{
-			PreProceed(invocation);
-			PerformProceed(invocation);
-			PostProceed(invocation);
+			PreProceed(invocation, proceed);
+			PerformProceed(invocation, proceed);
+			PostProceed(invocation, proceed);
 		}
 
-		protected virtual void PerformProceed(IInvocation invocation)
+		protected virtual void PerformProceed(IInvocation invocation, InvocationDelegate proceed)
 		{
-			invocation.Proceed();
+			proceed(invocation);
 		}
 
-		protected virtual void PreProceed(IInvocation invocation)
+		protected virtual void PreProceed(IInvocation invocation, InvocationDelegate proceed)
 		{
 		}
 
-		protected virtual void PostProceed(IInvocation invocation)
+		protected virtual void PostProceed(IInvocation invocation, InvocationDelegate proceed)
 		{
 		}
 	}


### PR DESCRIPTION
This PR solved the async problem discussed in #145

Breaking Change:
`void IInvocation.Proceed()` is moved to `void IInterceptor.Intercept(IInvocation invocation, InvocationDelegate proceed);`

Before:
 ```csharp
public class Interceptor : IInterceptor
{
    public void Intercept(IInvocation invocation)
    {
        invocation.Proceed();
    }
}
```

Becomes:
 ```csharp
public class Interceptor : IInterceptor
{
    public void Intercept(IInvocation invocation, InvocationDelegate proceed)
    {
        proceed(invocation);
    }
}
```
