### PR TITLE
Add ability to mix in delegate (types) to proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Enhancements:
 - Added trace logging level below Debug; maps to Trace in log4net/NLog, and Verbose in Serilog (@pi3k14, #404)
 - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
 - DictionaryAdapter: Exposed GetAdapter overloads with NameValueCollection parameter in .NET Standard (@rzontar, #423)
+- Ability to add delegate mixins to proxies using `ProxyGenerationOptions.AddDelegate[Type]Mixin`. You can bind to the mixed-in `Invoke` methods on the proxy using `ProxyUtil.TryCreateDelegateToMixin`. (@stakx, #436)
 - New `IInvocation.CaptureProceedInfo()` method to enable better implementations of asynchronous interceptors (@stakx, #439)
 
 Deprecations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Enhancements:
 - Added trace logging level below Debug; maps to Trace in log4net/NLog, and Verbose in Serilog (@pi3k14, #404)
 - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
 - DictionaryAdapter: Exposed GetAdapter overloads with NameValueCollection parameter in .NET Standard (@rzontar, #423)
-- Ability to add delegate mixins to proxies using `ProxyGenerationOptions.AddDelegate[Type]Mixin`. You can bind to the mixed-in `Invoke` methods on the proxy using `ProxyUtil.TryCreateDelegateToMixin`. (@stakx, #436)
+- Ability to add delegate mixins to proxies using `ProxyGenerationOptions.AddDelegate[Type]Mixin`. You can bind to the mixed-in `Invoke` methods on the proxy using `ProxyUtil.CreateDelegateToMixin`. (@stakx, #436)
 - New `IInvocation.CaptureProceedInfo()` method to enable better implementations of asynchronous interceptors (@stakx, #439)
 
 Deprecations:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
@@ -1,0 +1,300 @@
+// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Reflection;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class DelegateMixinTestCase  : BasePEVerifyTestCase
+	{
+		[Test]
+		public void ProxyGenerationOptions_AddDelegateTypeMixin_when_given_null_throws_ArgumentNullException()
+		{
+			var options = new ProxyGenerationOptions();
+			Assert.Throws<ArgumentNullException>(() => options.AddDelegateTypeMixin(null));
+		}
+
+		[Test]
+		public void ProxyGenerationOptions_AddDelegateTypeMixin_when_given_non_delegate_type_throws_ArgumentException()
+		{
+			var options = new ProxyGenerationOptions();
+			Assert.Throws<ArgumentException>(() => options.AddDelegateTypeMixin(typeof(Exception)));
+		}
+
+		[Test]
+		public void ProxyGenerationOptions_AddDelegateTypeMixin_when_given_delegate_type_succeeds()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+		}
+
+		[Test]
+		public void ProxyGenerationOptions_AddDelegateMixin_when_given_null_throws_ArgumentNullException()
+		{
+			var options = new ProxyGenerationOptions();
+			Assert.Throws<ArgumentNullException>(() => options.AddDelegateMixin(null));
+		}
+
+		[Test]
+		public void ProxyGenerationOptions_AddDelegateMixin_when_given_delegate_succeeds()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateMixin(new Action(() => { }));
+		}
+
+
+		[Test]
+		public void ProxyGenerator_CreateClassProxy_can_create_delegate_proxy_without_target()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+			var _ = new Interceptor();
+			var proxy = generator.CreateClassProxy(typeof(object), options, _);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithoutTarget_can_create_delegate_proxy_without_target()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+			var _ = new Interceptor();
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, _);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithTarget_can_create_delegate_proxy_without_target()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+			var _ = new Interceptor();
+			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, _);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateClassProxy_can_create_callable_delegate_proxy_without_target()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor();
+
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithoutTarget_can_create_callable_delegate_proxy_without_target()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor();
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithTarget_can_create_callable_delegate_proxy_without_target()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor();
+
+			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateClassProxy_cannot_proceed_to_delegate_type_mixin()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			Assert.Throws<NotImplementedException>(() => action.Invoke());
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithoutTarget_cannot_proceed_to_delegate_type_mixin()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			Assert.Throws<NotImplementedException>(() => action.Invoke());
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithTarget_cannot_proceed_to_delegate_type_mixin()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			Assert.Throws<NotImplementedException>(() => action.Invoke());
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateClassProxy_can_proceed_to_delegate_mixin()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateMixin(new Action(target.Method));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.True(target.MethodInvoked);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithoutTarget_can_proceed_to_delegate_mixin()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateMixin(new Action(target.Method));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.True(target.MethodInvoked);
+		}
+
+		[Test]
+		public void ProxyGenerator_CreateInterfaceProxyWithTarget_can_proceed_to_delegate_mixin()
+		{
+			var target = new Target();
+
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateMixin(new Action(target.Method));
+
+			var interceptor = new Interceptor(shouldProceed: true);
+
+			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+
+			action.Invoke();
+			Assert.True(target.MethodInvoked);
+		}
+
+		[Test]
+		public void Can_mixin_several_different_delegate_types_simultaneously()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Action));
+			options.AddDelegateTypeMixin(typeof(Action<int>));
+
+			var interceptor = new Interceptor();
+
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			action.Invoke();
+
+			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action<int> intAction));
+			intAction.Invoke(42);
+		}
+
+		[Test]
+		public void Cannot_mixin_several_delegate_types_with_same_signature()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddDelegateTypeMixin(typeof(Func<Exception, bool>));
+			options.AddDelegateTypeMixin(typeof(Predicate<Exception>));
+			Assert.Throws<InvalidMixinConfigurationException>(() => options.Initialize());
+
+		}
+
+		[Serializable]
+		public sealed class Target : IComparable
+		{
+			public bool CompareToInvoked { get; set; }
+
+			public bool MethodInvoked { get; set; }
+
+			public int CompareTo(object obj)
+			{
+				CompareToInvoked = true;
+				return 123;
+			}
+
+			public void Method()
+			{
+				MethodInvoked = true;
+			}
+		}
+
+		private sealed class Interceptor : IInterceptor
+		{
+			private readonly bool shouldProceed;
+
+			public Interceptor(bool shouldProceed = false)
+			{
+				this.shouldProceed = shouldProceed;
+			}
+
+			public IInvocation LastInvocation { get; set; }
+
+			public void Intercept(IInvocation invocation)
+			{
+				LastInvocation = invocation;
+				if (shouldProceed)
+				{
+					invocation.Proceed();
+				}
+			}
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
@@ -96,7 +96,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor();
 
 			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
@@ -111,7 +112,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor();
 
 			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
@@ -128,7 +130,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor();
 
 			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.AreSame(typeof(Action).GetTypeInfo().GetMethod("Invoke"), interceptor.LastInvocation.Method);
@@ -143,7 +146,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			Assert.Throws<NotImplementedException>(() => action.Invoke());
 		}
@@ -157,7 +161,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			Assert.Throws<NotImplementedException>(() => action.Invoke());
 		}
@@ -173,7 +178,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			Assert.Throws<NotImplementedException>(() => action.Invoke());
 		}
@@ -189,7 +195,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.True(target.MethodInvoked);
@@ -206,7 +213,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IComparable), options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.True(target.MethodInvoked);
@@ -223,7 +231,8 @@ namespace Castle.DynamicProxy.Tests
 			var interceptor = new Interceptor(shouldProceed: true);
 
 			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IComparable), target, options, interceptor);
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 
 			action.Invoke();
 			Assert.True(target.MethodInvoked);
@@ -240,10 +249,12 @@ namespace Castle.DynamicProxy.Tests
 
 			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
 
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
+			Assert.NotNull(action);
 			action.Invoke();
 
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action<int> intAction));
+			var intAction = ProxyUtil.CreateDelegateToMixin<Action<int>>(proxy);
+			Assert.NotNull(action);
 			intAction.Invoke(42);
 		}
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
@@ -239,5 +239,51 @@ namespace Castle.DynamicProxy.Tests
 			MixinData mixinData2 = new MixinData(new object[] { typeof(Predicate<object>) });
 			Assert.AreNotEqual(mixinData1, mixinData2);
 		}
+
+		[Test]
+		public void Ctor_succeeds_when_mixing_regular_mixin_instances_with_delegate_mixins()
+		{
+			var mixinData = new MixinData(new object[]
+			{
+				new NotADelegate(),
+				new Action(() => { }),
+			});
+		}
+
+		[Test]
+		public void Ctor_succeeds_when_mixing_regular_mixin_instances_with_delegate_type_mixins()
+		{
+			var mixinData = new MixinData(new object[]
+			{
+				new NotADelegate(),
+				typeof(Action),
+			});
+		}
+
+		[Test]
+		public void Ctor_throws_when_multiple_delegate_mixins_for_same_Invoke_signature()
+		{
+			Assert.Throws<ArgumentException>(() => new MixinData(new object[]
+			{
+				new NotADelegate(),
+				new Func<object, bool>(_ => true),
+				new Predicate<object>(_ => false),
+			}));
+		}
+
+		[Test]
+		public void Ctor_throws_when_multiple_delegate_type_mixins_for_same_Invoke_signature()
+		{
+			Assert.Throws<ArgumentException>(() => new MixinData(new object[]
+			{
+				typeof(Func<object, bool>),
+				new NotADelegate(),
+				typeof(Predicate<object>)
+			}));
+		}
+
+		public class NotADelegate : INotADelegate { }
+
+		public interface INotADelegate { }
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
@@ -193,5 +193,51 @@ namespace Castle.DynamicProxy.Tests
 				new MixinData(new object[] { mixin1, mixin2 })
 			);
 		}
+
+		[Test]
+		public void Equals_false_for_two_instances_having_different_delegate_type_mixins()
+		{
+			MixinData mixinData1 = new MixinData(new object[] { typeof(Action) });
+			MixinData mixinData2 = new MixinData(new object[] { typeof(Action<int>) });
+			Assert.AreNotEqual(mixinData1, mixinData2);
+		}
+
+		[Test]
+		public void Equals_true_for_two_instances_having_same_delegate_type_mixins()
+		{
+			MixinData mixinData1 = new MixinData(new object[] { typeof(Action) });
+			MixinData mixinData2 = new MixinData(new object[] { typeof(Action) });
+			Assert.AreEqual(mixinData1, mixinData2);
+		}
+
+		[Test]
+		public void GetHashCode_equal_for_two_instances_having_same_delegate_type_mixins()
+		{
+			MixinData mixinData1 = new MixinData(new object[] { typeof(Action) });
+			MixinData mixinData2 = new MixinData(new object[] { typeof(Action) });
+			Assert.AreEqual(mixinData1.GetHashCode(), mixinData2.GetHashCode());
+		}
+
+		// This test appears to be incorrect. However, remember that GetHashCode is allowed to
+		// sacrifice accuracy for speed. It's not a full replacement for the more expensive
+		// Equals check; the only requirement is that equal object have equal hashcodes.
+		[Test]
+		public void GetHashCode_equal_for_two_instances_having_different_delegate_type_mixins()
+		{
+			MixinData mixinData1 = new MixinData(new object[] { typeof(Action) });
+			MixinData mixinData2 = new MixinData(new object[] { typeof(Action<int>) });
+			Assert.AreEqual(mixinData1.GetHashCode(), mixinData2.GetHashCode());
+		}
+
+		// This is a current limitation that means DynamicProxy will might not recognize
+		// suitable cached proxy types for such compatible delegate scenarios, and regenerate
+		// an identical type. This might not even matter that much in practice.
+		[Test]
+		public void Equals_false_for_two_instances_having_compatible_delegate_type_mixins()
+		{
+			MixinData mixinData1 = new MixinData(new object[] { typeof(Func<object, bool>) });
+			MixinData mixinData2 = new MixinData(new object[] { typeof(Predicate<object>) });
+			Assert.AreNotEqual(mixinData1, mixinData2);
+		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
@@ -25,58 +25,58 @@ namespace Castle.DynamicProxy.Tests
 	public class ProxyUtilTestCase
 	{
 		[Test]
-		public void TryCreateDelegateToMixin_when_given_null_for_proxy_throws_ArgumentNullException()
+		public void CreateDelegateToMixin_when_given_null_for_proxy_throws_ArgumentNullException()
 		{
 			var _ = typeof(Action);
-			Assert.Throws<ArgumentNullException>(() => ProxyUtil.TryCreateDelegateToMixin(null, _, out var __));
+			Assert.Throws<ArgumentNullException>(() => ProxyUtil.CreateDelegateToMixin(null, _));
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_when_given_null_for_delegateType_throws_ArgumentNullException()
+		public void CreateDelegateToMixin_when_given_null_for_delegateType_throws_ArgumentNullException()
 		{
 			var _ = new object();
-			Assert.Throws<ArgumentNullException>(() => ProxyUtil.TryCreateDelegateToMixin(_, null, out var __));
+			Assert.Throws<ArgumentNullException>(() => ProxyUtil.CreateDelegateToMixin(_, null));
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_when_given_non_delegate_type_throws_ArgumentException()
+		public void CreateDelegateToMixin_when_given_non_delegate_type_throws_ArgumentException()
 		{
 			var _ = new object();
-			Assert.Throws<ArgumentException>(() => ProxyUtil.TryCreateDelegateToMixin(_, typeof(Exception), out var __));
+			Assert.Throws<ArgumentException>(() => ProxyUtil.CreateDelegateToMixin(_, typeof(Exception)));
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_when_given_valid_arguments_succeeds()
+		public void CreateDelegateToMixin_when_given_valid_arguments_succeeds()
 		{
 			var proxy = new FakeProxyWithInvokeMethods();
-			Assert.True(ProxyUtil.TryCreateDelegateToMixin(proxy, typeof(Action), out _));
+			Assert.NotNull(ProxyUtil.CreateDelegateToMixin(proxy, typeof(Action)));
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_returns_false_if_no_suitable_Invoke_method_found()
+		public void CreateDelegateToMixin_throws_MissingMethodException_if_no_suitable_Invoke_method_found()
 		{
 			var proxy = new FakeProxyWithInvokeMethods();
-			Assert.False(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action<bool> boolAction));
+			Assert.Throws<MissingMethodException>(() => ProxyUtil.CreateDelegateToMixin<Action<bool>>(proxy));
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_returns_invokable_delegate()
+		public void CreateDelegateToMixin_returns_invokable_delegate()
 		{
 			var proxy = new FakeProxyWithInvokeMethods();
-			Assume.That(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
 			action.Invoke();
 		}
 
 		[Test]
-		public void TryCreateDelegateToMixin_can_deal_with_multiple_Invoke_overloads()
+		public void CreateDelegateToMixin_can_deal_with_multiple_Invoke_overloads()
 		{
 			var proxy = new FakeProxyWithInvokeMethods();
 
-			Assume.That(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action action));
+			var action = ProxyUtil.CreateDelegateToMixin<Action>(proxy);
 			action.Invoke();
 			Assert.AreEqual("Invoke()", proxy.LastInvocation);
 
-			Assume.That(ProxyUtil.TryCreateDelegateToMixin(proxy, out Action<int> intAction));
+			var intAction = ProxyUtil.CreateDelegateToMixin<Action<int>>(proxy);
 			intAction.Invoke(42);
 			Assert.AreEqual("Invoke(42)", proxy.LastInvocation);
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -187,7 +187,7 @@ namespace Castle.DynamicProxy.Contributors
 				return false;
 			}
 
-			if (IsDelegate(baseType))
+			if (baseType.IsDelegateType())
 			{
 				//working around bug in CLR which returns true for "does this type implement ISerializable" for delegates
 				return false;
@@ -228,11 +228,6 @@ namespace Castle.DynamicProxy.Contributors
 			}
 
 			return true;
-		}
-
-		private bool IsDelegate(Type baseType)
-		{
-			return baseType.BaseType == typeof(MulticastDelegate);
 		}
 #endif
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -99,7 +99,7 @@ namespace Castle.DynamicProxy.Contributors
 		public void AddInterfaceToProxy(Type @interface)
 		{
 			Debug.Assert(@interface != null, "@interface == null", "Shouldn't be adding empty interfaces...");
-			Debug.Assert(@interface.GetTypeInfo().IsInterface, "@interface.IsInterface", "Should be adding interfaces only...");
+			Debug.Assert(@interface.GetTypeInfo().IsInterface || @interface.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)), "@interface.IsInterface || @interface.IsSubclassOf(typeof(MulticastDelegate))", "Should be adding interfaces or delegate types only...");
 			Debug.Assert(!interfaces.Contains(@interface), "!interfaces.ContainsKey(@interface)",
 			             "Shouldn't be adding same interface twice...");
 

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -99,7 +99,7 @@ namespace Castle.DynamicProxy.Contributors
 		public void AddInterfaceToProxy(Type @interface)
 		{
 			Debug.Assert(@interface != null, "@interface == null", "Shouldn't be adding empty interfaces...");
-			Debug.Assert(@interface.GetTypeInfo().IsInterface || @interface.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)), "@interface.IsInterface || @interface.IsSubclassOf(typeof(MulticastDelegate))", "Should be adding interfaces or delegate types only...");
+			Debug.Assert(@interface.GetTypeInfo().IsInterface || @interface.IsDelegateType(), "@interface.IsInterface || @interface.IsDelegateType()", "Should be adding interfaces or delegate types only...");
 			Debug.Assert(!interfaces.Contains(@interface), "!interfaces.ContainsKey(@interface)",
 			             "Shouldn't be adding same interface twice...");
 

--- a/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
@@ -18,6 +18,7 @@ namespace Castle.DynamicProxy.Contributors
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
+	using Castle.DynamicProxy.Internal;
 
 	internal sealed class DelegateTypeMembersCollector : MembersCollector
 	{
@@ -28,7 +29,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.Name == "Invoke" && method.DeclaringType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)))
+			if (method.Name == "Invoke" && method.DeclaringType.IsDelegateType())
 			{
 				return new MetaMethod(method, method, isStandalone, true, false);
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
@@ -1,0 +1,41 @@
+// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Contributors
+{
+	using System;
+	using System.Reflection;
+
+	using Castle.DynamicProxy.Generators;
+
+	internal sealed class DelegateTypeMembersCollector : MembersCollector
+	{
+		public DelegateTypeMembersCollector(Type delegateType)
+			: base(delegateType)
+		{
+		}
+
+		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
+		{
+			if (method.Name == "Invoke" && method.DeclaringType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)))
+			{
+				return new MetaMethod(method, method, isStandalone, true, false);
+			}
+			else
+			{
+				return null;
+			}
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -22,6 +22,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+	using Castle.DynamicProxy.Internal;
 
 	public class MixinContributor : CompositeTypeContributor
 	{
@@ -79,7 +80,7 @@ namespace Castle.DynamicProxy.Contributors
 				}
 				else
 				{
-					Debug.Assert(@interface.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+					Debug.Assert(@interface.IsDelegateType());
 					item = new DelegateTypeMembersCollector(@interface);
 				}
 				item.CollectMembersToProxy(hook);

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -72,7 +72,16 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			foreach (var @interface in interfaces)
 			{
-				var item = new InterfaceMembersCollector(@interface);
+				MembersCollector item;
+				if (@interface.GetTypeInfo().IsInterface)
+				{
+					item = new InterfaceMembersCollector(@interface);
+				}
+				else
+				{
+					Debug.Assert(@interface.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+					item = new DelegateTypeMembersCollector(@interface);
+				}
 				item.CollectMembersToProxy(hook);
 				yield return item;
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Reflection;
 	using System.Reflection.Emit;
 
@@ -48,7 +49,14 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			{
 				foreach (var inter in interfaces)
 				{
-					TypeBuilder.AddInterfaceImplementation(inter);
+					if (inter.GetTypeInfo().IsInterface)
+					{
+						TypeBuilder.AddInterfaceImplementation(inter);
+					}
+					else
+					{
+						Debug.Assert(inter.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+					}
 				}
 			}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -20,6 +20,8 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
+	using Castle.DynamicProxy.Internal;
+
 	public class ClassEmitter : AbstractTypeEmitter
 	{
 		internal const TypeAttributes DefaultAttributes =
@@ -55,7 +57,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 					}
 					else
 					{
-						Debug.Assert(inter.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+						Debug.Assert(inter.IsDelegateType());
 					}
 				}
 			}

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -226,6 +226,14 @@ namespace Castle.DynamicProxy.Internal
 			return sortedMembers;
 		}
 
+		/// <summary>
+		///   Checks whether the specified <paramref name="type"/> is a delegate type (i.e. a direct subclass of <see cref="MulticastDelegate"/>).
+		/// </summary>
+		internal static bool IsDelegateType(this Type type)
+		{
+			return type.GetTypeInfo().BaseType == typeof(MulticastDelegate);
+		}
+
 		private static bool CloseGenericParametersIfAny(AbstractTypeEmitter emitter, Type[] arguments)
 		{
 			var hasAnyGenericParameters = false;

--- a/src/Castle.Core/DynamicProxy/MixinData.cs
+++ b/src/Castle.Core/DynamicProxy/MixinData.cs
@@ -21,6 +21,7 @@ namespace Castle.DynamicProxy
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
+	using Castle.DynamicProxy.Internal;
 
 	public class MixinData
 	{
@@ -49,13 +50,13 @@ namespace Castle.DynamicProxy
 				{
 					Type[] mixinInterfaces;
 					object target;
-					if (mixin is MulticastDelegate @delegate)
+					if (mixin is Delegate)
 					{
 						++delegateMixinCount;
 						mixinInterfaces = new[] { mixin.GetType() };
 						target = mixin;
 					}
-					else if (mixin is Type delegateType && delegateType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)))
+					else if (mixin is Type delegateType && delegateType.IsDelegateType())
 					{
 						++delegateMixinCount;
 						mixinInterfaces = new[] { delegateType };
@@ -84,7 +85,7 @@ namespace Castle.DynamicProxy
 							}
 							else
 							{
-								Debug.Assert(inter.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+								Debug.Assert(inter.IsDelegateType());
 								message = string.Format(
 									"The list of mixins already contains a mixin for delegate type '{0}'.",
 									inter.FullName);
@@ -102,7 +103,7 @@ namespace Castle.DynamicProxy
 					var invokeMethods = new HashSet<MethodInfo>();
 					foreach (var mixedInType in interface2Mixin.Keys)
 					{
-						if (mixedInType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)))
+						if (mixedInType.IsDelegateType())
 						{
 							var invokeMethod = mixedInType.GetMethod("Invoke");
 							if (invokeMethods.Contains(invokeMethod, MethodSignatureComparer.Instance))
@@ -176,8 +177,8 @@ namespace Castle.DynamicProxy
 
 			if (delegateMixinCount > 0)
 			{
-				var delegateMixinTypes = mixinPositions.Select(m => m.Key).Where(t => t.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
-				var otherDelegateMixinTypes = other.mixinPositions.Select(m => m.Key).Where(t => t.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)));
+				var delegateMixinTypes = mixinPositions.Select(m => m.Key).Where(TypeUtil.IsDelegateType);
+				var otherDelegateMixinTypes = other.mixinPositions.Select(m => m.Key).Where(TypeUtil.IsDelegateType);
 				return Enumerable.SequenceEqual(delegateMixinTypes, otherDelegateMixinTypes);
 			}
 

--- a/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
@@ -136,15 +136,8 @@ namespace Castle.DynamicProxy
 		/// <exception cref="ArgumentException"><paramref name="delegateType"/> is not a delegate type.</exception>
 		public void AddDelegateTypeMixin(Type delegateType)
 		{
-			if (delegateType == null)
-			{
-				throw new ArgumentNullException(nameof(delegateType));
-			}
-
-			if (!delegateType.IsDelegateType())
-			{
-				throw new ArgumentException("Type must be a delegate type.", nameof(delegateType));
-			}
+			if (delegateType == null) throw new ArgumentNullException(nameof(delegateType));
+			if (!delegateType.IsDelegateType()) throw new ArgumentException("Type must be a delegate type.", nameof(delegateType));
 
 			AddMixinImpl(delegateType);
 		}
@@ -158,25 +151,15 @@ namespace Castle.DynamicProxy
 		/// <exception cref="ArgumentNullException"><paramref name="delegate"/> is <see langword="null"/>.</exception>
 		public void AddDelegateMixin(Delegate @delegate)
 		{
-			if (@delegate == null)
-			{
-				throw new ArgumentNullException(nameof(@delegate));
-			}
+			if (@delegate == null) throw new ArgumentNullException(nameof(@delegate));
 
 			AddMixinImpl(@delegate);
 		}
 
 		public void AddMixinInstance(object instance)
 		{
-			if (instance == null)
-			{
-				throw new ArgumentNullException("instance");
-			}
-
-			if (instance is Type)
-			{
-				throw new ArgumentException("You may not mix in types using this method.", nameof(instance));
-			}
+			if (instance == null) throw new ArgumentNullException(nameof(instance));
+			if (instance is Type) throw new ArgumentException("You may not mix in types using this method.", nameof(instance));
 
 			AddMixinImpl(instance);
 		}

--- a/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
@@ -26,6 +26,7 @@ namespace Castle.DynamicProxy
 #endif
 
 	using Castle.Core.Internal;
+	using Castle.DynamicProxy.Internal;
 
 #if FEATURE_SERIALIZATION
 	[Serializable]
@@ -140,7 +141,7 @@ namespace Castle.DynamicProxy
 				throw new ArgumentNullException(nameof(delegateType));
 			}
 
-			if (delegateType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)) == false)
+			if (!delegateType.IsDelegateType())
 			{
 				throw new ArgumentException("Type must be a delegate type.", nameof(delegateType));
 			}
@@ -155,7 +156,7 @@ namespace Castle.DynamicProxy
 		/// </summary>
 		/// <param name="delegate">The delegate that should act as the target for calls to `Invoke` methods with a matching signature.</param>
 		/// <exception cref="ArgumentNullException"><paramref name="delegate"/> is <see langword="null"/>.</exception>
-		public void AddDelegateMixin(MulticastDelegate @delegate)
+		public void AddDelegateMixin(Delegate @delegate)
 		{
 			if (@delegate == null)
 			{

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -34,36 +34,31 @@ namespace Castle.DynamicProxy
 		private static readonly SynchronizedDictionary<Assembly, bool> internalsVisibleToDynamicProxy = new SynchronizedDictionary<Assembly, bool>();
 
 		/// <summary>
-		///   Attempts to create a delegate of the specified type to a suitable `Invoke` method
+		///   Creates a delegate of the specified type to a suitable `Invoke` method
 		///   on the given <paramref name="proxy"/> instance.
 		/// </summary>
 		/// <param name="proxy">The proxy instance to which the delegate should be bound.</param>
 		/// <typeparam name="TDelegate">The type of delegate that should be created.</typeparam>
-		/// <param name="delegate">The produced delegate if the method succeeds; otherwise <see langword="null"/>.</param>
-		/// <returns><see langword="true"/> if the method succeeds; otherwise <see langword="false"/>.</returns>
-		public static bool TryCreateDelegateToMixin<TDelegate>(object proxy, out TDelegate @delegate)
+		/// <exception cref="MissingMethodException">
+		///   The <paramref name="proxy"/> does not have an `Invoke` method that is compatible with
+		///   the requested <typeparamref name="TDelegate"/> type.
+		/// </exception>
+		public static TDelegate CreateDelegateToMixin<TDelegate>(object proxy)
 		{
-			if (TryCreateDelegateToMixin(proxy, typeof(TDelegate), out var d))
-			{
-				@delegate = (TDelegate)(object)d;
-				return true;
-			}
-			else
-			{
-				@delegate = default(TDelegate);
-				return false;
-			}
+			return (TDelegate)(object)CreateDelegateToMixin(proxy, typeof(TDelegate));
 		}
 
 		/// <summary>
-		///   Attempts to create a delegate of the specified type to a suitable `Invoke` method
+		///   Creates a delegate of the specified type to a suitable `Invoke` method
 		///   on the given <paramref name="proxy"/> instance.
 		/// </summary>
 		/// <param name="proxy">The proxy instance to which the delegate should be bound.</param>
 		/// <param name="delegateType">The type of delegate that should be created.</param>
-		/// <param name="delegate">The produced delegate if the method succeeds; otherwise <see langword="null"/>.</param>
-		/// <returns><see langword="true"/> if the method succeeds; otherwise <see langword="false"/>.</returns>
-		public static bool TryCreateDelegateToMixin(object proxy, Type delegateType, out Delegate @delegate)
+		/// <exception cref="MissingMethodException">
+		///   The <paramref name="proxy"/> does not have an `Invoke` method that is compatible with
+		///   the requested <paramref name="delegateType"/>.
+		/// </exception>
+		public static Delegate CreateDelegateToMixin(object proxy, Type delegateType)
 		{
 			if (proxy == null) throw new ArgumentNullException(nameof(proxy));
 			if (delegateType == null) throw new ArgumentNullException(nameof(delegateType));
@@ -79,17 +74,16 @@ namespace Castle.DynamicProxy
 
 			if (proxiedInvokeMethod == null)
 			{
-				@delegate = null;
-				return false;
+				throw new MissingMethodException("The proxy does not have an Invoke method " +
+				                                 "that is compatible with the requested delegate type.");
 			}
 			else
 			{
 #if FEATURE_NETCORE_REFLECTION_API
-				@delegate = proxiedInvokeMethod.CreateDelegate(delegateType, proxy);
+				return proxiedInvokeMethod.CreateDelegate(delegateType, proxy);
 #else
-				@delegate = Delegate.CreateDelegate(delegateType, proxy, proxiedInvokeMethod);
+				return Delegate.CreateDelegate(delegateType, proxy, proxiedInvokeMethod);
 #endif
-				return true;
 			}
 		}
 

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -27,6 +27,7 @@ namespace Castle.DynamicProxy
 
 	using Castle.Core.Internal;
 	using Castle.DynamicProxy.Generators;
+	using Castle.DynamicProxy.Internal;
 
 	public static class ProxyUtil
 	{
@@ -74,7 +75,7 @@ namespace Castle.DynamicProxy
 				throw new ArgumentNullException(nameof(delegateType));
 			}
 
-			if (delegateType.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate)) == false)
+			if (!delegateType.IsDelegateType())
 			{
 				throw new ArgumentException("Type is not a delegate type.", nameof(delegateType));
 			}

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -65,20 +65,9 @@ namespace Castle.DynamicProxy
 		/// <returns><see langword="true"/> if the method succeeds; otherwise <see langword="false"/>.</returns>
 		public static bool TryCreateDelegateToMixin(object proxy, Type delegateType, out Delegate @delegate)
 		{
-			if (proxy == null)
-			{
-				throw new ArgumentNullException(nameof(proxy));
-			}
-
-			if (delegateType == null)
-			{
-				throw new ArgumentNullException(nameof(delegateType));
-			}
-
-			if (!delegateType.IsDelegateType())
-			{
-				throw new ArgumentException("Type is not a delegate type.", nameof(delegateType));
-			}
+			if (proxy == null) throw new ArgumentNullException(nameof(proxy));
+			if (delegateType == null) throw new ArgumentNullException(nameof(delegateType));
+			if (!delegateType.IsDelegateType()) throw new ArgumentException("Type is not a delegate type.", nameof(delegateType));
 
 			var invokeMethod = delegateType.GetMethod("Invoke");
 			var proxiedInvokeMethod =


### PR DESCRIPTION
This is a follow-up to #403, which started out with the goal of adding a set of  `ProxyGenerator.CreateDelegateProxy` methods, and ended with us thinking about achieving delegate proxies through DynamicProxy's mixin capabilities. I am closing the earlier PR in favour of this present one.

This PR adds the following capabilities to DynamicProxy:

 * **`ProxyGenerationOptions.AddDelegateMixin(Delegate @delegate)`**  
   to add a delegate mixin. This will produce an `Invoke` method on the proxy that has the same signature as the delegate. The delegate can be `Proceed`-ed to.

 * **`ProxyGenerationOptions.AddDelegateTypeMixin(Type delegateType)`**  
   adds an `Invoke` method on the proxy that has the same signature as a specified delegate type. When those `Invoke` methods are intercepted, they cannot be proceeded from as that mixin has no target.

 * **`ProxyUtil.TryCreateDelegateToMixin(object target, Type delegateType, out Delegate @delegate)`**  
   **`ProxyUtil.TryCreateDelegateToMixin<TDelegate>(object target, out TDelegate @delegate)`**  
   are helper methods to create a delegate of a given type to a suitable `Invoke` method on a proxy.

By combining the above methods, you can now create a delegate proxy:

```csharp
var options = new ProxyGenerationOptions();
options.AddDelegateTypeMixin(typeof(Action));

var _ = generator.CreateClassProxy(typeof(object), options, ...);

ProxyUtil.TryCreateDelegateToMixin(_, out Action proxy);
                                      ^^^^^^^^^^^^^^^^
```

Because you're creating a class (or interface) proxy, you have full control over the "container" type for the generated interceptable `Invoke` method. You're also free to add custom attributes to that type, as you normally would.

I'd still like to...

* [X] ~~run some tests whether these new capabilities are actually useful in consuming libraries (Moq in my case)~~

   See [feedback for Moq](https://github.com/castleproject/Core/pull/436#issuecomment-472966476) and [NSubstitute](https://github.com/castleproject/Core/pull/436#issuecomment-473072088) below. Feedback is better than anticipated.

* [X] ~~I am also still unsure whether there may be serialization issues when using lambda delegates as mixin targets... and whether that is relevant in practice.~~

   ⚠️ If you use a lambda that captures any variables as a delegate mixin, then you won't be able to save the generated dynamic assembly to disk because the captured variables are put in a non-serializable "display class" by the compiler.

   This can be worked around by rewriting such lambdas & captures as explicit types. Beyond that, I'm not yet sure this is even fixable; if so, then we'd likely have to let `ProxyGenerationOptions` implement `ISerializable` and serialize it differently (specifically the `mixins` field).

   For now, I'd like to treat this as a known current limitation of the delegate mixin story, as it's probably not an immediate roadblock for most downstream libs.

Closes #399 (where we said that noone except DP itself should emit into its dynamic assembly, and the only known roadblock to that is delegate proxying; so if we get that, we no longer need `ModuleScope.DefineType`).

/cc @blairconrad, @thomaslevesque, @zvirja