### PR TITLE
Add some basic code style rules to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,10 @@ indent_size = 2
 [*.cs]
 indent_style = tab
 indent_size = 4
+csharp_prefer_braces = true:suggestion
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first = true
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false


### PR DESCRIPTION
Closes #409. This PR doesn't go as far as codifying *all* conventions documented in https://github.com/castleproject/Home/blob/master/coding-standards.md, but it takes care of those that trigger the most "light bulbs" (refactoring suggestions) in VS.