### PR TITLE
Add memento capture to `IInvocation` (aka async interception groundwork)

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests
+{
+	using System;
+	using System.Linq;
+	using System.Reflection;
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy;
+	using Castle.DynamicProxy.Tests;
+
+	using CastleTests.DynamicProxy.Tests.Classes;
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+	using CastleTests.Interceptors;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AsyncInterceptorTestCase : BasePEVerifyTestCase
+	{
+	    [Test]
+	    public async Task Should_Intercept_Asynchronous_Methods_With_An_Async_Operations_Prior_To_Calling_Proceed()
+	    {
+			// Arrange
+		    IInterfaceWithAsynchronousMethod target = new ClassWithAsynchronousMethod();
+			IInterceptor interceptor = new AsyncInterceptor();
+
+		    IInterfaceWithAsynchronousMethod proxy =
+			    generator.CreateInterfaceProxyWithTargetInterface(target, interceptor);
+
+			// Act
+		    await proxy.Method().ConfigureAwait(false);
+	    }
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Classes
+{
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	using CastleTests.DynamicProxy.Tests.Interfaces;
+
+	public class ClassWithAsynchronousMethod : IInterfaceWithAsynchronousMethod
+	{
+		public async Task Method()
+		{
+			Console.WriteLine(
+				$"Before Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+
+			await Task.Delay(10).ConfigureAwait(false);
+
+			Console.WriteLine(
+				$"After Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.DynamicProxy.Tests.Interfaces
+{
+	using System.Threading.Tasks;
+
+	public interface IInterfaceWithAsynchronousMethod
+	{
+		Task Method();
+	}
+}

--- a/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
@@ -26,8 +26,12 @@ namespace CastleTests.Interceptors
 
 		private static async Task InterceptAsyncMethod(IInvocation invocation)
 		{
+			var interceptionProgress = invocation.GetMemento(InvocationMementoOptions.InterceptionProgress);
+
 			// It all falls down when executing async before calling Proceed().
 			await Task.Delay(10).ConfigureAwait(false);
+
+			interceptionProgress.Restore();
 
 			invocation.Proceed();
 

--- a/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
+++ b/src/Castle.Core.Tests/Interceptors/AsyncInterceptor.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests.Interceptors
+{
+	using System.Threading.Tasks;
+	using Castle.DynamicProxy;
+
+	public class AsyncInterceptor : IInterceptor
+	{
+		public void Intercept(IInvocation invocation)
+		{
+			invocation.ReturnValue = InterceptAsyncMethod(invocation);
+		}
+
+		private static async Task InterceptAsyncMethod(IInvocation invocation)
+		{
+			// It all falls down when executing async before calling Proceed().
+			await Task.Delay(10).ConfigureAwait(false);
+
+			invocation.Proceed();
+
+			// Hmmmmm, now with it simplified down to this, I see the glaring hole that is the return value being set
+			// in two situations.
+			Task returnValue = (Task)invocation.ReturnValue;
+
+			await returnValue.ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/IInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocation.cs
@@ -125,5 +125,11 @@ namespace Castle.DynamicProxy
 		/// <param name = "index">The index of the argument to override.</param>
 		/// <param name = "value">The new value for the argument.</param>
 		void SetArgumentValue(int index, object value);
+
+		/// <summary>
+		///   Gets an object that captures the specified parts of this invocation's state for later restoration.
+		/// </summary>
+		/// <param name="options">Specifies which parts of this invocation's state should be captured.</param>
+		IInvocationMemento GetMemento(InvocationMementoOptions options);
 	}
 }

--- a/src/Castle.Core/DynamicProxy/IInvocationMemento.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocationMemento.cs
@@ -1,0 +1,30 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy
+{
+	using System.ComponentModel;
+
+	/// <summary>
+	///   Represents a full or partial state of an <see cref="IInvocation"/> captured at an earlier time.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public interface IInvocationMemento
+	{
+		/// <summary>
+		///   Restores the state captured by this instance to the associated <see cref="IInvocation"/>.
+		/// </summary>
+		void Restore();
+	}
+}

--- a/src/Castle.Core/DynamicProxy/InvocationMementoOptions.cs
+++ b/src/Castle.Core/DynamicProxy/InvocationMementoOptions.cs
@@ -1,0 +1,46 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy
+{
+	using System;
+
+	/// <summary>
+	///   Specifies which parts of an invocation's state to capture.
+	/// </summary>
+	[Flags]
+	public enum InvocationMementoOptions
+	{
+		/// <summary>
+		///   Specifies that arguments should be captured.
+		/// </summary>
+		Arguments = 1,
+
+		/// <summary>
+		///   Specifies that the return value should be captured.
+		/// </summary>
+		ReturnValue = 2,
+
+		/// <summary>
+		///   Specifies that the invocation's position in the interception pipeline should be captured.
+		///   <para>
+		///     Note that interception of an invocation may have finished by the time a call to
+		///     <see cref="IInvocationMemento.Restore"/> is made. While such a "stale" invocation
+		///     can be procesed again by interceptors, setting the return value or by-ref arguments
+		///     will no longer have any effect on the calling code.
+		///   </para>
+		/// </summary>
+		InterceptionProgress = 4,
+	}
+}


### PR DESCRIPTION
This is the smallest change I can think of that might just be sufficient to enable people to write async interceptors. While technically still a breaking change (it adds a new member to the pre-existing `IInvocation` interface) it's a comparatively minor one, and it does fix the same unit test from #429.

**What problem does this PR attempt to solve?** As soon as an async continuation is set up in an interceptor's `Intercept` method (e.g. by means of an  `await`), interception starts to regress back to the caller and the invocation's `currentInterceptorIndex` starts getting decremented&mdash;this is why `invocation.Proceed()` will no longer work in the async continuations: it will end up proceeding to an *earlier* interceptor instead of to the next one.

I therefore tried to find a way to make `currentInterceptorIndex` modifiable without exposing it, and ended up with the [Memento pattern](https://en.wikipedia.org/wiki/Memento_pattern).

While I think [completely removing `Proceed` (and `currentInterceptorIndex` with it) from `AbstractInvocation`](https://github.com/stakx/Castle.Core/commit/9f67f16a49bfbc3ba547fd56cf4a22106cdcd821) would possibly be the cleaner solution in the long term, it would also trigger the need for a fairly large breaking change in DynamicProxy's `Intercept` / `Proceed` API, and I'm not sure we're ready for that.

I don't expect this to get merged, as we probably don't really need a generic memento facility for invocation objects 😜, but I am still curious what others think about this approach.

/cc @JSkimming, @brunoblank