### PR TITLE
Add `IInvocation.CaptureProceedInfo()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Enhancements:
 - Added trace logging level below Debug; maps to Trace in log4net/NLog, and Verbose in Serilog (@pi3k14, #404)
 - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
 - DictionaryAdapter: Exposed GetAdapter overloads with NameValueCollection parameter in .NET Standard (@rzontar, #423)
+- New `IInvocation.GetProceedInfo()` method to enable better implementations of asynchronous interceptors (@stakx, #439)
 
 Deprecations:
 - The API surrounding `Lock` has been deprecated. This consists of the members listed below. Consider using the Base Class Library's `System.Threading.ReaderWriterLockSlim` instead. (@stakx, #391)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Enhancements:
 - Added trace logging level below Debug; maps to Trace in log4net/NLog, and Verbose in Serilog (@pi3k14, #404)
 - Recognize read-only parameters by the `In` modreq (@zvirja, #406)
 - DictionaryAdapter: Exposed GetAdapter overloads with NameValueCollection parameter in .NET Standard (@rzontar, #423)
-- New `IInvocation.GetProceedInfo()` method to enable better implementations of asynchronous interceptors (@stakx, #439)
+- New `IInvocation.CaptureProceedInfo()` method to enable better implementations of asynchronous interceptors (@stakx, #439)
 
 Deprecations:
 - The API surrounding `Lock` has been deprecated. This consists of the members listed below. Consider using the Base Class Library's `System.Threading.ReaderWriterLockSlim` instead. (@stakx, #391)

--- a/docs/dynamicproxy-async-interception.md
+++ b/docs/dynamicproxy-async-interception.md
@@ -1,0 +1,290 @@
+# Asynchronous interception
+
+This article discusses several interception scenarios related to asynchrony. We'll look at these scenarios in increasing order of implementation difficulty:
+
+ * Intercepting awaitable methods that don't produce a return value (e.g. `Task`), with and without using `async`/`await` in interceptor code
+
+ * Intercepting awaitable methods that do produce a return value (e.g. `Task<TResult>`), with using `async`/`await` in interceptor code
+
+ * Using `invocation.Proceed()` in combination with `async`/`await`
+
+This article contains C# code examples that make use of the `async`/`await` keywords. Before you proceed, please make sure that you have a good understanding of how these work. They are merely "syntactic sugar" that cause the .NET compilers to rewrite an async method to a state machine with continuations. The [Async/Await FAQ by Stephen Toub](https://devblogs.microsoft.com/pfxteam/asyncawait-faq/) explains these keywords in more detail.
+
+For brevity's sake, the examples shown in this article will focus on an interceptor's `Intercept` method. Assume that code examples are backed by the following code:
+
+
+```csharp
+var serviceProxy = proxyGenerator.CreateInterfaceProxyWithoutTarget<IService>(new AsyncInterceptor());
+
+// Examples will show how interception gets triggered:
+int result = await serviceProxy.GetAsync();
+
+public interface IService
+{
+	Task DoAsync();
+	Task<int> GetAsync(int n);
+}
+
+class AsyncInterceptor : IInterceptor
+{
+	// Examples will mostly focus on this method's implementation:
+	public void Intercept(IInvocation invocation)
+	{
+		...
+	}
+}
+```
+
+
+## Intercepting awaitable methods that don't produce a return value
+
+Intercepting awaitable methods (e.g. ones with a return type of `Task`) is fairly easy and not much different from intercepting non-awaitable methods. You'll simply have to set the intercepted invocation's return value to any valid `Task` object.
+
+
+```csharp
+// calling code:
+await serviceProxy.DoAsync();
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = httpClient.PostAsync(...);
+}
+```
+
+
+That wasn't very interesting, and in real-world scenarios you'll quickly reach a point where you'd like to use `async`/`await`. That, however, is also fairly trivial:
+
+
+```csharp
+// calling code:
+await serviceProxy.DoAsync();
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = InterceptAsync(invocation);
+}
+
+private async Task InterceptAsync(IInvocation invocation)
+{
+	// In this method, you have the comfort of using `await`:
+	var response = await httpClient.PostAsync(...);
+	...
+}
+```
+
+
+Things get more complicated once you want to return a value to the calling code. Let's look at that next!
+
+
+## Intercepting awaitable methods that produce a return value
+
+When intercepting an awaitable method that produces a return value (such as a method with a return type of `Task<TResult>`), it is important to remember that the very first `await` that gets hit by execution effectively returns to the caller right away. (The C# compiler will move the statements following the `await` into a continuation that will execute once the `await` "completes".)
+
+In other words, the very first `await` inside your interceptor completes the proxy method interception!
+
+DynamicProxy requires that interceptors (or the proxy target object) provide a return value for intercepted non-`void` methods. Naturally, the same requirement holds in an async scenario. Because the first `await` causes an early return to the caller, you must make sure to set the intercepted invocation's return value prior to any `await`.
+
+We already did that at the end of the last section; let's quickly go back and take a closer look:
+
+
+```csharp
+// calling code:
+var result = await serviceProxy.DoAsync();
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = InterceptAsync(invocation);
+	//         ^^^^^^^^^^^^^
+}
+
+private async Task InterceptAsync(IInvocation invocation)
+{
+	// At this point, interception is still going on
+	// as we haven't yet hit upon an `await`.
+
+	var response = await httpClient.PostAsync(...);
+
+	// At this point, interception has already completed!
+
+	invocation.ReturnValue = ...;
+	// ^ Any assignments to `invocation.ReturnValue` are no longer
+	//   observable by the calling code, which already received its
+	//   return value earlier (specifically, the `Task` produced by
+	//   the C# compiler representing this asynchronous method).
+	//   `invocation` is essentially a "cold", "detached", "stale",
+	//   or "dead" object (pick your favourite term).
+}
+```
+
+
+So, how would we communicate a return value back to the calling code when the intercepted method's return type is not just `Task`, but say, `Task<int>`? The following example shows how you can control the result of the task received by calling code:
+
+
+```csharp
+// calling code:
+var result = await serviceProxy.GetAsync(41);
+Assert.Equal(42, result);
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = InterceptAsync(invocation);
+}
+
+private async Task<int> InterceptAsync(IInvocation invocation)
+{
+	// We can still use `await`:
+	await ...;
+
+	// And we can simply `return` values, and the C# compiler
+	// will do the rest for us:
+	return (int)invocation.Arguments[0] + 1;
+}
+```
+
+
+Unfortunately, it usually won't be *that* easy in real-world scenarios, where you cannot assume that every method that your interceptor deals with will have the exact same return type of `Task<int>`. So, instead of being able to just comfortably `return someInt;` from a `async Task<int>` method, you'll have to resort to a non-generic `Task`, a `TaskCompletionSource`, and some reflection:
+
+
+```csharp
+// calling code--as before:
+var result = await serviceProxy.GetAsync(41);
+Assert.Equal(42, result);
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	var returnType = invocation.Method.ReturnType;
+
+	// For this example, we'll just assume that we're dealing with
+	// a `returnType` of `Task<TResult>`. In practice, you'd have
+	// to have logic for non-`Task`, `Task`, `Task<TResult>`, and
+	// any other awaitable types that you care about:
+	Debug.Assert(typeof(Task).IsAssignableFrom(returnType) && returnType.IsGenericType);
+
+	// Instantiate a `TaskCompletionSource<TResult>`, whose `Task`
+	// we will return to the calling code, so that we can control
+	// the result:
+	var tcsType = typeof(TaskCompletionSource<>)
+	              .MakeGenericType(returnType.GetGenericArguments()[0]);
+	var tcs = Activator.CreateInstance(tcsType);
+	invocation.ReturnValue = tcsType.GetProperty("Task").GetValue(tcs, null);
+
+	// Because we're not in an `async` method, we cannot use `await`
+	// and have the compiler generate a continuation for the code
+	// following it. Let's therefore set up the continuation manually:
+	InterceptAsync(invocation).ContinueWith(_ =>
+	{
+		// This sets the result of the task that we have previously
+		// returned to the calling code, based on `invocation.ReturnValue`
+		// which has been set in the (by now completed) `InterceptAsync`
+		// method (see below):
+		tcsType.GetMethod("SetResult").Invoke(tcs, new object[] { invocation.ReturnValue });
+	});
+}
+
+private async Task InterceptAsync(IInvocation invocation)
+{
+	// In this method, we now have the comfort of `await`:
+	var response = await httpClient.GetStringAsync(...);
+
+	// ... and we can still set the final return value! Note that
+	// the return type of this method is now `Task`, not `Task<TResult>`,
+	// so we can no longer `return` a value. Instead, we use the
+	// "stale" `invocation` to hold the real return value for us.
+	// It will get processed in the continuation (above) when this
+	// async method completes:
+	invocation.ReturnValue = (int)invocation.Arguments[0] + 1;
+}
+```
+
+
+Phew! And things get even more complex once we want to do an `invocation.Proceed()` to a succeeding interceptor or the proxy's target method. Let's look at that next!
+
+
+## Using `invocation.Proceed()` in combination with `async`/`await`
+
+Here's a quick recap about `invocation.Proceed()`: This method gets used to proceed to the next interceptor in line, or, if there is no other interceptor but a proxy target object, to that. Remember this image from the [introduction to DynamicProxy](dynamicproxy-introduction.md#interception-pipeline):
+
+![](images/proxy-pipeline.png)
+
+Let's get straight to the point: `Proceed()` will not do what you might expect in an async scenario! Remember that the very first `await` inside your interceptor completes interception, i.e. causes an early return to the calling code? This means that interception starts to "bubble back up" towards the calling code (i.e. along the green arrows in the above picture).
+
+Therefore, after having `await`-ed in your interceptor, interception has completed at the position of the last green arrow. Calling `invocation.Proceed` in the continuation (i.e. after the `await`) will then simply advance to the very first interceptor again... that's likely not what you want, and can cause infinite loops and other unexpected malfunctions.
+
+
+```csharp
+// calling code:
+await serviceProxy.DoAsync();
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = InterceptAsync(invocation);
+}
+
+private async Task InterceptAsync(IInvocation invocation)
+{
+	await ...;
+	invocation.Proceed(); // will not proceed, but reenter this interceptor
+	                      // or--if this isn't the first--an earlier one!
+}
+```
+
+
+In order for you to be able to work around this problem, DynamicProxy offers another method, `invocation.CaptureProceedInfo()`, which allows you to capture the invocation's current position in the interception pipeline (i.e. where along the yellow arrows it is currently located). This method returns an object to you which you can use to continue interception from this very same location onward.
+
+The solution to the problem demonstrated above now becomes very simple:
+
+
+```csharp
+// calling code--as before:
+await serviceProxy.DoAsync();
+
+// interception:
+public void Intercept(IInvocation invocation)
+{
+	invocation.ReturnValue = InterceptAsync(invocation);
+}
+
+private async Task InterceptAsync(IInvocation invocation)
+{
+	// If we want to `Proceed` at any point in this method,
+	// we need to capture how far in the invocation pipeline
+	// we're currently located *before* we `await`:
+	var proceed = invocation.CaptureProceedInfo();
+
+	await ...;
+
+	// At this point, interception is completed and we have
+	// a "stale" invocation that has been reset to the very
+	// beginning of the interception pipeline. However,
+	// that doesn't mean that we cannot send it onward to the
+	// remaining interceptors or to the proxy target object:
+	proceed.Invoke();
+
+	// At this point, a later interceptor might have over-
+	// written `invocation.ReturnValue`. As explained earlier,
+	// while the calling code will no longer observe this
+	// value, we could inspect it to set our own task's
+	// result (if we returned a `Task<TResult>`).
+}
+```
+
+
+## Closing remarks
+
+ * As you have seen, async interception is only trivial in very simple scenarios, but can get quite complex very quickly. If you don't feel comfortable writing such code yourself, look for third-party libraries that help you with async interception, for example:
+
+   * [Castle.Core.AsyncInterceptor](https://www.nuget.org/packages/Castle.Core.AsyncInterceptor) (third-party, despite the Castle Project's package namespace)
+
+   If you are the author of a generally useful async interception helper library, and would like to add your library to the above list, feel free to submit a PR.
+
+ * The above examples have shown cases where a "stale" invocation object has its `ReturnValue` repeatedly set, even though only the first value might be observed by calling code. It is however possible that invocation objects are recorded somewhere, and could be inspected later on. Other parties might then observe a `ReturnValue` that does not reflect what the original caller got.
+
+   Because of that, it might be good practice for your async interceptors to restore, at the end of interception, the `ReturnValue` to the value that actually made it back to the calling code.
+
+ * The same recommendation&mdash;restoration to the value(s) observed by the calling code&mdash;applies to by-ref arguments that have been repeatedly overwritten using `invocation.SetArgumentValue`.

--- a/docs/dynamicproxy.md
+++ b/docs/dynamicproxy.md
@@ -20,6 +20,7 @@ If you're new to DynamicProxy you can read a [quick introduction](dynamicproxy-i
 * [SRP applies to interceptors](dynamicproxy-srp-applies-to-interceptors.md)
 * [Behavior of by-reference parameters during interception](dynamicproxy-by-ref-parameters.md)
 * [Optional parameter value limitations](dynamicproxy-optional-parameter-value-limitations.md)
+* [Asynchronous interception](dynamicproxy-async-interception.md)
 
 :information_source: **Where is `Castle.DynamicProxy.dll`?:** DynamicProxy used to live in its own assembly. As part of changes in version 2.5 it was merged into `Castle.Core.dll` and that's where you'll find it.
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -1,0 +1,63 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy.Tests.Classes;
+	using Castle.DynamicProxy.Tests.Interfaces;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class AsyncInterceptorTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public async Task Should_Intercept_Asynchronous_Methods_With_An_Async_Operations_Prior_To_Calling_Proceed()
+		{
+			// Arrange
+			IInterfaceWithAsynchronousMethod target = new ClassWithAsynchronousMethod();
+			IInterceptor interceptor = new AsyncInterceptor();
+
+			IInterfaceWithAsynchronousMethod proxy =
+				generator.CreateInterfaceProxyWithTargetInterface(target, interceptor);
+
+			// Act
+			await proxy.Method().ConfigureAwait(false);
+		}
+
+		private class AsyncInterceptor : IInterceptor
+		{
+			public void Intercept(IInvocation invocation)
+			{
+				invocation.ReturnValue = InterceptAsyncMethod(invocation);
+			}
+
+			private static async Task InterceptAsyncMethod(IInvocation invocation)
+			{
+				// It all falls down when executing async before calling Proceed().
+				await Task.Delay(10).ConfigureAwait(false);
+
+				invocation.Proceed();
+
+				// Return value is being set in two situations, but this doesn't matter
+				// for the above test.
+				Task returnValue = (Task)invocation.ReturnValue;
+
+				await returnValue.ConfigureAwait(false);
+			}
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -47,7 +47,7 @@ namespace Castle.DynamicProxy.Tests
 
 			private static async Task InterceptAsyncMethod(IInvocation invocation)
 			{
-				var proceed = invocation.GetProceedInfo();
+				var proceed = invocation.CaptureProceedInfo();
 
 				await Task.Delay(10).ConfigureAwait(false);
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -47,10 +47,11 @@ namespace Castle.DynamicProxy.Tests
 
 			private static async Task InterceptAsyncMethod(IInvocation invocation)
 			{
-				// It all falls down when executing async before calling Proceed().
+				var proceed = invocation.GetProceedInfo();
+
 				await Task.Delay(10).ConfigureAwait(false);
 
-				invocation.Proceed();
+				proceed.Invoke();
 
 				// Return value is being set in two situations, but this doesn't matter
 				// for the above test.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
@@ -1,0 +1,38 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	using Castle.DynamicProxy.Tests.Interfaces;
+
+	public class ClassWithAsynchronousMethod : IInterfaceWithAsynchronousMethod
+	{
+		public async Task Method()
+		{
+			Console.WriteLine(
+				$"Before Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+
+			await Task.Delay(10).ConfigureAwait(false);
+
+			Console.WriteLine(
+				$"After Await ClassWithAsynchronousMethod:Method ThreadId='{Thread.CurrentThread.ManagedThreadId}'.",
+				Thread.CurrentThread.ManagedThreadId);
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
@@ -1,0 +1,23 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	using System.Threading.Tasks;
+
+	public interface IInterfaceWithAsynchronousMethod
+	{
+		Task Method();
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
@@ -35,7 +35,7 @@ namespace Castle.DynamicProxy.Tests
 				new SetReturnValueInterceptor(0),
 				new WithCallbackInterceptor(invocation =>
 				{
-					var proceed = invocation.GetProceedInfo();
+					var proceed = invocation.CaptureProceedInfo();
 				}),
 			};
 
@@ -51,7 +51,7 @@ namespace Castle.DynamicProxy.Tests
 				new SetReturnValueInterceptor(0),
 				new WithCallbackInterceptor(invocation =>
 				{
-					var proceed = invocation.GetProceedInfo();
+					var proceed = invocation.CaptureProceedInfo();
 					Assert.Throws<NotImplementedException>(() => proceed.Invoke());
 				}),
 			};
@@ -67,7 +67,7 @@ namespace Castle.DynamicProxy.Tests
 			{
 				new WithCallbackInterceptor(invocation =>
 				{
-					var proceed = invocation.GetProceedInfo();
+					var proceed = invocation.CaptureProceedInfo();
 					proceed.Invoke();
 				}),
 				new SetReturnValueInterceptor(1),
@@ -85,7 +85,7 @@ namespace Castle.DynamicProxy.Tests
 
 			var interceptor = new WithCallbackInterceptor(invocation =>
 				{
-					var proceed = invocation.GetProceedInfo();
+					var proceed = invocation.CaptureProceedInfo();
 					proceed.Invoke();
 				});
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
@@ -30,33 +30,29 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		public void Proxy_without_target_and_last_interceptor_ProceedInfo_succeeds()
 		{
-			var interceptors = new IInterceptor[]
-			{
-				new SetReturnValueInterceptor(0),
-				new WithCallbackInterceptor(invocation =>
+			var interceptor = new WithCallbackInterceptor(invocation =>
 				{
+					invocation.ReturnValue = 0;  // not relevant to this test, but prevents DP
+					                             // from complaining about missing return value.
 					var proceed = invocation.CaptureProceedInfo();
-				}),
-			};
+				});
 
-			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptors);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptor);
 			proxy.OneMethod();
 		}
 
 		[Test]
 		public void Proxy_without_target_and_last_interceptor_ProceedInfo_Invoke_throws_NotImplementedException()
 		{
-			var interceptors = new IInterceptor[]
-			{
-				new SetReturnValueInterceptor(0),
-				new WithCallbackInterceptor(invocation =>
+			var interceptor = new WithCallbackInterceptor(invocation =>
 				{
+					invocation.ReturnValue = 0;  // not relevant for this test, but prevents DP
+					                             // from complaining about missing return value.
 					var proceed = invocation.CaptureProceedInfo();
 					Assert.Throws<NotImplementedException>(() => proceed.Invoke());
-				}),
-			};
+				});
 
-			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptors);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptor);
 			proxy.OneMethod();
 		}
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedInfoTestCase.cs
@@ -1,0 +1,97 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+
+	using Castle.DynamicProxy.Tests.Interceptors;
+	using Castle.DynamicProxy.Tests.InterClasses;
+	using Castle.DynamicProxy.Tests.Interfaces;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class InvocationProceedInfoTestCase
+	{
+		private readonly ProxyGenerator generator = new ProxyGenerator();
+
+		[Test]
+		public void Proxy_without_target_and_last_interceptor_ProceedInfo_succeeds()
+		{
+			var interceptors = new IInterceptor[]
+			{
+				new SetReturnValueInterceptor(0),
+				new WithCallbackInterceptor(invocation =>
+				{
+					var proceed = invocation.GetProceedInfo();
+				}),
+			};
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptors);
+			proxy.OneMethod();
+		}
+
+		[Test]
+		public void Proxy_without_target_and_last_interceptor_ProceedInfo_Invoke_throws_NotImplementedException()
+		{
+			var interceptors = new IInterceptor[]
+			{
+				new SetReturnValueInterceptor(0),
+				new WithCallbackInterceptor(invocation =>
+				{
+					var proceed = invocation.GetProceedInfo();
+					Assert.Throws<NotImplementedException>(() => proceed.Invoke());
+				}),
+			};
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptors);
+			proxy.OneMethod();
+		}
+
+		[Test]
+		public void Proxy_without_target_and_second_to_last_interceptor_ProceedInfo_Invoke_proceeds_to_interceptor()
+		{
+			var interceptors = new IInterceptor[]
+			{
+				new WithCallbackInterceptor(invocation =>
+				{
+					var proceed = invocation.GetProceedInfo();
+					proceed.Invoke();
+				}),
+				new SetReturnValueInterceptor(1),
+			};
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IOne>(interceptors);
+			var returnValue = proxy.OneMethod();
+			Assert.AreEqual(1, returnValue);
+		}
+
+		[Test]
+		public void Proxy_with_target_and_last_interceptor_ProceedInfo_Invoke_proceeds_to_target()
+		{
+			var target = new One();
+
+			var interceptor = new WithCallbackInterceptor(invocation =>
+				{
+					var proceed = invocation.GetProceedInfo();
+					proceed.Invoke();
+				});
+
+			var proxy = generator.CreateInterfaceProxyWithTarget<IOne>(new One(), interceptor);
+			var returnValue = proxy.OneMethod();
+			Assert.AreEqual(1, returnValue);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
@@ -142,7 +142,7 @@ namespace Castle.DynamicProxy
 			}
 		}
 
-		public IInvocationProceedInfo GetProceedInfo()
+		public IInvocationProceedInfo CaptureProceedInfo()
 		{
 			return new ProceedInfo(this);
 		}

--- a/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
@@ -142,6 +142,11 @@ namespace Castle.DynamicProxy
 			}
 		}
 
+		public IInvocationProceedInfo GetProceedInfo()
+		{
+			return new ProceedInfo(this);
+		}
+
 		protected abstract void InvokeMethodOnTarget();
 
 		protected void ThrowOnNoTarget()
@@ -187,6 +192,32 @@ namespace Castle.DynamicProxy
 				return method.GetGenericMethodDefinition().MakeGenericMethod(genericMethodArguments);
 			}
 			return method;
+		}
+
+		private sealed class ProceedInfo : IInvocationProceedInfo
+		{
+			private readonly AbstractInvocation invocation;
+			private readonly int interceptorIndex;
+
+			public ProceedInfo(AbstractInvocation invocation)
+			{
+				this.invocation = invocation;
+				this.interceptorIndex = invocation.currentInterceptorIndex;
+			}
+
+			public void Invoke()
+			{
+				var previousInterceptorIndex = invocation.currentInterceptorIndex;
+				try
+				{
+					invocation.currentInterceptorIndex = interceptorIndex;
+					invocation.Proceed();
+				}
+				finally
+				{
+					invocation.currentInterceptorIndex = previousInterceptorIndex;
+				}
+			}
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/IInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocation.cs
@@ -118,7 +118,7 @@ namespace Castle.DynamicProxy
 		///   Returns an object describing the <see cref="Proceed"/> operation for this <see cref="IInvocation"/>
 		///   at this specific point during interception.
 		/// </summary>
-		IInvocationProceedInfo GetProceedInfo();
+		IInvocationProceedInfo CaptureProceedInfo();
 
 		/// <summary>
 		///   Overrides the value of an argument at the given <paramref name = "index" /> with the

--- a/src/Castle.Core/DynamicProxy/IInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocation.cs
@@ -115,6 +115,12 @@ namespace Castle.DynamicProxy
 		void Proceed();
 
 		/// <summary>
+		///   Returns an object describing the <see cref="Proceed"/> operation for this <see cref="IInvocation"/>
+		///   at this specific point during interception.
+		/// </summary>
+		IInvocationProceedInfo GetProceedInfo();
+
+		/// <summary>
 		///   Overrides the value of an argument at the given <paramref name = "index" /> with the
 		///   new <paramref name = "value" /> provided.
 		/// </summary>

--- a/src/Castle.Core/DynamicProxy/IInvocationProceedInfo.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocationProceedInfo.cs
@@ -1,0 +1,31 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy
+{
+	using System;
+
+	/// <summary>
+	///   Describes the <see cref="IInvocation.Proceed"/> operation for an <see cref="IInvocation"/>
+	///   at a specific point during interception.
+	/// </summary>
+	public interface IInvocationProceedInfo
+	{
+		/// <summary>
+		///   Executes the <see cref="IInvocation.Proceed"/> operation described by this instance.
+		/// </summary>
+		/// <exception cref="NotImplementedException">There is no interceptor, nor a proxy target object, to proceed to.</exception>
+		void Invoke();
+	}
+}


### PR DESCRIPTION
**TL;DR:** This resolves #145.

This is another attempt (after #438) at enabling asynchronous interceptors (#145) via an API addition that's as non-breaking as possible, in the sense of both "not breaking any abstractions" and "not introducing any breaking changes".

I abandoned #438 because the abstraction introduced there didn't seem quite right: We don't really need the ability to snapshot an `IInvocation` object's state (specifically, `currentInterceptorIndex`) and restore it later; what we *do* need is a way to make `invocation.Proceed()` calls work from an async continuation that executes when interception of `invocation` has already completed.

The new API introduced here is an `invocation.CaptureProceedInfo()` method that captures, in the form of an `IInvocationProceedInfo` descriptor object (think Reflection!), whatever `invocation.Proceed()` would do at that specific moment. That action can then be `Invoke`d at a later time via that returned descriptor object:

```diff
 void IInterceptor.Intercept(IInvocation invocation)
 {
     invocation.ReturnValue = InterceptAsync(invocation);
 }

 async Task InterceptAsync(IInvocation invocation)
 {
+    var proceed = invocation.CaptureProceedInfo();

     await ...              // early return, i.e. interception completes before the next line
-    invocation.Proceed();  // this would "proceed" back to the very first interceptor

+    proceed.Invoke();      // this proceeds to the interceptor following the current one
 }
```

This should be sufficient to let people implement some kind of `AsyncInterceptor` base class.

What this does *not* solve is #238, i.e. the fact that `AbstractInvocation.Proceed` is inherently thread-unsafe due to the non-atomic `currentInterceptorIndex` increment/decrement dance. #428 may possibly do a better job in that regard, FWIW.

/cc @JSkimming, @brunoblank (sorry for needlessly CCing you in #438; I hope this PR will fare better)