### PR TITLE
Deprecate `ModuleScope.DefineType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Deprecations:
    - `Castle.Core.Internal.Lock` (class)
    - `Castle.Core.Internal.ILockHolder` (interface)
    - `Castle.Core.Internal.IUpgradeableLockHolder` (interface)
+- You should no longer manually emit types into DynamicProxy's dynamic assembly. For this reason, the following member has been deprecated. (@stakx, #445)
+   - `Castle.DynamicProxy.ModuleScope.DefineType` (method)
 - The proxy type cache in `ModuleScope` should no longer be accessed directly. For this reason, the members listed below have been deprecated. (@stakx, #391)
    - `Castle.DynamicProxy.ModuleScope.Lock` (property)
    - `Castle.DynamicProxy.ModuleScope.GetFromCache` (method)

--- a/ref/Castle.Core-net35.cs
+++ b/ref/Castle.Core-net35.cs
@@ -2647,6 +2647,7 @@ namespace Castle.DynamicProxy
         public System.Reflection.Emit.ModuleBuilder WeakNamedModule { get; }
         public string WeakNamedModuleDirectory { get; }
         public string WeakNamedModuleName { get; }
+        [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Reflection.Emit.TypeBuilder DefineType(bool inSignedModulePreferably, string name, System.Reflection.TypeAttributes flags) { }
         [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Type GetFromCache(Castle.DynamicProxy.Generators.CacheKey key) { }

--- a/ref/Castle.Core-net40.cs
+++ b/ref/Castle.Core-net40.cs
@@ -2694,6 +2694,7 @@ namespace Castle.DynamicProxy
         public System.Reflection.Emit.ModuleBuilder WeakNamedModule { get; }
         public string WeakNamedModuleDirectory { get; }
         public string WeakNamedModuleName { get; }
+        [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Reflection.Emit.TypeBuilder DefineType(bool inSignedModulePreferably, string name, System.Reflection.TypeAttributes flags) { }
         [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Type GetFromCache(Castle.DynamicProxy.Generators.CacheKey key) { }

--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -2694,6 +2694,7 @@ namespace Castle.DynamicProxy
         public System.Reflection.Emit.ModuleBuilder WeakNamedModule { get; }
         public string WeakNamedModuleDirectory { get; }
         public string WeakNamedModuleName { get; }
+        [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Reflection.Emit.TypeBuilder DefineType(bool inSignedModulePreferably, string name, System.Reflection.TypeAttributes flags) { }
         [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Type GetFromCache(Castle.DynamicProxy.Generators.CacheKey key) { }

--- a/ref/Castle.Core-netstandard1.3.cs
+++ b/ref/Castle.Core-netstandard1.3.cs
@@ -1543,6 +1543,7 @@ namespace Castle.DynamicProxy
         public string StrongNamedModuleName { get; }
         public System.Reflection.Emit.ModuleBuilder WeakNamedModule { get; }
         public string WeakNamedModuleName { get; }
+        [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Reflection.Emit.TypeBuilder DefineType(bool inSignedModulePreferably, string name, System.Reflection.TypeAttributes flags) { }
         [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Type GetFromCache(Castle.DynamicProxy.Generators.CacheKey key) { }

--- a/ref/Castle.Core-netstandard1.5.cs
+++ b/ref/Castle.Core-netstandard1.5.cs
@@ -1543,6 +1543,7 @@ namespace Castle.DynamicProxy
         public string StrongNamedModuleName { get; }
         public System.Reflection.Emit.ModuleBuilder WeakNamedModule { get; }
         public string WeakNamedModuleName { get; }
+        [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Reflection.Emit.TypeBuilder DefineType(bool inSignedModulePreferably, string name, System.Reflection.TypeAttributes flags) { }
         [System.ObsoleteAttribute("Exposes a component that is intended for internal use only.")]
         public System.Type GetFromCache(Castle.DynamicProxy.Generators.CacheKey key) { }

--- a/src/Castle.Core/DynamicProxy/ModuleScope.cs
+++ b/src/Castle.Core/DynamicProxy/ModuleScope.cs
@@ -573,6 +573,8 @@ namespace Castle.DynamicProxy
 		}
 #endif
 
+		[Obsolete("Exposes a component that is intended for internal use only.")] // TODO: Redeclare this method as `internal`.
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public TypeBuilder DefineType(bool inSignedModulePreferably, string name, TypeAttributes flags)
 		{
 			var module = ObtainDynamicModule(disableSignedModule == false && inSignedModulePreferably);


### PR DESCRIPTION
This is in response to https://github.com/castleproject/Core/issues/399#issuecomment-411738133:

>> [@stakx:] [...] deprecating `ModuleScope.DefineType` should be fine. 
>
> [@jonorossi:] I'm definitely in favour of it, I don't like that others are emitting into the DP assembly [...].

The single known reason for using `ModuleScope.DefineType` was to allow mocking libraries to create delegate proxies, the enhancements from #436 now provide a cleaner way to do that, so we can go ahead and deprecate `ModuleScope.DefineType`.