### PR TITLE
WIP: Forward non-intercepted methods on class proxies to target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Bugfixes:
+- Forward non-intercepted methods on class proxies to target (@stakx, #450)
+
 ## 4.4.0 (2019-04-05)
 
 Enhancements:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
@@ -1,0 +1,21 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	public class HasVirtualStringAutoProperty
+	{
+		public virtual string Property { get; set; }
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
@@ -1,0 +1,41 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Reflection;
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	public class ProxySomeMethodsHook : IProxyGenerationHook
+	{
+		private readonly Func<Type, MethodInfo, bool> shouldInterceptMethod;
+
+		public ProxySomeMethodsHook(Func<Type, MethodInfo, bool> shouldInterceptMethod)
+		{
+			this.shouldInterceptMethod = shouldInterceptMethod;
+		}
+
+		public bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+		{
+			return shouldInterceptMethod(type, methodInfo);
+		}
+
+		void IProxyGenerationHook.MethodsInspected() { }
+
+		void IProxyGenerationHook.NonProxyableMemberNotification(Type type, MemberInfo memberInfo) { }
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -66,8 +66,7 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (!method.Proxyable)
 			{
-				return new MinimialisticMethodGenerator(method,
-				                                        overrideMethod);
+				return new ForwardingMethodGenerator(method, overrideMethod, (c, m) => c.GetField("__target"));
 			}
 
 			if (IsDirectlyAccessible(method) == false)

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -37,17 +37,12 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (ProxyUtil.IsAccessibleMethod(method) == false)
+			if (method.IsPublic == false || ProxyUtil.IsAccessibleMethod(method) == false)
 			{
 				return null;
 			}
 
 			var accepted = AcceptMethod(method, true, hook);
-			if (!accepted && !method.IsAbstract)
-			{
-				//we don't need to do anything...
-				return null;
-			}
 
 			return new MetaMethod(method, method, isStandalone, accepted, hasTarget: true);
 		}


### PR DESCRIPTION
This should resolve #67.

(At least as far as is possible: non-interceptable methods such as non-virtual, sealed, or private methods of course still cannot be forwarded to the proxy.)