### PR TITLE
Fix build error NETSDK1061

### DIFF
--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -57,5 +57,5 @@ echo ---------------------------
 echo Running NETCOREAPP1.1 Tests
 echo ---------------------------
 
-.\src\Castle.Core.Tests\bin\%Configuration%\netcoreapp1.1\Castle.Core.Tests.exe --result=NetCoreClrTestResults.xml;format=nunit3 || exit /b 1
-.\src\Castle.Core.Tests.WeakNamed\bin\%Configuration%\netcoreapp1.1\Castle.Core.Tests.WeakNamed.exe --result=NetCoreClrWeakNamedTestResults.xml;format=nunit3 || exit /b 1
+dotnet .\src\Castle.Core.Tests\bin\%Configuration%\netcoreapp1.1\Castle.Core.Tests.dll --result=NetCoreClrTestResults.xml;format=nunit3 || exit /b 1
+dotnet .\src\Castle.Core.Tests.WeakNamed\bin\%Configuration%\netcoreapp1.1/Castle.Core.Tests.WeakNamed.dll --result=NetCoreClrWeakNamedTestResults.xml;format=nunit3 || exit /b 1

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -10,7 +10,6 @@
 		<BuildVersionMajor>$(BuildVersion.Split('.')[0])</BuildVersionMajor>
 		<BuildVersionNoSuffix>$(BuildVersion.Split('-')[0])</BuildVersionNoSuffix>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
+++ b/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
@@ -7,13 +7,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!--This was the only way at the time of writing to $(OutputType) to honour the 'Exe' setting. This can probably be deleted from netcoreapp2.0(inclusive) onwards. Pathing dependencies: build.sh, build.cmd -->
-		<RuntimeIdentifier Condition="'$(OS)'=='Windows_NT'">win7-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='netcoreapp1.1'"></RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='net461'"></RuntimeIdentifier>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<Authors>Castle Contributors</Authors>
 		<AssemblyName>Castle.Core.Tests.WeakNamed</AssemblyName>

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -7,13 +7,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!--This was the only way at the time of writing to $(OutputType) to honour the 'Exe' setting. This can probably be deleted from netcoreapp2.0(inclusive) onwards. Pathing dependencies: build.sh, build.cmd -->
-		<RuntimeIdentifier Condition="'$(OS)'=='Windows_NT'">win7-x64</RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='netcoreapp1.1'"></RuntimeIdentifier>
-		<RuntimeIdentifier Condition="'$(OS)'=='Unix'AND'$(TargetFramework)'=='net461'"></RuntimeIdentifier>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<Authors>Castle Contributors</Authors>
 		<AssemblyName>Castle.Core.Tests</AssemblyName>


### PR DESCRIPTION
While working on #450, I noticed that the build scripts produce a new kind of error. For example, [this AppVeyor build](https://ci.appveyor.com/project/castleproject/core/builds/25956231) failed with:

> NETSDK1061: The project was restored using Microsoft.NETCore.App version 1.1.12, but with current settings, version 1.1.10 would be used instead. To resolve this issue, make sure the same settings are used for restore and for subsequent operations such as build or publish. Typically this issue can occur if the RuntimeIdentifier property is set during build or publish but not during restore. For more information, see https://aka.ms/dotnet-runtime-patch-selection.

Removing explicit `<RuntimeIdentifier>`s from the test project files appears to resolve this.