### PR TITLE
Make NUnit tests runnable in VS Test Explorer

### DIFF
--- a/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
+++ b/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
@@ -15,11 +15,14 @@
 		<AssemblyVersion>0.0.0.0</AssemblyVersion>
 		<SignAssembly>False</SignAssembly>
 		<PublicSign Condition="'$(OS)'=='Unix'">false</PublicSign>
+		<StartupObject>Program</StartupObject>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 		<PackageReference Include="NUnit" Version="3.6.1" />
 		<PackageReference Include="NUnit.Console" Version="3.6.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
 		<PackageReference Include="NUnitLite" Version="3.6.1" />
 		<PackageReference Include="log4net" Version="2.0.8" />
 		<PackageReference Include="NLog" Version="4.5.0" />

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -17,6 +17,7 @@
 		<AssemblyOriginatorKeyFile>..\..\buildscripts\CastleKey.snk</AssemblyOriginatorKeyFile>
 		<PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
 		<LangVersion>7.2</LangVersion>
+		<StartupObject>Program</StartupObject>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
@@ -38,8 +39,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 		<PackageReference Include="NUnit" Version="3.6.1" />
 		<PackageReference Include="NUnit.Console" Version="3.6.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
 		<PackageReference Include="NUnitLite" Version="3.6.1" />
 		<PackageReference Include="log4net" Version="2.0.8" />
 		<PackageReference Include="NLog" Version="4.5.0" />

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterAcceptanceTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterAcceptanceTestCase.cs
@@ -1017,47 +1017,49 @@ namespace Castle.Components.DictionaryAdapter.Xml.Tests
 				ExtraInfo = new object[] { 43, "Extra", manager }
 			};
 
-			using (var stream = new FileStream("out.xml", FileMode.Create))
+			using (var stream = new MemoryStream())
 			{
 				var serializer = new XmlSerializer(typeof(Group));
 				serializer.Serialize(stream, group);
+
 				stream.Flush();
+				stream.Position = 0;
+
+				var document = new XmlDocument();
+				document.Load(stream);
+
+				var groupRead = CreateXmlAdapter<IGroup>(null, ref document);
+				Assert.AreEqual(2, groupRead.Id);
+				Assert.IsInstanceOf<IManager>(groupRead.Owner);
+				var managerRead = (IManager)groupRead.Owner;
+				Assert.AreEqual(manager.Name, managerRead.Name);
+				Assert.AreEqual(manager.Level, managerRead.Level);
+				var employeesRead = groupRead.Employees;
+				Assert.AreEqual(2, employeesRead.Length);
+				Assert.AreEqual(employee.Name, employeesRead[0].Name);
+				Assert.AreEqual(employee.Job.Title, employeesRead[0].Job.Title);
+				Assert.AreEqual(employee.Job.Salary, employeesRead[0].Job.Salary);
+				Assert.AreEqual(employee.Metadata.Tag, employeesRead[0].Metadata.Tag);
+				CollectionAssert.AreEqual(employee.Key, employeesRead[0].Key);
+				Assert.AreEqual(manager.Name, employeesRead[1].Name);
+				Assert.IsInstanceOf<IManager>(employeesRead[1]);
+				var managerEmplRead = (IManager)employeesRead[1];
+				Assert.AreEqual(manager.Level, managerEmplRead.Level);
+				CollectionAssert.AreEqual(group.Tags, groupRead.Tags);
+				var extraInfoRead = groupRead.ExtraInfo;
+				Assert.AreEqual(3, extraInfoRead.Length);
+				Assert.AreEqual(group.ExtraInfo[0], extraInfoRead[0]);
+				Assert.AreEqual(group.ExtraInfo[1], extraInfoRead[1]);
+				Assert.IsInstanceOf<IManager>(extraInfoRead[2]);
+				var managerExtra = (IManager)extraInfoRead[2];
+				Assert.AreEqual(manager.Name, managerExtra.Name);
+				Assert.AreEqual(manager.Level, managerExtra.Level);
+
+				groupRead.Comment = "Hello World";
+				Assert.AreEqual("Hello World", groupRead.Comment);
+				var commentRead = document["Comment", "Yum"];
+				Assert.IsNull(commentRead);
 			}
-
-			var document = new XmlDocument();
-			document.Load("out.xml");
-
-			var groupRead = CreateXmlAdapter<IGroup>(null, ref document);
-			Assert.AreEqual(2, groupRead.Id);
-			Assert.IsInstanceOf<IManager>(groupRead.Owner);
-			var managerRead = (IManager)groupRead.Owner;
-			Assert.AreEqual(manager.Name, managerRead.Name);
-			Assert.AreEqual(manager.Level, managerRead.Level);
-			var employeesRead = groupRead.Employees;
-			Assert.AreEqual(2, employeesRead.Length);
-			Assert.AreEqual(employee.Name, employeesRead[0].Name);
-			Assert.AreEqual(employee.Job.Title, employeesRead[0].Job.Title);
-			Assert.AreEqual(employee.Job.Salary, employeesRead[0].Job.Salary);
-			Assert.AreEqual(employee.Metadata.Tag, employeesRead[0].Metadata.Tag);
-			CollectionAssert.AreEqual(employee.Key, employeesRead[0].Key);
-			Assert.AreEqual(manager.Name, employeesRead[1].Name);
-			Assert.IsInstanceOf<IManager>(employeesRead[1]);
-			var managerEmplRead = (IManager)employeesRead[1];
-			Assert.AreEqual(manager.Level, managerEmplRead.Level);
-			CollectionAssert.AreEqual(group.Tags, groupRead.Tags);
-			var extraInfoRead = groupRead.ExtraInfo;
-			Assert.AreEqual(3, extraInfoRead.Length);
-			Assert.AreEqual(group.ExtraInfo[0], extraInfoRead[0]);
-			Assert.AreEqual(group.ExtraInfo[1], extraInfoRead[1]);
-			Assert.IsInstanceOf<IManager>(extraInfoRead[2]);
-			var managerExtra = (IManager)extraInfoRead[2];
-			Assert.AreEqual(manager.Name, managerExtra.Name);
-			Assert.AreEqual(manager.Level, managerExtra.Level);
-
-			groupRead.Comment = "Hello World";
-			Assert.AreEqual("Hello World", groupRead.Comment);
-			var commentRead = document["Comment", "Yum"];
-			Assert.IsNull(commentRead);
 		}
 
 		[Test]
@@ -1070,20 +1072,22 @@ namespace Castle.Components.DictionaryAdapter.Xml.Tests
 				Employees = new Employee[] { null, manager }
 			};
 
-			using (var stream = new FileStream("out.xml", FileMode.Create))
+			using (var stream = new MemoryStream())
 			{
 				var serializer = new XmlSerializer(typeof(Group));
 				serializer.Serialize(stream, group);
+
 				stream.Flush();
+				stream.Position = 0;
+
+				var document = new XmlDocument();
+				document.Load(stream);
+
+				var groupRead = CreateXmlAdapter<IGroup>(null, ref document);
+				Assert.IsNull(groupRead.Owner);
+				Assert.IsNull(groupRead.ExtraInfo);
+				Assert.AreEqual(1, groupRead.Employees.Length);
 			}
-
-			var document = new XmlDocument();
-			document.Load("out.xml");
-
-			var groupRead = CreateXmlAdapter<IGroup>(null, ref document);
-			Assert.IsNull(groupRead.Owner);
-			Assert.IsNull(groupRead.ExtraInfo);
-			Assert.AreEqual(1, groupRead.Employees.Length);
 		}
 
 		[Test, Ignore("Need to opt in or out of reference tracking for this to work.")]
@@ -1114,10 +1118,13 @@ namespace Castle.Components.DictionaryAdapter.Xml.Tests
 			group.Comment = "Nothing important";
 			group.ExtraInfo = new object[] { 43, "Extra", manager };
 
-			document.Save("out.xml");
-
-			using (var stream = new FileStream("out.xml", FileMode.Open))
+			using (var stream = new MemoryStream())
 			{
+				document.Save(stream);
+
+				stream.Flush();
+				stream.Position = 0;
+
 				var serializer = new XmlSerializer(typeof(Group));
 				var groupRead = (Group)serializer.Deserialize(stream);
 
@@ -1161,10 +1168,13 @@ namespace Castle.Components.DictionaryAdapter.Xml.Tests
 			group.Owner = null;
 			group.Employees = new IEmployee[] { null, manager };
 
-			document.Save("out.xml");
-
-			using (var stream = new FileStream("out.xml", FileMode.Open))
+			using (var stream = new MemoryStream())
 			{
+				document.Save(stream);
+
+				stream.Flush();
+				stream.Position = 0;
+
 				var serializer = new XmlSerializer(typeof(Group));
 				var groupRead = (Group)serializer.Deserialize(stream);
 				Assert.IsNull(groupRead.Owner);

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributeInfoTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributeInfoTestCase.cs
@@ -174,9 +174,9 @@ namespace Castle.DynamicProxy.Tests
 		[Test]
 		[TestCaseSource("FromExpressionTestCases")]
 		public void FromExpression_Creates_Same_CustomAttributeInfo_As_Calling_The_Constructor(
-			Expression<Func<Attribute>> expr, CustomAttributeInfo expected)
+			Opaque<Expression<Func<Attribute>>> expr, CustomAttributeInfo expected)
 		{
-			var actual = CustomAttributeInfo.FromExpression(expr);
+			var actual = CustomAttributeInfo.FromExpression(expr.Value);
 			Assert.AreEqual(expected, actual);
 		}
 
@@ -227,7 +227,29 @@ namespace Castle.DynamicProxy.Tests
 
 		private static object[] CreateFromExpressionTestCase(Expression<Func<Attribute>> expr, CustomAttributeInfo expected)
 		{
-			return new object[] { expr, expected };
+			return new object[] { new Opaque<Expression<Func<Attribute>>>(expr), expected };
+		}
+
+		// NOTE: The following type is needed as a workaround for an issue with either NUnit 3's test adapter,
+		// or Visual Studio's test executor: One of them appears to be unable to parse formatted LINQ expression
+		// trees. Therefore, we need to wrap those in a dummy type to prevent formatting. This will change how
+		// the individual test cases are displayed/identified in Test Explorer.
+		//
+		// See https://developercommunity.visualstudio.com/content/problem/663145/test-explorer-in-vs-1620-can-no-longer-run-certain.html.
+
+		public struct Opaque<T>
+		{
+			public readonly T Value;
+
+			public Opaque(T value)
+			{
+				Value = value;
+			}
+
+			public override string ToString()
+			{
+				return Value.GetType().ToString();
+			}
 		}
 	}
 }


### PR DESCRIPTION
While the test projects can simply be started to run the tests (thanks to NUnitLite), tests cannot be run in VS Test Explorer, which could be handy especially when one wants to run only a subset of all tests.
Currently, doing that requires one to set a `--test=...` command-line argument in the test project settings.)

This commit adds the packages required to run our tests in VS Test Explorer.