### PR TITLE
Fix culture-dependent test failures

### DIFF
--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
@@ -17,6 +17,7 @@ namespace Castle.Components.DictionaryAdapter.Tests
 	using System;
 	using System.Collections;
 	using System.Collections.Generic;
+	using System.Globalization;
 	using System.Linq;
 	using System.Reflection;
 
@@ -433,28 +434,32 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.AreEqual(guid, conversions.Guid);
 		}
 
-		[Test]
-		public void UpdateAdapter_WithDefaultConversions_WorksFine()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void UpdateAdapter_WithDefaultConversions_WorksFine(bool useInvariantCulture)
 		{
-			var today = DateTime.Today;
-			var guid = Guid.NewGuid();
+			UsingCulture(useInvariantCulture ? CultureInfo.InvariantCulture : new CultureInfo("en-US"), () =>
+			{
+				var today = DateTime.Today;
+				var guid = Guid.NewGuid();
 
-			var conversions = factory.GetAdapter<IConversionsToString>(dictionary);
-			conversions.Int = 22;
-			conversions.Float = 98.6F;
-			conversions.Double = 3.14;
-			conversions.Decimal = 100;
-			conversions.DateTime = today;
-			conversions.Guid = guid;
-			conversions.Phone = new Phone("2124751012", "22");
+				var conversions = factory.GetAdapter<IConversionsToString>(dictionary);
+				conversions.Int = 22;
+				conversions.Float = 98.6F;
+				conversions.Double = 3.14;
+				conversions.Decimal = 100;
+				conversions.DateTime = today;
+				conversions.Guid = guid;
+				conversions.Phone = new Phone("2124751012", "22");
 
-			Assert.AreEqual(string.Format("{0}", 22), dictionary["Int"]);
-			Assert.AreEqual(string.Format("{0}", 98.6), dictionary["Float"]);
-			Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["Double"]);
-			Assert.AreEqual(string.Format("{0}", 100M), dictionary["Decimal"]);
-			Assert.AreEqual(today.ToString("d"), dictionary["DateTime"]);
-			Assert.AreEqual(guid.ToString(), dictionary["Guid"]);
-			Assert.AreEqual("2124751012,22", dictionary["Phone"]);
+				Assert.AreEqual(string.Format("{0}", 22), dictionary["Int"]);
+				Assert.AreEqual(string.Format("{0}", 98.6), dictionary["Float"]);
+				Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["Double"]);
+				Assert.AreEqual(string.Format("{0}", 100M), dictionary["Decimal"]);
+				Assert.AreEqual(today.ToString("d"), dictionary["DateTime"]);
+				Assert.AreEqual(guid.ToString(), dictionary["Guid"]);
+				Assert.AreEqual("2124751012,22", dictionary["Phone"]);
+			});
 		}
 
 		[Test]
@@ -479,26 +484,30 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.AreEqual(guid, conversions.NullGuid);
 		}
 
-		[Test]
-		public void UpdateAdapter_WithDefaultNullableConversions_WorksFine()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void UpdateAdapter_WithDefaultNullableConversions_WorksFine(bool useInvariantCulture)
 		{
-			DateTime? today = DateTime.Today;
-			Guid? guid = Guid.NewGuid();
+			UsingCulture(useInvariantCulture ? CultureInfo.InvariantCulture : new CultureInfo("en-US"), () =>
+			{
+				DateTime? today = DateTime.Today;
+				Guid? guid = Guid.NewGuid();
 
-			var conversions = factory.GetAdapter<IConversionsToString>(dictionary);
-			conversions.NullInt = 22;
-			conversions.NullFloat = 98.6F;
-			conversions.NullDouble = 3.14;
-			conversions.NullDecimal = 100;
-			conversions.NullDateTime = today;
-			conversions.NullGuid = guid;
+				var conversions = factory.GetAdapter<IConversionsToString>(dictionary);
+				conversions.NullInt = 22;
+				conversions.NullFloat = 98.6F;
+				conversions.NullDouble = 3.14;
+				conversions.NullDecimal = 100;
+				conversions.NullDateTime = today;
+				conversions.NullGuid = guid;
 
-			Assert.AreEqual(string.Format("{0}", 22), dictionary["NullInt"]);
-			Assert.AreEqual(string.Format("{0}", 98.6), dictionary["NullFloat"]);
-			Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["NullDouble"]);
-			Assert.AreEqual(string.Format("{0}", 100M), dictionary["NullDecimal"]);
-			Assert.AreEqual(today.Value.ToString("d"), dictionary["NullDateTime"]);
-			Assert.AreEqual(guid.ToString(), dictionary["NullGuid"]);
+				Assert.AreEqual(string.Format("{0}", 22), dictionary["NullInt"]);
+				Assert.AreEqual(string.Format("{0}", 98.6), dictionary["NullFloat"]);
+				Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["NullDouble"]);
+				Assert.AreEqual(string.Format("{0}", 100M), dictionary["NullDecimal"]);
+				Assert.AreEqual(today.Value.ToString("d"), dictionary["NullDateTime"]);
+				Assert.AreEqual(guid.ToString(), dictionary["NullGuid"]);
+			});
 		}
 
 		[Test]
@@ -1509,6 +1518,20 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.IsTrue(dictionary.Contains("NullableValue"));
 			empty.NullableValue = null;
 			Assert.IsFalse(dictionary.Contains("NullableValue"));
+		}
+
+		private void UsingCulture(CultureInfo culture, Action action)
+		{
+			CultureInfo originalCulture = CultureInfo.CurrentCulture;
+			CultureInfo.CurrentCulture = culture;
+			try
+			{
+				action.Invoke();
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = originalCulture;
+			}
 		}
 	}
 }

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
@@ -434,11 +434,10 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.AreEqual(guid, conversions.Guid);
 		}
 
-		[TestCase(false)]
-		[TestCase(true)]
-		public void UpdateAdapter_WithDefaultConversions_WorksFine(bool useInvariantCulture)
+		[Test]
+		public void UpdateAdapter_WithDefaultConversions_WorksFine()
 		{
-			UsingCulture(useInvariantCulture ? CultureInfo.InvariantCulture : new CultureInfo("en-US"), () =>
+			UsingCulture(CultureInfo.InvariantCulture, () =>
 			{
 				var today = DateTime.Today;
 				var guid = Guid.NewGuid();
@@ -456,7 +455,7 @@ namespace Castle.Components.DictionaryAdapter.Tests
 				Assert.AreEqual(string.Format("{0}", 98.6), dictionary["Float"]);
 				Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["Double"]);
 				Assert.AreEqual(string.Format("{0}", 100M), dictionary["Decimal"]);
-				Assert.AreEqual(today.ToString("d"), dictionary["DateTime"]);
+				Assert.AreEqual(today.ToString("yyyy-MM-dd"), dictionary["DateTime"]);
 				Assert.AreEqual(guid.ToString(), dictionary["Guid"]);
 				Assert.AreEqual("2124751012,22", dictionary["Phone"]);
 			});
@@ -484,11 +483,10 @@ namespace Castle.Components.DictionaryAdapter.Tests
 			Assert.AreEqual(guid, conversions.NullGuid);
 		}
 
-		[TestCase(false)]
-		[TestCase(true)]
-		public void UpdateAdapter_WithDefaultNullableConversions_WorksFine(bool useInvariantCulture)
+		[Test]
+		public void UpdateAdapter_WithDefaultNullableConversions_WorksFine()
 		{
-			UsingCulture(useInvariantCulture ? CultureInfo.InvariantCulture : new CultureInfo("en-US"), () =>
+			UsingCulture(CultureInfo.InvariantCulture, () =>
 			{
 				DateTime? today = DateTime.Today;
 				Guid? guid = Guid.NewGuid();
@@ -505,7 +503,7 @@ namespace Castle.Components.DictionaryAdapter.Tests
 				Assert.AreEqual(string.Format("{0}", 98.6), dictionary["NullFloat"]);
 				Assert.AreEqual(string.Format("{0}", 3.14D), dictionary["NullDouble"]);
 				Assert.AreEqual(string.Format("{0}", 100M), dictionary["NullDecimal"]);
-				Assert.AreEqual(today.Value.ToString("d"), dictionary["NullDateTime"]);
+				Assert.AreEqual(today.Value.ToString("yyyy-MM-dd"), dictionary["NullDateTime"]);
 				Assert.AreEqual(guid.ToString(), dictionary["NullGuid"]);
 			});
 		}


### PR DESCRIPTION
While playing around with migrating the Unix/Mono build over to AppVeyor, I stumbled on some failing tests: We have two DictionaryAdapter tests that only work when `CultureInfo.CurrentCulture` happens to be set to anything other than the invariant culture.

This PR fixes these two tests by actively setting the culture instead of relying on the environment's choice.

(Funnily enough, fixing the tests is easiest when deciding on the invariant culture, since that one is guaranteed to be available, and its precise behavior as far as the tests are concerned is documented.)