### PR TITLE
Fix annoying XML documentation warning

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -32,6 +32,7 @@ namespace Castle.DynamicProxy.Generators
 		/// </summary>
 		/// <param name = "name">The name.</param>
 		/// <param name = "declaringType">Type declaring the original event being overridden, or null.</param>
+		/// <param name = "eventDelegateType">The event delegate type.</param>
 		/// <param name = "adder">The add method.</param>
 		/// <param name = "remover">The remove method.</param>
 		/// <param name = "attributes">The attributes.</param>


### PR DESCRIPTION
> CS1573: Parameter 'eventDelegateType' has no matching param tag in the XML comment for 'MetaEvent.MetaEvent(...)' (but other parameters do)

We've probably seen that often enough by now. Let's fix it.