### PR TITLE
Rewrite some tests for better compatibility with more recent versions of NUnit

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MethodFinderTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MethodFinderTestCase.cs
@@ -26,62 +26,13 @@ namespace Castle.DynamicProxy.Tests
 	[TestFixture]
 	public class MethodFinderTestCase
 	{
-		private static void AssertArraysAreEqualUnsorted(object[] expected, object[] actual)
-		{
-			Assert.AreEqual(expected.Length, actual.Length);
-			List<object> actualAsList = new List<object>(actual);
-			foreach (object expectedElement in expected)
-			{
-				Assert.Contains(expectedElement, actualAsList);
-				actualAsList.Remove(expectedElement);
-				// need to remove the element after it has been found to guarantee that duplicate elements are handled correctly
-			}
-		}
-
-		[Test]
-		public void AssertArrayAreEqualUnsorted()
-		{
-			AssertArraysAreEqualUnsorted(new object[0], new object[0]);
-			AssertArraysAreEqualUnsorted(new object[] { null }, new object[] { null });
-			AssertArraysAreEqualUnsorted(new object[] { null, "one", null }, new object[] { null, null, "one" });
-			AssertArraysAreEqualUnsorted(new object[] { null, "one", null }, new object[] { "one", null, null });
-
-			try
-			{
-				AssertArraysAreEqualUnsorted(new object[] { null, "one", null }, new object[] { "one", "one", null });
-				Assert.Fail();
-			}
-			catch (AssertionException)
-			{
-				// ok
-			}
-			try
-			{
-				AssertArraysAreEqualUnsorted(new object[] { null, "one" }, new object[] { "one", null, null });
-				Assert.Fail();
-			}
-			catch (AssertionException)
-			{
-				// ok
-			}
-			try
-			{
-				AssertArraysAreEqualUnsorted(new object[] { null, "one", null }, new object[] { "one", null });
-				Assert.Fail();
-			}
-			catch (AssertionException)
-			{
-				// ok
-			}
-		}
-
 		[Test]
 		public void GetMethodsForPublic()
 		{
 			MethodInfo[] methods =
 				MethodFinder.GetAllInstanceMethods(typeof(object), BindingFlags.Instance | BindingFlags.Public);
 			MethodInfo[] realMethods = typeof(object).GetMethods(BindingFlags.Instance | BindingFlags.Public);
-			AssertArraysAreEqualUnsorted(realMethods, methods);
+			CollectionAssert.AreEquivalent(realMethods, methods);
 		}
 
 		[Test]
@@ -90,7 +41,7 @@ namespace Castle.DynamicProxy.Tests
 			MethodInfo[] methods =
 				MethodFinder.GetAllInstanceMethods(typeof(object), BindingFlags.Instance | BindingFlags.NonPublic);
 			MethodInfo[] realMethods = typeof(object).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic);
-			AssertArraysAreEqualUnsorted(realMethods, methods);
+			CollectionAssert.AreEquivalent(realMethods, methods);
 		}
 
 		[Test]
@@ -101,7 +52,7 @@ namespace Castle.DynamicProxy.Tests
 												   BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 			MethodInfo[] realMethods =
 				typeof(object).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-			AssertArraysAreEqualUnsorted(realMethods, methods);
+			CollectionAssert.AreEquivalent(realMethods, methods);
 		}
 
 		[Test]


### PR DESCRIPTION
I updated NUnit out of curiosity to the latest version and noticed one test breaking (see commit message for details).

<details>
<summary>Expand to see the test failure message.</summary>

Taken from [this previous AppVeyor build log](https://ci.appveyor.com/project/castleproject/core/builds/26286007/job/nonifj1x5eewp93r#L1686):

> ```
> 1-1) Failed : Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted
>   Expected: some item equal to null
>   But was:  < "one" >
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArraysAreEqualUnsorted(Object[] expected, Object[] actual) in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 36
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted() in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 52
> 1-2) Failed : Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted
>   Expected: 2
>   But was:  3
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArraysAreEqualUnsorted(Object[] expected, Object[] actual) in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 32
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted() in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 61
> 1-3) Failed : Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted
>   Expected: 3
>   But was:  2
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArraysAreEqualUnsorted(Object[] expected, Object[] actual) in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 32
>    at Castle.DynamicProxy.Tests.MethodFinderTestCase.AssertArrayAreEqualUnsorted() in C:\projects\core\src\Castle.Core.Tests\DynamicProxy.Tests\MethodFinderTestCase.cs:line 70
> ```
</details>

While I would prefer not to update NUnit just now (as this might have other side effects I haven't looked into yet), it cannot hurt to fix this test now, such that it won't cause us trouble in the future.