### PR TITLE
Upgrade PublicApiGenerator to 9.3.0

### DIFF
--- a/ref/Castle.Core-net35.cs
+++ b/ref/Castle.Core-net35.cs
@@ -142,7 +142,7 @@ namespace Castle.Components.DictionaryAdapter
         public virtual object GetProperty(string propertyName, bool ifExists) { }
         public T GetPropertyOfType<T>(string propertyName) { }
         protected void Initialize() { }
-        protected internal void Invalidate() { }
+        protected void Invalidate() { }
         protected void NotifyPropertyChanged(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
         protected void NotifyPropertyChanged(string propertyName) { }
         protected bool NotifyPropertyChanging(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
@@ -420,7 +420,7 @@ namespace Castle.Components.DictionaryAdapter
     }
     public interface IDictionaryCopyStrategy
     {
-        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<, > selector);
+        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<Castle.Components.DictionaryAdapter.PropertyDescriptor, bool> selector);
     }
     public interface IDictionaryCreate
     {
@@ -560,7 +560,7 @@ namespace Castle.Components.DictionaryAdapter
         public KeySubstitutionAttribute(string oldValue, string newValue) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}, Adapter = {Adapter}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<T>))]
     public class ListProjection<T> : Castle.Components.DictionaryAdapter.IBindingListSource, Castle.Components.DictionaryAdapter.IBindingList<T>, Castle.Components.DictionaryAdapter.ICollectionAdapterObserver<T>, Castle.Components.DictionaryAdapter.ICollectionProjection, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.ICancelAddNew, System.ComponentModel.IChangeTracking, System.ComponentModel.IEditableObject, System.ComponentModel.IRaiseItemChangedEvents, System.ComponentModel.IRevertibleChangeTracking
     {
         public ListProjection(Castle.Components.DictionaryAdapter.ICollectionAdapter<T> adapter) { }
@@ -686,7 +686,7 @@ namespace Castle.Components.DictionaryAdapter
         public Castle.Components.DictionaryAdapter.PropertyDescriptor CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor other) { }
         public string GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
         public object GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, object storedValue, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor, bool ifExists) { }
-        public static void MergeBehavior<T>(ref System.Collections.Generic.List<> dictionaryBehaviors, T behavior)
+        public static void MergeBehavior<T>(ref System.Collections.Generic.List<T> dictionaryBehaviors, T behavior)
             where T :  class, Castle.Components.DictionaryAdapter.IDictionaryBehavior { }
         public bool SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, ref object value, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
     }
@@ -3011,13 +3011,13 @@ namespace Castle.DynamicProxy.Generators
         public ClassProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type targetType) { }
         public System.Type GenerateCode(System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string name, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class ClassProxyWithTargetGenerator : Castle.DynamicProxy.Generators.BaseProxyGenerator
     {
         public ClassProxyWithTargetGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type classToProxy, System.Type[] additionalInterfacesToProxy, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         public System.Type GetGeneratedType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class CompositionInvocationTypeGenerator : Castle.DynamicProxy.Generators.InvocationTypeGenerator
     {
@@ -3046,7 +3046,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public DelegateProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type delegateType) { }
         public System.Type GetProxyType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class GeneratorException : System.Exception
     {
@@ -3094,7 +3094,7 @@ namespace Castle.DynamicProxy.Generators
         public System.Type GenerateCode(System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string typeName, System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual Castle.DynamicProxy.Contributors.InterfaceProxyWithoutTargetContributor GetContributorForAdditionalInterfaces(Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual System.Type Init(string typeName, out Castle.DynamicProxy.Generators.Emitters.ClassEmitter emitter, System.Type proxyTargetType, out Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference interceptorsField, System.Collections.Generic.IEnumerable<System.Type> interfaces) { }
     }
     public class InterfaceProxyWithTargetInterfaceGenerator : Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator
@@ -3218,7 +3218,7 @@ namespace Castle.DynamicProxy.Generators
         public Castle.DynamicProxy.Generators.INamingScope SafeSubScope() { }
     }
     public class TypeElementCollection<TElement> : System.Collections.Generic.ICollection<TElement>, System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
-        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<>
+        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<TElement>
     {
         public TypeElementCollection() { }
         public int Count { get; }
@@ -3300,7 +3300,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     }
     public class ConstructorEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
+        protected ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.ConstructorCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.ConstructorBuilder ConstructorBuilder { get; }
         public System.Reflection.MemberInfo Member { get; }
@@ -3348,7 +3348,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     [System.Diagnostics.DebuggerDisplayAttribute("{builder.Name}")]
     public class MethodEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
+        protected MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.ArgumentReference[] Arguments { get; }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.MethodCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] GenericTypeParams { get; }

--- a/ref/Castle.Core-net40.cs
+++ b/ref/Castle.Core-net40.cs
@@ -144,7 +144,7 @@ namespace Castle.Components.DictionaryAdapter
         public virtual object GetProperty(string propertyName, bool ifExists) { }
         public T GetPropertyOfType<T>(string propertyName) { }
         protected void Initialize() { }
-        protected internal void Invalidate() { }
+        protected void Invalidate() { }
         protected void NotifyPropertyChanged(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
         protected void NotifyPropertyChanged(string propertyName) { }
         protected bool NotifyPropertyChanging(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
@@ -429,7 +429,7 @@ namespace Castle.Components.DictionaryAdapter
     }
     public interface IDictionaryCopyStrategy
     {
-        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<, > selector);
+        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<Castle.Components.DictionaryAdapter.PropertyDescriptor, bool> selector);
     }
     public interface IDictionaryCreate
     {
@@ -569,7 +569,7 @@ namespace Castle.Components.DictionaryAdapter
         public KeySubstitutionAttribute(string oldValue, string newValue) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}, Adapter = {Adapter}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<T>))]
     public class ListProjection<T> : Castle.Components.DictionaryAdapter.IBindingListSource, Castle.Components.DictionaryAdapter.IBindingList<T>, Castle.Components.DictionaryAdapter.ICollectionAdapterObserver<T>, Castle.Components.DictionaryAdapter.ICollectionProjection, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.ICancelAddNew, System.ComponentModel.IChangeTracking, System.ComponentModel.IEditableObject, System.ComponentModel.IRaiseItemChangedEvents, System.ComponentModel.IRevertibleChangeTracking
     {
         public ListProjection(Castle.Components.DictionaryAdapter.ICollectionAdapter<T> adapter) { }
@@ -695,7 +695,7 @@ namespace Castle.Components.DictionaryAdapter
         public Castle.Components.DictionaryAdapter.PropertyDescriptor CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor other) { }
         public string GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
         public object GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, object storedValue, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor, bool ifExists) { }
-        public static void MergeBehavior<T>(ref System.Collections.Generic.List<> dictionaryBehaviors, T behavior)
+        public static void MergeBehavior<T>(ref System.Collections.Generic.List<T> dictionaryBehaviors, T behavior)
             where T :  class, Castle.Components.DictionaryAdapter.IDictionaryBehavior { }
         public bool SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, ref object value, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
     }
@@ -3060,13 +3060,13 @@ namespace Castle.DynamicProxy.Generators
         public ClassProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type targetType) { }
         public System.Type GenerateCode(System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string name, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class ClassProxyWithTargetGenerator : Castle.DynamicProxy.Generators.BaseProxyGenerator
     {
         public ClassProxyWithTargetGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type classToProxy, System.Type[] additionalInterfacesToProxy, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         public System.Type GetGeneratedType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class CompositionInvocationTypeGenerator : Castle.DynamicProxy.Generators.InvocationTypeGenerator
     {
@@ -3095,7 +3095,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public DelegateProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type delegateType) { }
         public System.Type GetProxyType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class GeneratorException : System.Exception
     {
@@ -3143,7 +3143,7 @@ namespace Castle.DynamicProxy.Generators
         public System.Type GenerateCode(System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string typeName, System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual Castle.DynamicProxy.Contributors.InterfaceProxyWithoutTargetContributor GetContributorForAdditionalInterfaces(Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual System.Type Init(string typeName, out Castle.DynamicProxy.Generators.Emitters.ClassEmitter emitter, System.Type proxyTargetType, out Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference interceptorsField, System.Collections.Generic.IEnumerable<System.Type> interfaces) { }
     }
     public class InterfaceProxyWithTargetInterfaceGenerator : Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator
@@ -3267,7 +3267,7 @@ namespace Castle.DynamicProxy.Generators
         public Castle.DynamicProxy.Generators.INamingScope SafeSubScope() { }
     }
     public class TypeElementCollection<TElement> : System.Collections.Generic.ICollection<TElement>, System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
-        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<>
+        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<TElement>
     {
         public TypeElementCollection() { }
         public int Count { get; }
@@ -3349,7 +3349,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     }
     public class ConstructorEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
+        protected ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.ConstructorCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.ConstructorBuilder ConstructorBuilder { get; }
         public System.Reflection.MemberInfo Member { get; }
@@ -3397,7 +3397,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     [System.Diagnostics.DebuggerDisplayAttribute("{builder.Name}")]
     public class MethodEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
+        protected MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.ArgumentReference[] Arguments { get; }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.MethodCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] GenericTypeParams { get; }

--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -144,7 +144,7 @@ namespace Castle.Components.DictionaryAdapter
         public virtual object GetProperty(string propertyName, bool ifExists) { }
         public T GetPropertyOfType<T>(string propertyName) { }
         protected void Initialize() { }
-        protected internal void Invalidate() { }
+        protected void Invalidate() { }
         protected void NotifyPropertyChanged(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
         protected void NotifyPropertyChanged(string propertyName) { }
         protected bool NotifyPropertyChanging(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
@@ -429,7 +429,7 @@ namespace Castle.Components.DictionaryAdapter
     }
     public interface IDictionaryCopyStrategy
     {
-        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<, > selector);
+        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<Castle.Components.DictionaryAdapter.PropertyDescriptor, bool> selector);
     }
     public interface IDictionaryCreate
     {
@@ -569,7 +569,7 @@ namespace Castle.Components.DictionaryAdapter
         public KeySubstitutionAttribute(string oldValue, string newValue) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}, Adapter = {Adapter}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<T>))]
     public class ListProjection<T> : Castle.Components.DictionaryAdapter.IBindingListSource, Castle.Components.DictionaryAdapter.IBindingList<T>, Castle.Components.DictionaryAdapter.ICollectionAdapterObserver<T>, Castle.Components.DictionaryAdapter.ICollectionProjection, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList, System.ComponentModel.ICancelAddNew, System.ComponentModel.IChangeTracking, System.ComponentModel.IEditableObject, System.ComponentModel.IRaiseItemChangedEvents, System.ComponentModel.IRevertibleChangeTracking
     {
         public ListProjection(Castle.Components.DictionaryAdapter.ICollectionAdapter<T> adapter) { }
@@ -695,7 +695,7 @@ namespace Castle.Components.DictionaryAdapter
         public Castle.Components.DictionaryAdapter.PropertyDescriptor CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor other) { }
         public string GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
         public object GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, object storedValue, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor, bool ifExists) { }
-        public static void MergeBehavior<T>(ref System.Collections.Generic.List<> dictionaryBehaviors, T behavior)
+        public static void MergeBehavior<T>(ref System.Collections.Generic.List<T> dictionaryBehaviors, T behavior)
             where T :  class, Castle.Components.DictionaryAdapter.IDictionaryBehavior { }
         public bool SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, ref object value, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
     }
@@ -3060,13 +3060,13 @@ namespace Castle.DynamicProxy.Generators
         public ClassProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type targetType) { }
         public System.Type GenerateCode(System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string name, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class ClassProxyWithTargetGenerator : Castle.DynamicProxy.Generators.BaseProxyGenerator
     {
         public ClassProxyWithTargetGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type classToProxy, System.Type[] additionalInterfacesToProxy, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         public System.Type GetGeneratedType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class CompositionInvocationTypeGenerator : Castle.DynamicProxy.Generators.InvocationTypeGenerator
     {
@@ -3095,7 +3095,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public DelegateProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type delegateType) { }
         public System.Type GetProxyType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class GeneratorException : System.Exception
     {
@@ -3143,7 +3143,7 @@ namespace Castle.DynamicProxy.Generators
         public System.Type GenerateCode(System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string typeName, System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual Castle.DynamicProxy.Contributors.InterfaceProxyWithoutTargetContributor GetContributorForAdditionalInterfaces(Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual System.Type Init(string typeName, out Castle.DynamicProxy.Generators.Emitters.ClassEmitter emitter, System.Type proxyTargetType, out Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference interceptorsField, System.Collections.Generic.IEnumerable<System.Type> interfaces) { }
     }
     public class InterfaceProxyWithTargetInterfaceGenerator : Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator
@@ -3267,7 +3267,7 @@ namespace Castle.DynamicProxy.Generators
         public Castle.DynamicProxy.Generators.INamingScope SafeSubScope() { }
     }
     public class TypeElementCollection<TElement> : System.Collections.Generic.ICollection<TElement>, System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
-        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<>
+        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<TElement>
     {
         public TypeElementCollection() { }
         public int Count { get; }
@@ -3349,7 +3349,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     }
     public class ConstructorEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
+        protected ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.ConstructorCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.ConstructorBuilder ConstructorBuilder { get; }
         public System.Reflection.MemberInfo Member { get; }
@@ -3397,7 +3397,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     [System.Diagnostics.DebuggerDisplayAttribute("{builder.Name}")]
     public class MethodEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
+        protected MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.ArgumentReference[] Arguments { get; }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.MethodCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] GenericTypeParams { get; }

--- a/ref/Castle.Core-netstandard1.3.cs
+++ b/ref/Castle.Core-netstandard1.3.cs
@@ -106,7 +106,7 @@ namespace Castle.Components.DictionaryAdapter
         public virtual object GetProperty(string propertyName, bool ifExists) { }
         public T GetPropertyOfType<T>(string propertyName) { }
         protected void Initialize() { }
-        protected internal void Invalidate() { }
+        protected void Invalidate() { }
         protected void NotifyPropertyChanged(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
         protected void NotifyPropertyChanged(string propertyName) { }
         protected bool NotifyPropertyChanging(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
@@ -367,7 +367,7 @@ namespace Castle.Components.DictionaryAdapter
     }
     public interface IDictionaryCopyStrategy
     {
-        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<, > selector);
+        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<Castle.Components.DictionaryAdapter.PropertyDescriptor, bool> selector);
     }
     public interface IDictionaryCreate
     {
@@ -507,7 +507,7 @@ namespace Castle.Components.DictionaryAdapter
         public KeySubstitutionAttribute(string oldValue, string newValue) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}, Adapter = {Adapter}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<T>))]
     public class ListProjection<T> : Castle.Components.DictionaryAdapter.IBindingList<T>, Castle.Components.DictionaryAdapter.ICollectionAdapterObserver<T>, Castle.Components.DictionaryAdapter.ICollectionProjection, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IChangeTracking, System.ComponentModel.IEditableObject, System.ComponentModel.IRevertibleChangeTracking
     {
         public ListProjection(Castle.Components.DictionaryAdapter.ICollectionAdapter<T> adapter) { }
@@ -638,7 +638,7 @@ namespace Castle.Components.DictionaryAdapter
         public Castle.Components.DictionaryAdapter.PropertyDescriptor CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor other) { }
         public string GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
         public object GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, object storedValue, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor, bool ifExists) { }
-        public static void MergeBehavior<T>(ref System.Collections.Generic.List<> dictionaryBehaviors, T behavior)
+        public static void MergeBehavior<T>(ref System.Collections.Generic.List<T> dictionaryBehaviors, T behavior)
             where T :  class, Castle.Components.DictionaryAdapter.IDictionaryBehavior { }
         public bool SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, ref object value, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
     }
@@ -1891,13 +1891,13 @@ namespace Castle.DynamicProxy.Generators
         public ClassProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type targetType) { }
         public System.Type GenerateCode(System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string name, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class ClassProxyWithTargetGenerator : Castle.DynamicProxy.Generators.BaseProxyGenerator
     {
         public ClassProxyWithTargetGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type classToProxy, System.Type[] additionalInterfacesToProxy, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         public System.Type GetGeneratedType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class CompositionInvocationTypeGenerator : Castle.DynamicProxy.Generators.InvocationTypeGenerator
     {
@@ -1926,7 +1926,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public DelegateProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type delegateType) { }
         public System.Type GetProxyType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class GeneratorException : System.Exception
     {
@@ -1972,7 +1972,7 @@ namespace Castle.DynamicProxy.Generators
         public System.Type GenerateCode(System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string typeName, System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual Castle.DynamicProxy.Contributors.InterfaceProxyWithoutTargetContributor GetContributorForAdditionalInterfaces(Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual System.Type Init(string typeName, out Castle.DynamicProxy.Generators.Emitters.ClassEmitter emitter, System.Type proxyTargetType, out Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference interceptorsField, System.Collections.Generic.IEnumerable<System.Type> interfaces) { }
     }
     public class InterfaceProxyWithTargetInterfaceGenerator : Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator
@@ -2096,7 +2096,7 @@ namespace Castle.DynamicProxy.Generators
         public Castle.DynamicProxy.Generators.INamingScope SafeSubScope() { }
     }
     public class TypeElementCollection<TElement> : System.Collections.Generic.ICollection<TElement>, System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
-        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<>
+        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<TElement>
     {
         public TypeElementCollection() { }
         public int Count { get; }
@@ -2178,7 +2178,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     }
     public class ConstructorEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
+        protected ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.ConstructorCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.ConstructorBuilder ConstructorBuilder { get; }
         public System.Reflection.MemberInfo Member { get; }
@@ -2226,7 +2226,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     [System.Diagnostics.DebuggerDisplayAttribute("{builder.Name}")]
     public class MethodEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
+        protected MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.ArgumentReference[] Arguments { get; }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.MethodCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] GenericTypeParams { get; }

--- a/ref/Castle.Core-netstandard1.5.cs
+++ b/ref/Castle.Core-netstandard1.5.cs
@@ -106,7 +106,7 @@ namespace Castle.Components.DictionaryAdapter
         public virtual object GetProperty(string propertyName, bool ifExists) { }
         public T GetPropertyOfType<T>(string propertyName) { }
         protected void Initialize() { }
-        protected internal void Invalidate() { }
+        protected void Invalidate() { }
         protected void NotifyPropertyChanged(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
         protected void NotifyPropertyChanged(string propertyName) { }
         protected bool NotifyPropertyChanging(Castle.Components.DictionaryAdapter.PropertyDescriptor property, object oldValue, object newValue) { }
@@ -367,7 +367,7 @@ namespace Castle.Components.DictionaryAdapter
     }
     public interface IDictionaryCopyStrategy
     {
-        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<, > selector);
+        bool Copy(Castle.Components.DictionaryAdapter.IDictionaryAdapter source, Castle.Components.DictionaryAdapter.IDictionaryAdapter target, ref System.Func<Castle.Components.DictionaryAdapter.PropertyDescriptor, bool> selector);
     }
     public interface IDictionaryCreate
     {
@@ -507,7 +507,7 @@ namespace Castle.Components.DictionaryAdapter
         public KeySubstitutionAttribute(string oldValue, string newValue) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Count = {Count}, Adapter = {Adapter}")]
-    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<>))]
+    [System.Diagnostics.DebuggerTypeProxyAttribute(typeof(Castle.Components.DictionaryAdapter.ListProjectionDebugView<T>))]
     public class ListProjection<T> : Castle.Components.DictionaryAdapter.IBindingList<T>, Castle.Components.DictionaryAdapter.ICollectionAdapterObserver<T>, Castle.Components.DictionaryAdapter.ICollectionProjection, System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IChangeTracking, System.ComponentModel.IEditableObject, System.ComponentModel.IRevertibleChangeTracking
     {
         public ListProjection(Castle.Components.DictionaryAdapter.ICollectionAdapter<T> adapter) { }
@@ -638,7 +638,7 @@ namespace Castle.Components.DictionaryAdapter
         public Castle.Components.DictionaryAdapter.PropertyDescriptor CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor other) { }
         public string GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
         public object GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, object storedValue, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor, bool ifExists) { }
-        public static void MergeBehavior<T>(ref System.Collections.Generic.List<> dictionaryBehaviors, T behavior)
+        public static void MergeBehavior<T>(ref System.Collections.Generic.List<T> dictionaryBehaviors, T behavior)
             where T :  class, Castle.Components.DictionaryAdapter.IDictionaryBehavior { }
         public bool SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter dictionaryAdapter, string key, ref object value, Castle.Components.DictionaryAdapter.PropertyDescriptor descriptor) { }
     }
@@ -1891,13 +1891,13 @@ namespace Castle.DynamicProxy.Generators
         public ClassProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type targetType) { }
         public System.Type GenerateCode(System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string name, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class ClassProxyWithTargetGenerator : Castle.DynamicProxy.Generators.BaseProxyGenerator
     {
         public ClassProxyWithTargetGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type classToProxy, System.Type[] additionalInterfacesToProxy, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         public System.Type GetGeneratedType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class CompositionInvocationTypeGenerator : Castle.DynamicProxy.Generators.InvocationTypeGenerator
     {
@@ -1926,7 +1926,7 @@ namespace Castle.DynamicProxy.Generators
     {
         public DelegateProxyGenerator(Castle.DynamicProxy.ModuleScope scope, System.Type delegateType) { }
         public System.Type GetProxyType() { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
     }
     public class GeneratorException : System.Exception
     {
@@ -1972,7 +1972,7 @@ namespace Castle.DynamicProxy.Generators
         public System.Type GenerateCode(System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.ProxyGenerationOptions options) { }
         protected virtual System.Type GenerateType(string typeName, System.Type proxyTargetType, System.Type[] interfaces, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual Castle.DynamicProxy.Contributors.InterfaceProxyWithoutTargetContributor GetContributorForAdditionalInterfaces(Castle.DynamicProxy.Generators.INamingScope namingScope) { }
-        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
+        protected virtual System.Collections.Generic.IEnumerable<System.Type> GetTypeImplementerMapping(System.Type[] interfaces, System.Type proxyTargetType, out System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Contributors.ITypeContributor> contributors, Castle.DynamicProxy.Generators.INamingScope namingScope) { }
         protected virtual System.Type Init(string typeName, out Castle.DynamicProxy.Generators.Emitters.ClassEmitter emitter, System.Type proxyTargetType, out Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference interceptorsField, System.Collections.Generic.IEnumerable<System.Type> interfaces) { }
     }
     public class InterfaceProxyWithTargetInterfaceGenerator : Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator
@@ -2096,7 +2096,7 @@ namespace Castle.DynamicProxy.Generators
         public Castle.DynamicProxy.Generators.INamingScope SafeSubScope() { }
     }
     public class TypeElementCollection<TElement> : System.Collections.Generic.ICollection<TElement>, System.Collections.Generic.IEnumerable<TElement>, System.Collections.IEnumerable
-        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<>
+        where TElement : Castle.DynamicProxy.Generators.MetaTypeElement, System.IEquatable<TElement>
     {
         public TypeElementCollection() { }
         public int Count { get; }
@@ -2178,7 +2178,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     }
     public class ConstructorEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
+        protected ConstructorEmitter(Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter maintype, System.Reflection.Emit.ConstructorBuilder builder) { }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.ConstructorCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.ConstructorBuilder ConstructorBuilder { get; }
         public System.Reflection.MemberInfo Member { get; }
@@ -2226,7 +2226,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
     [System.Diagnostics.DebuggerDisplayAttribute("{builder.Name}")]
     public class MethodEmitter : Castle.DynamicProxy.Generators.Emitters.IMemberEmitter
     {
-        protected internal MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
+        protected MethodEmitter(System.Reflection.Emit.MethodBuilder builder) { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.ArgumentReference[] Arguments { get; }
         public virtual Castle.DynamicProxy.Generators.Emitters.CodeBuilders.MethodCodeBuilder CodeBuilder { get; }
         public System.Reflection.Emit.GenericTypeParameterBuilder[] GenericTypeParams { get; }

--- a/ref/Castle.Services.Logging.NLogIntegration-net35.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-net35.cs
@@ -14,7 +14,7 @@ namespace Castle.Services.Logging.NLogIntegration
     public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
     {
         public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -38,14 +38,14 @@ namespace Castle.Services.Logging.NLogIntegration
     public class NLogLogger : Castle.Core.Logging.ILogger
     {
         public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal NLog.Logger Logger { get; set; }
+        protected NLog.Logger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.NLogIntegration-net40.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-net40.cs
@@ -16,7 +16,7 @@ namespace Castle.Services.Logging.NLogIntegration
     public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
     {
         public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -40,14 +40,14 @@ namespace Castle.Services.Logging.NLogIntegration
     public class NLogLogger : Castle.Core.Logging.ILogger
     {
         public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal NLog.Logger Logger { get; set; }
+        protected NLog.Logger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.NLogIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-net45.cs
@@ -16,7 +16,7 @@ namespace Castle.Services.Logging.NLogIntegration
     public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
     {
         public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -40,14 +40,14 @@ namespace Castle.Services.Logging.NLogIntegration
     public class NLogLogger : Castle.Core.Logging.ILogger
     {
         public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal NLog.Logger Logger { get; set; }
+        protected NLog.Logger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.NLogIntegration-netstandard1.3.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-netstandard1.3.cs
@@ -15,7 +15,7 @@ namespace Castle.Services.Logging.NLogIntegration
     public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
     {
         public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -39,14 +39,14 @@ namespace Castle.Services.Logging.NLogIntegration
     public class NLogLogger : Castle.Core.Logging.ILogger
     {
         public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
-        protected internal Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
+        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal NLog.Logger Logger { get; set; }
+        protected NLog.Logger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
@@ -11,14 +11,14 @@ namespace Castle.Services.Logging.SerilogIntegration
     public class SerilogLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
     {
         public SerilogLogger(Serilog.ILogger logger, Castle.Services.Logging.SerilogIntegration.SerilogFactory factory) { }
-        protected internal Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
+        protected Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal Serilog.ILogger Logger { get; set; }
+        protected Serilog.ILogger Logger { get; set; }
         public Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
         public void Debug(string message, System.Exception exception) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.SerilogIntegration-netstandard1.3.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-netstandard1.3.cs
@@ -11,14 +11,14 @@ namespace Castle.Services.Logging.SerilogIntegration
     public class SerilogLogger : Castle.Core.Logging.ILogger
     {
         public SerilogLogger(Serilog.ILogger logger, Castle.Services.Logging.SerilogIntegration.SerilogFactory factory) { }
-        protected internal Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
+        protected Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal Serilog.ILogger Logger { get; set; }
+        protected Serilog.ILogger Logger { get; set; }
         public Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
         public void Debug(string message, System.Exception exception) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.log4netIntegration-net35.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net35.cs
@@ -15,7 +15,7 @@ namespace Castle.Services.Logging.Log4netIntegration
     {
         public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
         public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -39,14 +39,14 @@ namespace Castle.Services.Logging.Log4netIntegration
     public class Log4netLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
     {
         public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal log4net.Core.ILogger Logger { get; set; }
+        protected log4net.Core.ILogger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.log4netIntegration-net40.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net40.cs
@@ -17,7 +17,7 @@ namespace Castle.Services.Logging.Log4netIntegration
     {
         public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
         public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -41,14 +41,14 @@ namespace Castle.Services.Logging.Log4netIntegration
     public class Log4netLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
     {
         public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal log4net.Core.ILogger Logger { get; set; }
+        protected log4net.Core.ILogger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.log4netIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net45.cs
@@ -17,7 +17,7 @@ namespace Castle.Services.Logging.Log4netIntegration
     {
         public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
         public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -41,14 +41,14 @@ namespace Castle.Services.Logging.Log4netIntegration
     public class Log4netLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
     {
         public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal log4net.Core.ILogger Logger { get; set; }
+        protected log4net.Core.ILogger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/ref/Castle.Services.Logging.log4netIntegration-netstandard1.3.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-netstandard1.3.cs
@@ -16,7 +16,7 @@ namespace Castle.Services.Logging.Log4netIntegration
     {
         public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
         public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
@@ -40,14 +40,14 @@ namespace Castle.Services.Logging.Log4netIntegration
     public class Log4netLogger : Castle.Core.Logging.ILogger
     {
         public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
-        protected internal Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
+        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected internal log4net.Core.ILogger Logger { get; set; }
+        protected log4net.Core.ILogger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(string message) { }
         public void Debug(System.Func<string> messageFactory) { }

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -73,7 +73,7 @@
 		<Reference Include="Microsoft.CSharp" />
 		<Reference Include="System.Windows.Forms" />
 		<Reference Include="WindowsBase" />
-		<PackageReference Include="PublicApiGenerator" Version="9.1.0" />
+		<PackageReference Include="PublicApiGenerator" Version="9.3.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="ADODB">


### PR DESCRIPTION
- Removes internal modifiers on protected internal members
- Outputs open/closed generic type parameters for ref method parameters