### PR TITLE
Match generic type parameters by position, not by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Bugfixes:
+- Generic method with differently named generic arguments to parent throws `KeyNotFoundException` (@stakx, #106)
+
+Deprecations:
+- `Castle.DynamicProxy.Generators.Emitters.AbstractTypeEmitter.GetGenericArgumentsFor(Type)` (method)
+
 ## 4.4.0 (2019-04-05)
 
 Enhancements:

--- a/ref/Castle.Core-net35.cs
+++ b/ref/Castle.Core-net35.cs
@@ -3267,6 +3267,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
         public System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference> GetAllFields() { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference GetField(string name) { }
         public System.Type GetGenericArgument(string genericArgumentName) { }
+        [System.ObsoleteAttribute("Intended for internal use only.")]
         public System.Type[] GetGenericArgumentsFor(System.Type genericType) { }
         public System.Type[] GetGenericArgumentsFor(System.Reflection.MethodInfo genericMethod) { }
         public void SetGenericTypeParameters(System.Reflection.Emit.GenericTypeParameterBuilder[] genericTypeParameterBuilders) { }

--- a/ref/Castle.Core-net40.cs
+++ b/ref/Castle.Core-net40.cs
@@ -3316,6 +3316,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
         public System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference> GetAllFields() { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference GetField(string name) { }
         public System.Type GetGenericArgument(string genericArgumentName) { }
+        [System.ObsoleteAttribute("Intended for internal use only.")]
         public System.Type[] GetGenericArgumentsFor(System.Type genericType) { }
         public System.Type[] GetGenericArgumentsFor(System.Reflection.MethodInfo genericMethod) { }
         public void SetGenericTypeParameters(System.Reflection.Emit.GenericTypeParameterBuilder[] genericTypeParameterBuilders) { }

--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -3316,6 +3316,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
         public System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference> GetAllFields() { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference GetField(string name) { }
         public System.Type GetGenericArgument(string genericArgumentName) { }
+        [System.ObsoleteAttribute("Intended for internal use only.")]
         public System.Type[] GetGenericArgumentsFor(System.Type genericType) { }
         public System.Type[] GetGenericArgumentsFor(System.Reflection.MethodInfo genericMethod) { }
         public void SetGenericTypeParameters(System.Reflection.Emit.GenericTypeParameterBuilder[] genericTypeParameterBuilders) { }

--- a/ref/Castle.Core-netstandard1.3.cs
+++ b/ref/Castle.Core-netstandard1.3.cs
@@ -2145,6 +2145,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
         public System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference> GetAllFields() { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference GetField(string name) { }
         public System.Type GetGenericArgument(string genericArgumentName) { }
+        [System.ObsoleteAttribute("Intended for internal use only.")]
         public System.Type[] GetGenericArgumentsFor(System.Type genericType) { }
         public System.Type[] GetGenericArgumentsFor(System.Reflection.MethodInfo genericMethod) { }
         public void SetGenericTypeParameters(System.Reflection.Emit.GenericTypeParameterBuilder[] genericTypeParameterBuilders) { }

--- a/ref/Castle.Core-netstandard1.5.cs
+++ b/ref/Castle.Core-netstandard1.5.cs
@@ -2145,6 +2145,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
         public System.Collections.Generic.IEnumerable<Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference> GetAllFields() { }
         public Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference GetField(string name) { }
         public System.Type GetGenericArgument(string genericArgumentName) { }
+        [System.ObsoleteAttribute("Intended for internal use only.")]
         public System.Type[] GetGenericArgumentsFor(System.Type genericType) { }
         public System.Type[] GetGenericArgumentsFor(System.Reflection.MethodInfo genericMethod) { }
         public void SetGenericTypeParameters(System.Reflection.Emit.GenericTypeParameterBuilder[] genericTypeParameterBuilders) { }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericTypeParameterNameMismatchTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericTypeParameterNameMismatchTestCase.cs
@@ -1,0 +1,53 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+
+	using Castle.DynamicProxy.Tests.Interceptors;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class GenericTypeParameterNameMismatchTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		[TestCase(typeof(Test))]
+		[TestCase(typeof(TestVirtual))]
+		public void GenericMethodDifferentlyNamedGenericArguments(Type classType)
+		{
+			generator.CreateClassProxy(classType, new[] { typeof(ITest) }, new DoNothingInterceptor());
+		}
+
+		public interface ITest
+		{
+			void Hi<T>();
+		}
+
+		public class Test : ITest
+		{
+			public void Hi<U>()
+			{
+			}
+		}
+
+		public class TestVirtual : ITest
+		{
+			public virtual void Hi<U>()
+			{
+			}
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -279,6 +279,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			return null;
 		}
 
+		[Obsolete("Intended for internal use only.")] // TODO: Remove this method.
 		public Type[] GetGenericArgumentsFor(Type genericType)
 		{
 			var types = new List<Type>();

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
+	using System.Linq;
 	using System.Reflection;
 	using System.Reflection.Emit;
 
@@ -303,7 +304,8 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			var types = new List<Type>();
 			foreach (var genType in genericMethod.GetGenericArguments())
 			{
-				types.Add(name2GenericType[genType.Name].AsType());
+				var matchingGenType = name2GenericType.Values.Single(t => t.GenericParameterPosition == genType.GenericParameterPosition);
+				types.Add(matchingGenType.AsType());
 			}
 
 			return types.ToArray();

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -17,7 +17,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
-	using System.Linq;
 	using System.Reflection;
 	using System.Reflection.Emit;
 
@@ -304,8 +303,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			var types = new List<Type>();
 			foreach (var genType in genericMethod.GetGenericArguments())
 			{
-				var matchingGenType = name2GenericType.Values.Single(t => t.GenericParameterPosition == genType.GenericParameterPosition);
-				types.Add(matchingGenType.AsType());
+				types.Add(genericTypeParams[genType.GenericParameterPosition].AsType());
 			}
 
 			return types.ToArray();

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -102,7 +102,13 @@ namespace Castle.DynamicProxy.Internal
 		{
 			if (parameter.GetTypeInfo().IsGenericTypeDefinition)
 			{
-				return parameter.GetGenericTypeDefinition().MakeGenericType(type.GetGenericArgumentsFor(parameter));
+				// If my understanding of `.IsGenericTypeDefinition` is correct, we arrive here
+				// only if `parameter` is not a fully constructed (closed) generic type... which
+				// according to ECMA-335, section II.9.4, shouldn't be possible:
+				//
+				// "The CLI does not support partial instantiation of generic types. And generic
+				// types shall not appear uninstantiated anywhere in metadata signature blobs."
+				throw new NotSupportedException();
 			}
 
 			if (parameter.GetTypeInfo().IsGenericType)


### PR DESCRIPTION
Fixes #106.

I didn't (and still don't quite) trust this bug fix, mainly because it seems far too easy for DP standards (+-1 LoC!? 😝). However, it makes good sense to match generic type parameters by position instead of by name; in IL, for instance, generic type parameters are referred to by position (e.g. ` ``1 `). The execution environment doesn't really care about the names.

To give us some added safety, I ran a few additional checks:

* [X] I ran the Moq unit test suite (approx. 1,500 additional tests) against the updated version of DP to see whether this might cause regressions further downstream. (Doesn't look like it.)
* [X] I verified that the [original Moq issue which led to #106](https://github.com/Moq/moq4/issues/193) is fixed by this. (It is.)