### PR TITLE
Change explicit implementation method naming scheme to prevent name collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Castle Core Changelog
 
+## Unreleased
+
+Bugfixes:
+- Prevent method name collisions when a proxy type implements more than two identically named interfaces having one or more identically named methods each. Name collisions are avoided by including the declaring types' namespaces in the proxy type's method names. (@stakx, #469)
+
 ## 4.4.0 (2019-04-05)
 
 Enhancements:

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
@@ -321,6 +321,19 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", intNestedGenericBoolMethod.Name);
 		}
 
+		[Test]
+		public void Should_choose_noncolliding_member_names_when_implementing_identically_named_methods_and_types_from_different_namespaces_several_times()
+		{
+			generator.CreateInterfaceProxyWithoutTarget(
+				interfaceToProxy: typeof(Interfaces.A.ISharedName),
+				additionalInterfacesToProxy: new[]
+				{
+					typeof(Interfaces.B.ISharedName),
+					typeof(Interfaces.C.ISharedName),
+				},
+				interceptors: new StandardInterceptor());
+		}
+
 		private ParameterInfo[] GetMyTestMethodParams(Type type)
 		{
 			MethodInfo methodInfo = type.GetMethod("MyTestMethod", BindingFlags.Instance | BindingFlags.Public);

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
@@ -213,7 +213,7 @@ namespace Castle.DynamicProxy.Tests
 			MethodInfo method = type.GetMethod("Foo", BindingFlags.Instance | BindingFlags.Public);
 			Assert.IsNotNull(method);
 			Assert.AreSame(method, type.GetTypeInfo().GetRuntimeInterfaceMap(typeof(IIdenticalOne)).TargetMethods[0]);
-			MethodInfo method2 = type.GetMethod("IIdenticalTwo.Foo", BindingFlags.Instance | BindingFlags.Public);
+			MethodInfo method2 = type.GetMethod("Castle.DynamicProxy.Tests.Interfaces.IIdenticalTwo.Foo", BindingFlags.Instance | BindingFlags.Public);
 			Assert.IsNotNull(method2);
 		}
 
@@ -234,10 +234,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual("SomeMethod", boolMethod.Name);
 
 			var intMethod = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`1[Int32].SomeMethod", intMethod.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithNonGenericMethod`1[Int32].SomeMethod", intMethod.Name);
 
 			var nestedGenericBoolMethod = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`1[IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", nestedGenericBoolMethod.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithNonGenericMethod`1[IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", nestedGenericBoolMethod.Name);
 		}
 
 		[Test]
@@ -260,13 +260,13 @@ namespace Castle.DynamicProxy.Tests
 
 			var intGetter = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
 			var intSetter = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[1];
-			Assert.AreEqual("IGenericWithProperty`1[Int32].get_SomeProperty", intGetter.Name);
-			Assert.AreEqual("IGenericWithProperty`1[Int32].set_SomeProperty", intSetter.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithProperty`1[Int32].get_SomeProperty", intGetter.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithProperty`1[Int32].set_SomeProperty", intSetter.Name);
 
 			var nestedGenericBoolGetter = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
 			var nestedGenericBoolSetter = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[1];
-			Assert.AreEqual("IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].get_SomeProperty", nestedGenericBoolGetter.Name);
-			Assert.AreEqual("IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].set_SomeProperty", nestedGenericBoolSetter.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].get_SomeProperty", nestedGenericBoolGetter.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithProperty`1[IGenericWithProperty`1[Boolean]].set_SomeProperty", nestedGenericBoolSetter.Name);
 		}
 
 		[Test]
@@ -289,13 +289,13 @@ namespace Castle.DynamicProxy.Tests
 
 			var intAdder = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[0];
 			var intRemover = type.GetRuntimeInterfaceMap(intInterfaceType).TargetMethods[1];
-			Assert.AreEqual("IGenericWithEvent`1[Int32].add_SomeEvent", intAdder.Name);
-			Assert.AreEqual("IGenericWithEvent`1[Int32].remove_SomeEvent", intRemover.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithEvent`1[Int32].add_SomeEvent", intAdder.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithEvent`1[Int32].remove_SomeEvent", intRemover.Name);
 
 			var nestedGenericBoolAdder = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[0];
 			var nestedGenericBoolRemover = type.GetRuntimeInterfaceMap(nestedGenericBoolInterfaceType).TargetMethods[1];
-			Assert.AreEqual("IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].add_SomeEvent", nestedGenericBoolAdder.Name);
-			Assert.AreEqual("IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].remove_SomeEvent", nestedGenericBoolRemover.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].add_SomeEvent", nestedGenericBoolAdder.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithEvent`1[IGenericWithEvent`1[Boolean]].remove_SomeEvent", nestedGenericBoolRemover.Name);
 		}
 
 		[Test]
@@ -315,10 +315,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual("SomeMethod", boolIntMethod.Name);
 
 			var intBoolMethod = type.GetRuntimeInterfaceMap(intBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,Boolean].SomeMethod", intBoolMethod.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithNonGenericMethod`2[Int32,Boolean].SomeMethod", intBoolMethod.Name);
 
 			var intNestedGenericBoolMethod = type.GetRuntimeInterfaceMap(intNestedGenericBoolInterfaceType).TargetMethods[0];
-			Assert.AreEqual("IGenericWithNonGenericMethod`2[Int32,IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", intNestedGenericBoolMethod.Name);
+			Assert.AreEqual("Castle.DynamicProxy.Tests.Interfaces.IGenericWithNonGenericMethod`2[Int32,IGenericWithNonGenericMethod`1[Boolean]].SomeMethod", intNestedGenericBoolMethod.Name);
 		}
 
 		[Test]

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
@@ -82,6 +82,14 @@ namespace Castle.DynamicProxy.Tests
 			Assert.NotNull(implementingType.GetMethod($"{c.Namespace}.{c.Name}.M", bindingFlags));
 		}
 
+		// Verification of the BCL's representation of "no namespace" supports our implementation
+		// of the above naming scheme:
+		[Test]
+		public void Namespace_of_types_without_namespace_equals_null()
+		{
+			Assert.Null(typeof(global::IHaveNoNamespace).Namespace);
+		}
+
 		private sealed class TripleSharedName : ISharedNameFromA, ISharedNameFromB, ISharedNameFromC
 		{
 			void ISharedNameFromA.M() { }
@@ -90,3 +98,5 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 }
+
+internal interface IHaveNoNamespace { }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
@@ -1,0 +1,92 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Reflection;
+
+	using NUnit.Framework;
+
+	using ISharedNameFromA = Interfaces.A.ISharedName;
+	using ISharedNameFromB = Interfaces.B.ISharedName;
+	using ISharedNameFromC = Interfaces.C.ISharedName;
+
+	[TestFixture]
+	public class ExplicitlyImplementedMethodNamesTestCase
+	{
+		// This test does not target DynamicProxy. Rather, it codifies our assumption about
+		// how the C# compiler names explicitly implemented methods. We need to verify it
+		// because we want DynamicProxy to follow the same naming convention.
+		[Test]
+		public void Csharp_compiler_includes_namespace_and_type_name_in_names_of_explicitly_implemented_methods()
+		{
+			var b = typeof(ISharedNameFromB);
+			var c = typeof(ISharedNameFromC);
+
+			var implementingType = typeof(TripleSharedName);
+
+			AssertNamingSchemeOfExplicitlyImplementedMethods(b, c, implementingType);
+		}
+
+		[Test]
+		public void DynamicProxy_includes_namespace_and_type_name_in_names_of_explicitly_implemented_methods()
+		{
+			var a = typeof(ISharedNameFromA);
+			var b = typeof(ISharedNameFromB);
+			var c = typeof(ISharedNameFromC);
+
+			var proxy = new ProxyGenerator().CreateInterfaceProxyWithoutTarget(
+				interfaceToProxy: a,
+				additionalInterfacesToProxy: new[] { b, c },
+				interceptors: new StandardInterceptor());
+
+			var implementingType = proxy.GetType();
+
+			AssertNamingSchemeOfExplicitlyImplementedMethods(b, c, implementingType);
+		}
+
+		private void AssertNamingSchemeOfExplicitlyImplementedMethods(Type b, Type c, Type implementingType)
+		{
+			const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+			// The assertions at the end of this method only make sense if certain preconditions
+			// are met. We verify those using NUnit assumptions:
+
+			// We require two interface types that have the same name and a method named `M` each:
+			Assume.That(b.GetTypeInfo().IsInterface);
+			Assume.That(c.GetTypeInfo().IsInterface);
+			Assume.That(b.Name == c.Name);
+			Assume.That(b.GetMethod("M") != null);
+			Assume.That(c.GetMethod("M") != null);
+
+			// We also need a type that implements the above interfaces:
+			Assume.That(b.IsAssignableFrom(implementingType));
+			Assume.That(c.IsAssignableFrom(implementingType));
+
+			// If all of the above conditions are met, we expect the methods from the interfaces
+			// to be implemented explicitly. For our purposes, this means that they follow the
+			// naming scheme `<namespace>.<type>.M`:
+			Assert.NotNull(implementingType.GetMethod($"{b.Namespace}.{b.Name}.M", bindingFlags));
+			Assert.NotNull(implementingType.GetMethod($"{c.Namespace}.{c.Name}.M", bindingFlags));
+		}
+
+		private sealed class TripleSharedName : ISharedNameFromA, ISharedNameFromB, ISharedNameFromC
+		{
+			void ISharedNameFromA.M() { }
+			void ISharedNameFromB.M() { }
+			void ISharedNameFromC.M() { }
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISharedName.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISharedName.cs
@@ -1,0 +1,40 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	namespace A
+	{
+		public interface ISharedName
+		{
+			void M();
+		}
+	}
+
+	namespace B
+	{
+		public interface ISharedName
+		{
+			void M();
+		}
+	}
+
+	namespace C
+	{
+		public interface ISharedName
+		{
+			void M();
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementUtil.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators
 {
 	using System;
+	using System.Diagnostics;
 	using System.Reflection;
 	using System.Text;
 
@@ -22,13 +23,25 @@ namespace Castle.DynamicProxy.Generators
 	{
 		public static string CreateNameForExplicitImplementation(Type sourceType, string name)
 		{
+			var ns = sourceType.Namespace;
+			Debug.Assert(ns == null || ns != "");
+
 			if (sourceType.GetTypeInfo().IsGenericType)
 			{
 				var nameBuilder = new StringBuilder();
+				if (ns != null)
+				{
+					nameBuilder.Append(ns);
+					nameBuilder.Append('.');
+				}
 				nameBuilder.AppendNameOf(sourceType);
 				nameBuilder.Append('.');
 				nameBuilder.Append(name);
 				return nameBuilder.ToString();
+			}
+			else if (ns != null)
+			{
+				return string.Concat(ns, ".", sourceType.Name, ".", name);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #469.