### PR TITLE
Repro test for interface ordering issue

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
@@ -399,5 +399,17 @@ namespace Castle.DynamicProxy.Tests
 			var proxy = generator.CreateInterfaceProxyWithTarget(typeof(IService), new Type[] { typeof(IDerivedSimpleMixin) }, new ServiceImpl(), options, interceptor);
 			Assert.AreEqual(1, (proxy as ISimpleMixin).DoSomething());
 		}
+
+		[Test]
+		public void CanCreateMixinWithCaseSensitiveImplementationOrder()
+		{
+			ProxyGenerationOptions options = new ProxyGenerationOptions();
+			options.AddMixinInstance(new DomainWithMixin());
+			options.AddMixinInstance(new DomainsAs());
+
+			var proxy = generator.CreateClassProxy(typeof(MixinDomainObject), options, new object[] { "argument" });
+			Assert.IsInstanceOf(typeof(MixinDomainObject), proxy);
+			Assert.AreEqual("argument", ((MixinDomainObject)proxy).Name);
+		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SortingIssueOnMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SortingIssueOnMixin.cs
@@ -1,0 +1,52 @@
+// Copyright 2004-2010 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Mixins
+{
+	using System;
+
+	public interface IDomainWithMixin
+	{
+		void DoSomething();
+	}
+	public interface IDomainsAs
+	{
+		void DoSomethingElse();
+	}
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	public class DomainWithMixin : IDomainWithMixin
+	{
+		public void DoSomething() { }
+	}
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	public class DomainsAs : IDomainsAs
+	{
+		public void DoSomethingElse() { }
+	}
+
+	public class MixinDomainObject
+	{
+		public readonly string Name;
+		public MixinDomainObject(string name)
+		{
+			this.Name = name;
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/MixinData.cs
+++ b/src/Castle.Core/DynamicProxy/MixinData.cs
@@ -115,7 +115,7 @@ namespace Castle.DynamicProxy
 					}
 				}
 
-				sortedMixedInterfaceTypes.Sort((x, y) => x.FullName.CompareTo(y.FullName));
+				sortedMixedInterfaceTypes.Sort((x, y) => String.CompareOrdinal(x.FullName, y.FullName));
 
 				for (var i = 0; i < sortedMixedInterfaceTypes.Count; i++)
 				{


### PR DESCRIPTION
Interfaces are ordered in a case insensitive way, while fields for ctor are order in case sensitive way and cause problems when creating class proxy

Test and fix for https://github.com/castleproject/Core/issues/474