### PR TITLE
Fix proxy generation for private protected constructors

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -1,7 +1,3 @@
-//----------------------------------------------------
-// Copyright 2020 Epic Systems Corporation
-//----------------------------------------------------
-
 // Copyright 2004-2016 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -1,3 +1,7 @@
+//----------------------------------------------------
+// Copyright 2020 Epic Systems Corporation
+//----------------------------------------------------
+
 // Copyright 2004-2016 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -378,6 +382,21 @@ namespace Castle.DynamicProxy.Tests
 			object proxy = generator.CreateClassProxy<ClassWithProtectedDefaultConstructor>();
 			object proxy2 = Activator.CreateInstance(proxy.GetType());
 			Assert.AreEqual("Something", ((ClassWithProtectedDefaultConstructor)proxy2).SomeString);
+		}
+
+		[Test]
+		public void ClassProxyShouldHaveDefaultConstructorWhenBaseClassHasPrivateProtected()
+		{
+			object proxy = generator.CreateClassProxy<ClassWithPrivateProtectedConstructor>();
+			Assert.IsNotNull(Activator.CreateInstance(proxy.GetType()));
+		}
+
+		[Test]
+		public void ClassProxyShouldCallPrivateProtectedDefaultConstructor()
+		{
+			object proxy = generator.CreateClassProxy<ClassWithPrivateProtectedConstructor>();
+			object proxy2 = Activator.CreateInstance(proxy.GetType());
+			Assert.AreEqual("Something", ((ClassWithPrivateProtectedConstructor)proxy2).SomeString);
 		}
 
 		[Test]

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2020 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
@@ -1,12 +1,16 @@
-﻿//----------------------------------------------------
-// Copyright 2020 Epic Systems Corporation
-//----------------------------------------------------
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright 2004-2016 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Castle.DynamicProxy.Tests.Classes
 {

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
@@ -1,0 +1,28 @@
+﻿//----------------------------------------------------
+// Copyright 2020 Epic Systems Corporation
+//----------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	public class ClassWithPrivateProtectedConstructor
+	{
+		private protected ClassWithPrivateProtectedConstructor()
+		{
+			_someString = "Something";
+		}
+
+		private string _someString = string.Empty;
+
+		public string SomeString
+		{
+			get { return _someString; }
+			set { _someString = value; }
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -1,7 +1,3 @@
-//----------------------------------------------------
-// Copyright 2020 Epic Systems Corporation
-//----------------------------------------------------
-
 // Copyright 2004-2011 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -1,3 +1,7 @@
+//----------------------------------------------------
+// Copyright 2020 Epic Systems Corporation
+//----------------------------------------------------
+
 // Copyright 2004-2011 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -281,7 +285,7 @@ namespace Castle.DynamicProxy.Generators
 
 			foreach (var constructor in constructors)
 			{
-				if (!IsConstructorVisible(constructor))
+				if (!ProxyUtil.IsAccessibleMethod(constructor))
 				{
 					continue;
 				}
@@ -407,14 +411,6 @@ namespace Castle.DynamicProxy.Generators
 			}
 
 			return proxyType;
-		}
-
-		private bool IsConstructorVisible(ConstructorInfo constructor)
-		{
-			return constructor.IsPublic ||
-				constructor.IsFamily ||
-				constructor.IsFamilyOrAssembly ||
-				(constructor.IsAssembly && ProxyUtil.AreInternalsVisibleToDynamicProxy(constructor.DeclaringType.GetTypeInfo().Assembly));
 		}
 
 		private bool OverridesEqualsAndGetHashCode(Type type)


### PR DESCRIPTION
Previously, it would not be possible to generate a proxy of a class with just a private protected constructor. This is because BaseProxyGenerator.IsConstructorVisible() did not check for the case of MethodBase.IsFamilyAndAssembly.

Now, we remove BaseProxyGenerator.IsConstructorVisible() and replace the call to it with a call to ProxyUtil.IsAccessibleMethod(), which has identical behavior as BaseProxyGenerator.IsConstructorVisible() except that it does already correctly handle MethodBase.IsFamilyAndAssembly.