### PR TITLE
Switch to NuGet `<PackageLicenseExpression>`

### DIFF
--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -18,7 +18,7 @@
 		<FileVersion>$(BuildVersionNoSuffix)</FileVersion>
 		<VersionPrefix>$(BuildVersion)</VersionPrefix>
 		<AssemblyVersion>$(BuildVersionMajor).0.0</AssemblyVersion>
-		<PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>http://www.castleproject.org/</PackageProjectUrl>
 		<PackageIconUrl>http://www.castleproject.org/img/castle-logo.png</PackageIconUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -32,9 +32,7 @@
 
 	<ItemGroup>
 		<Content Include="..\..\CHANGELOG.md" />
-		<Content Include="..\..\LICENSE">
-			<PackagePath></PackagePath>
-		</Content>
+		<Content Include="..\..\LICENSE" Pack="True" PackagePath="" />
 		<Content Include="..\..\buildscripts\ASL - Apache Software Foundation License.txt" />
 		<Content Include="..\..\buildscripts\readme.txt" />
 	</ItemGroup>


### PR DESCRIPTION
Switching from `<PackageLicenseUrl>` to `<PackageLicenseExpression>` will take care of the build warnings we're currently getting for each built project:

> **warning NU5125:**
> The `licenseUrl` element will be deprecated. Consider using the `license` element instead.
> [`C:\projects\core\src\Castle.Core\Castle.Core.csproj`]

Using an SPDX license expression makes it easier for tools to recognise the license type of our project.

This will also affect how tools will display package metadata. For example, Visual Studio's NuGet Package Manager:

##### Before (with `<PackageLicenseUrl>`):
![image](https://user-images.githubusercontent.com/104481/82063690-151df100-96cc-11ea-9bce-5419ea5047cd.png)

##### After (with `<PackageLicenseExpression>`):
![image](https://user-images.githubusercontent.com/104481/82063678-10f1d380-96cc-11ea-9247-db57a3670e6e.png)

Also, let's keep packaging the `LICENSE` file (there's no immediate reason why we shouldn't).