### PR TITLE
Remove support for remoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enhancements:
 Deprecations:
  - Removed support for the .NET Framework < 4.5 and .NET Standard 1.x. (@stakx, #495, #496)
  - Removed support for Code Access Security (CAS). (@stakx, #502)
+ - Removed support for Remoting. This library no longer defines any types deriving from `MarshalByRefObject`, and `ProxyUtil.IsProxy` (which used to recognize remoting/"transparent" proxies) now tests only for DynamicProxy proxies. (@stakx, #507)
  - The following public members have been removed:
     - `Castle.Core.Internal.Lock` (class) along with all related types and methods
     - `Castle.Core.Internal.PermissionUtil.IsGranted` (method)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 `FEATURE_APPDOMAIN`                 | :white_check_mark: | :no_entry_sign:
 `FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_EVENTLOG`                  | :white_check_mark: | :no_entry_sign:
-`FEATURE_REMOTING`                  | :white_check_mark: | :no_entry_sign:
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_TEST_COM`                  | :white_check_mark: | :no_entry_sign:
@@ -77,7 +76,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 * `FEATURE_APPDOMAIN` - enables support for features that make use of an AppDomain in the host.
 * `FEATURE_ASSEMBLYBUILDER_SAVE` - enabled support for saving the dynamically generated proxy assembly.
 * `FEATURE_EVENTLOG` - provides a diagnostics logger using the Windows Event Log.
-* `FEATURE_REMOTING` - supports remoting on various types including inheriting from MarshalByRefObject.
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.
 * `FEATURE_TEST_COM` - enables COM Interop tests.

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -45,7 +45,7 @@
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
 		<NetStandard21Constants>TRACE</NetStandard21Constants>
-		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_REMOTING;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TEST_COM;FEATURE_TEST_WINFORMS</CommonDesktopClrConstants>
+		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TEST_COM;FEATURE_TEST_WINFORMS</CommonDesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants)</DesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants);FEATURE_TEST_PEVERIFY</DesktopClrConstants>
 	</PropertyGroup>

--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -1966,7 +1966,7 @@ namespace Castle.Core.Internal
 }
 namespace Castle.Core.Logging
 {
-    public abstract class AbstractExtendedLoggerFactory : System.MarshalByRefObject, Castle.Core.Logging.IExtendedLoggerFactory, Castle.Core.Logging.ILoggerFactory
+    public abstract class AbstractExtendedLoggerFactory : Castle.Core.Logging.IExtendedLoggerFactory, Castle.Core.Logging.ILoggerFactory
     {
         protected AbstractExtendedLoggerFactory() { }
         public abstract Castle.Core.Logging.IExtendedLogger Create(string name);
@@ -1975,7 +1975,7 @@ namespace Castle.Core.Logging
         public virtual Castle.Core.Logging.IExtendedLogger Create(System.Type type, Castle.Core.Logging.LoggerLevel level) { }
         protected static System.IO.FileInfo GetConfigFile(string fileName) { }
     }
-    public abstract class AbstractLoggerFactory : System.MarshalByRefObject, Castle.Core.Logging.ILoggerFactory
+    public abstract class AbstractLoggerFactory : Castle.Core.Logging.ILoggerFactory
     {
         protected AbstractLoggerFactory() { }
         public abstract Castle.Core.Logging.ILogger Create(string name);
@@ -1984,7 +1984,7 @@ namespace Castle.Core.Logging
         public virtual Castle.Core.Logging.ILogger Create(System.Type type, Castle.Core.Logging.LoggerLevel level) { }
         protected static System.IO.FileInfo GetConfigFile(string fileName) { }
     }
-    public class ConsoleFactory : System.MarshalByRefObject, Castle.Core.Logging.ILoggerFactory
+    public class ConsoleFactory : Castle.Core.Logging.ILoggerFactory
     {
         public ConsoleFactory() { }
         public ConsoleFactory(Castle.Core.Logging.LoggerLevel level) { }
@@ -2106,7 +2106,7 @@ namespace Castle.Core.Logging
         Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level);
         Castle.Core.Logging.ILogger Create(System.Type type, Castle.Core.Logging.LoggerLevel level);
     }
-    public abstract class LevelFilteredLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
+    public abstract class LevelFilteredLogger : Castle.Core.Logging.ILogger
     {
         protected LevelFilteredLogger() { }
         protected LevelFilteredLogger(Castle.Core.Logging.LoggerLevel loggerLevel) { }
@@ -2150,7 +2150,6 @@ namespace Castle.Core.Logging
         public void InfoFormat(System.Exception exception, string format, params object[] args) { }
         public void InfoFormat(System.IFormatProvider formatProvider, string format, params object[] args) { }
         public void InfoFormat(System.Exception exception, System.IFormatProvider formatProvider, string format, params object[] args) { }
-        public override object InitializeLifetimeService() { }
         protected abstract void Log(Castle.Core.Logging.LoggerLevel loggerLevel, string loggerName, string message, System.Exception exception);
         public void Trace(System.Func<string> messageFactory) { }
         public void Trace(string message) { }
@@ -2752,7 +2751,7 @@ namespace Castle.DynamicProxy
         public static bool IsProxy(object instance) { }
         public static bool IsProxyType(System.Type type) { }
     }
-    public class StandardInterceptor : System.MarshalByRefObject, Castle.DynamicProxy.IInterceptor
+    public class StandardInterceptor : Castle.DynamicProxy.IInterceptor
     {
         public StandardInterceptor() { }
         public void Intercept(Castle.DynamicProxy.IInvocation invocation) { }

--- a/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
@@ -8,7 +8,7 @@ namespace Castle.Services.Logging.SerilogIntegration
         public override Castle.Core.Logging.ILogger Create(string name) { }
         public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
-    public class SerilogLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
+    public class SerilogLogger : Castle.Core.Logging.ILogger
     {
         public SerilogLogger(Serilog.ILogger logger, Castle.Services.Logging.SerilogIntegration.SerilogFactory factory) { }
         protected Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }

--- a/ref/Castle.Services.Logging.log4netIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net45.cs
@@ -37,7 +37,7 @@ namespace Castle.Services.Logging.Log4netIntegration
         public override Castle.Core.Logging.ILogger Create(string name) { }
         public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
-    public class Log4netLogger : System.MarshalByRefObject, Castle.Core.Logging.ILogger
+    public class Log4netLogger : Castle.Core.Logging.ILogger
     {
         public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
         protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Camera.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Camera.cs
@@ -33,11 +33,7 @@ namespace Castle.DynamicProxy.Tests.BugsReported
 		void Record(ICamera cam);
 	}
 
-	public class CameraService :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		ICameraService
+	public class CameraService : ICameraService
 	{
 		public ICamera Add(String name, String ipNumber)
 		{

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService2.cs
@@ -21,11 +21,7 @@ namespace Castle.DynamicProxy.Tests.InterClasses
 		void DoOperation2();
 	}
 
-	public class Service2 :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		IService2
+	public class Service2 : IService2
 	{
 		public void DoOperation2()
 		{

--- a/src/Castle.Core/Core/Logging/AbstractExtendedLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/AbstractExtendedLoggerFactory.cs
@@ -17,11 +17,7 @@ namespace Castle.Core.Logging
 	using System;
 	using System.IO;
 
-	public abstract class AbstractExtendedLoggerFactory :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		IExtendedLoggerFactory
+	public abstract class AbstractExtendedLoggerFactory : IExtendedLoggerFactory
 	{
 		/// <summary>
 		///   Creates a new extended logger, getting the logger name from the specified type.

--- a/src/Castle.Core/Core/Logging/AbstractLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/AbstractLoggerFactory.cs
@@ -20,11 +20,7 @@ namespace Castle.Core.Logging
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	public abstract class AbstractLoggerFactory :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		ILoggerFactory
+	public abstract class AbstractLoggerFactory : ILoggerFactory
 	{
 		public virtual ILogger Create(Type type)
 		{

--- a/src/Castle.Core/Core/Logging/ConsoleFactory.cs
+++ b/src/Castle.Core/Core/Logging/ConsoleFactory.cs
@@ -19,11 +19,7 @@ namespace Castle.Core.Logging
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	public class ConsoleFactory :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		ILoggerFactory
+	public class ConsoleFactory : ILoggerFactory
 	{
 		private LoggerLevel? level;
 

--- a/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
+++ b/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
@@ -25,11 +25,7 @@ namespace Castle.Core.Logging
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	public abstract class LevelFilteredLogger :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		ILogger
+	public abstract class LevelFilteredLogger : ILogger
 	{
 		private LoggerLevel level = LoggerLevel.Off;
 		private String name = "unnamed";
@@ -55,16 +51,6 @@ namespace Castle.Core.Logging
 		{
 			ChangeName(loggerName);
 		}
-
-#if FEATURE_REMOTING
-		/// <summary>
-		/// Keep the instance alive in a remoting scenario
-		/// </summary>
-		public override object InitializeLifetimeService()
-		{
-			return null;
-		}
-#endif
 
 		public abstract ILogger CreateChildLogger(string loggerName);
 

--- a/src/Castle.Core/DynamicProxy/AllMethodsHook.cs
+++ b/src/Castle.Core/DynamicProxy/AllMethodsHook.cs
@@ -26,10 +26,8 @@ namespace Castle.DynamicProxy
 		protected static readonly ICollection<Type> SkippedTypes = new[]
 		{
 			typeof(object),
-#if FEATURE_REMOTING
 			typeof(MarshalByRefObject),
 			typeof(ContextBoundObject)
-#endif
 		};
 
 		public virtual bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -203,10 +203,7 @@ namespace Castle.DynamicProxy.Contributors
 			var isOverridable = method.IsVirtual && !method.IsFinal;
 			if (onlyVirtuals && !isOverridable)
 			{
-				if (
-#if FEATURE_REMOTING
-					method.DeclaringType != typeof(MarshalByRefObject) &&
-#endif
+				if (method.DeclaringType != typeof(MarshalByRefObject) &&
 					method.IsGetType() == false &&
 					method.IsMemberwiseClone() == false)
 				{
@@ -231,12 +228,11 @@ namespace Castle.DynamicProxy.Contributors
 				return false;
 			}
 
-#if FEATURE_REMOTING
 			if (method.DeclaringType == typeof(MarshalByRefObject))
 			{
 				return false;
 			}
-#endif
+
 			if (method.IsFinalizer())
 			{
 				return false;

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -21,10 +21,6 @@ namespace Castle.DynamicProxy
 	using System.Runtime.CompilerServices;
 	using System.Threading;
 
-#if FEATURE_REMOTING
-	using System.Runtime.Remoting;
-#endif
-
 	using Castle.Core.Internal;
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Internal;
@@ -85,15 +81,9 @@ namespace Castle.DynamicProxy
 
 		public static object GetUnproxiedInstance(object instance)
 		{
-#if FEATURE_REMOTING
-			if (!RemotingServices.IsTransparentProxy(instance))
-#endif
+			if (instance is IProxyTargetAccessor accessor)
 			{
-				var accessor = instance as IProxyTargetAccessor;
-				if (accessor != null)
-				{
-					instance = accessor.DynProxyGetTarget();
-				}
+				instance = accessor.DynProxyGetTarget();
 			}
 
 			return instance;
@@ -101,25 +91,17 @@ namespace Castle.DynamicProxy
 
 		public static Type GetUnproxiedType(object instance)
 		{
-#if FEATURE_REMOTING
-			if (!RemotingServices.IsTransparentProxy(instance))
-#endif
+			if (instance is IProxyTargetAccessor accessor)
 			{
-				var accessor = instance as IProxyTargetAccessor;
-
-				if (accessor != null)
+				var target = accessor.DynProxyGetTarget();
+				if (target != null)
 				{
-					var target = accessor.DynProxyGetTarget();
-
-					if (target != null)
+					if (ReferenceEquals(target, instance))
 					{
-						if (ReferenceEquals(target, instance))
-						{
-							return instance.GetType().BaseType;
-						}
-
-						instance = target;
+						return instance.GetType().BaseType;
 					}
+
+					instance = target;
 				}
 			}
 
@@ -128,12 +110,6 @@ namespace Castle.DynamicProxy
 
 		public static bool IsProxy(object instance)
 		{
-#if FEATURE_REMOTING
-			if (RemotingServices.IsTransparentProxy(instance))
-			{
-				return true;
-			}
-#endif
 			return instance is IProxyTargetAccessor;
 		}
 

--- a/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
+++ b/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
@@ -19,11 +19,7 @@ namespace Castle.DynamicProxy
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	public class StandardInterceptor :
-#if FEATURE_REMOTING
-		MarshalByRefObject,
-#endif
-		IInterceptor
+	public class StandardInterceptor : IInterceptor
 	{
 		public void Intercept(IInvocation invocation)
 		{

--- a/src/Castle.Services.Logging.SerilogIntegration/SerilogLogger.cs
+++ b/src/Castle.Services.Logging.SerilogIntegration/SerilogLogger.cs
@@ -22,11 +22,7 @@ namespace Castle.Services.Logging.SerilogIntegration
 #if FEATURE_SERIALIZATION
     [Serializable]
 #endif
-    public class SerilogLogger :
-#if FEATURE_APPDOMAIN
-        MarshalByRefObject,
-#endif
-        Castle.Core.Logging.ILogger
+    public class SerilogLogger : Castle.Core.Logging.ILogger
     {
         public SerilogLogger(ILogger logger, SerilogFactory factory)
         {

--- a/src/Castle.Services.Logging.log4netIntegration/Log4netLogger.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/Log4netLogger.cs
@@ -24,11 +24,7 @@ namespace Castle.Services.Logging.Log4netIntegration
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	public class Log4netLogger :
-#if FEATURE_APPDOMAIN
-		MarshalByRefObject,
-#endif
-		Castle.Core.Logging.ILogger
+	public class Log4netLogger : Castle.Core.Logging.ILogger
 	{
 		private static readonly Type declaringType = typeof(Log4netLogger);
 


### PR DESCRIPTION
This is a follow-up to https://github.com/castleproject/Core/issues/501#issuecomment-640471295, where it was mentioned that there's no future for .NET remoting.

We can keep some minimal support for .NET remoting where it doesn't cost us anything (excluding `MarshalByRefObject` methods during proxy type creation), but there will be functional changes with our `net45` target. See the commit message for details.

@jonorossi, I've never worked much with app domains and remoting, so I figured we might just gear v5's feature set towards "modern" .NET; regarding backwards compatibility (i.e. `net45`), I'll defer to your judgement whether these changes are acceptable.