### PR TITLE
Remove all `FEATURE_TEST_COM` guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 `FEATURE_EVENTLOG`                  | :white_check_mark: | :no_entry_sign:
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
-`FEATURE_TEST_COM`                  | :white_check_mark: | :no_entry_sign:
 `FEATURE_TEST_PEVERIFY`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_TEST_WINFORMS`             | :white_check_mark: | :no_entry_sign:
 ---                                 |                    |
@@ -78,6 +77,5 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 * `FEATURE_EVENTLOG` - provides a diagnostics logger using the Windows Event Log.
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.
-* `FEATURE_TEST_COM` - enables COM Interop tests.
 * `FEATURE_TEST_PEVERIFY` - enables verification of dynamic assemblies using PEVerify during tests. (Only defined on Windows builds since Windows is currently the only platform where PEVerify is available.)
 * `FEATURE_TEST_WINFORMS` - enables Windows Forms tests.

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -45,7 +45,7 @@
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
 		<NetStandard21Constants>TRACE</NetStandard21Constants>
-		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TEST_COM;FEATURE_TEST_WINFORMS</CommonDesktopClrConstants>
+		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TEST_WINFORMS</CommonDesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants)</DesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants);FEATURE_TEST_PEVERIFY</DesktopClrConstants>
 	</PropertyGroup>

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInterfacesTests.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInterfacesTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
 namespace Castle.DynamicProxy.Tests
 {
 	using System;
@@ -27,6 +26,7 @@ namespace Castle.DynamicProxy.Tests
 	public class ComInterfacesTests:BasePEVerifyTestCase
 	{
 		[Test]
+		[Platform(Include = "Win,Mono", Reason = "`Marshal.Release` triggers a `PlatformNotSupportedException` with .NET Core on Linux.")]
 		public void Marshal_Release_throws_when_called_with_IntPtr_Zero()
 		{
 			Assert.Catch<ArgumentException>(() => Marshal.Release(IntPtr.Zero));
@@ -51,4 +51,3 @@ namespace Castle.DynamicProxy.Tests
 		}
 	}
 }
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Command.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Command.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System;
@@ -198,5 +196,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		}
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Connection.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Connection.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Runtime.InteropServices;
@@ -25,5 +23,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 	{
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Enums.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Enums.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System;
@@ -220,5 +218,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		adClipString = 2
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Fields.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Fields.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Runtime.InteropServices;
@@ -26,5 +24,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		// (member definitions omitted)
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameter.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameter.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Reflection;
@@ -149,5 +147,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		}
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameters.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Runtime.InteropServices;
@@ -26,5 +24,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		// (member definitions omitted)
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Properties.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Properties.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Runtime.InteropServices;
@@ -26,5 +24,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 		// (member definitions omitted)
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Recordset.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Recordset.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_COM
-
 namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 {
 	using System.Reflection;
@@ -481,5 +479,3 @@ namespace Castle.DynamicProxy.Tests.ComInteropTypes.ADODB
 			[In] PersistFormatEnum PersistFormat = PersistFormatEnum.adPersistADTG);
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
@@ -289,7 +289,6 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual("Foo ", logging.LogContents);
 		}
 
-#if FEATURE_TEST_COM
 		[Test]
 		public void ProxyingComInteraces()
 		{
@@ -297,7 +296,6 @@ namespace Castle.DynamicProxy.Tests
 				.CreateInterfaceProxyWithoutTarget(typeof (IComServiceProvider), new StandardInterceptor());
 			Assert.IsNotNull(o);
 		}
-#endif
 
 		[Test]
 		public void ProxyingGenericClassWithGenericClassConstraint()


### PR DESCRIPTION
:warning: This PR depends on #510, which needs to be merged first! 

----

`FEATURE_TEST_COM` currently guards code that would compile just fine for all of our targets, so it isn't needed from a purely compile-time perspective.

Tests that use the COM subsystem (there are 2 of those) may still fail at runtime on platforms where no COM subsystem exists. ~~Unfortunately, we cannot use NUnit's `[Platform]` attribute to conditionally skip them, because that attribute... 🥁... surprisingly isn't cross-platform itself!~~ (I was wrong about that, [see below](https://github.com/castleproject/Core/pull/509#issuecomment-642234389). Because of that, the following approach is now arguably obsolete, too:)

~~Instead, I am aborting tests at runtime using `Assert.Ignore` when a COM-related failure gets detected. Regrettably, the 2 tests end up having more error detection than actual test code, but I suppose that's the price to pay for error tolerance & .NET Standard being a leaky abstraction (static contracts vs. `PlatformNotSupportedException`).~~

On the positive side, using that approach taught me that COM tests pass for CoreCLR on Windows. I wouldn't have thought so. Had I been able to use `[Platform(Exclude = ...)]` I would've excluded CoreCLR wholesale.

* [X] ~~Draft status because I still need to figure out why `PlatformNotSupportedException` doesn't get caught as it should.~~ (See https://github.com/castleproject/Core/pull/509#issuecomment-642234389 below.)