### PR TITLE
Remove all `FEATURE_TEST_WINFORMS` guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_TEST_PEVERIFY`             | :white_check_mark: | :no_entry_sign:
-`FEATURE_TEST_WINFORMS`             | :white_check_mark: | :no_entry_sign:
 ---                                 |                    |
 `DOTNET45`                          | :white_check_mark: | :no_entry_sign:
 
@@ -78,4 +77,3 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.
 * `FEATURE_TEST_PEVERIFY` - enables verification of dynamic assemblies using PEVerify during tests. (Only defined on Windows builds since Windows is currently the only platform where PEVerify is available.)
-* `FEATURE_TEST_WINFORMS` - enables Windows Forms tests.

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -45,7 +45,7 @@
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
 		<NetStandard21Constants>TRACE</NetStandard21Constants>
-		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION;FEATURE_TEST_WINFORMS</CommonDesktopClrConstants>
+		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</CommonDesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants)</DesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants);FEATURE_TEST_PEVERIFY</DesktopClrConstants>
 	</PropertyGroup>

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -55,7 +55,6 @@
 		<PackageReference Include="System.Net.Primitives" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
-		<Reference Include="System.Windows.Forms" />
 		<PackageReference Include="PublicApiGenerator" Version="10.1.0" />
 	</ItemGroup>
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/WinFormsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/WinFormsTestCase.cs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_TEST_WINFORMS
-
 namespace Castle.DynamicProxy.Tests
 {
-	using System.Windows.Forms;
+	using System;
 
 	using NUnit.Framework;
 
@@ -27,10 +25,14 @@ namespace Castle.DynamicProxy.Tests
 		[Platform(Exclude = "Mono", Reason = "Disabled on Mono to remove the need to have X installed.")]
 		public void Can_proxy_windows_forms_control()
 		{
-			var proxy = generator.CreateClassProxy<Control>();
+			var controlType = Type.GetType("System.Windows.Forms.Control, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+			if (controlType == null)
+			{
+				Assert.Ignore("Windows Forms is not available on this system.");
+			}
+
+			var proxy = generator.CreateClassProxy(controlType);
 			Assert.IsNotNull(proxy);
 		}
 	}
 }
-
-#endif


### PR DESCRIPTION
There's just one Windows Forms test; rewrite it such that it compiles successfully with all targets, then bind to the required Windows Forms type at runtime.