### PR TITLE
Remove `FEATURE_EVENTLOG` guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 ----------------------------------- | ------------------ | ------------------
 `FEATURE_APPDOMAIN`                 | :white_check_mark: | :no_entry_sign:
 `FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:
-`FEATURE_EVENTLOG`                  | :white_check_mark: | :no_entry_sign:
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_TEST_PEVERIFY`             | :white_check_mark: | :no_entry_sign:
@@ -73,7 +72,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 
 * `FEATURE_APPDOMAIN` - enables support for features that make use of an AppDomain in the host.
 * `FEATURE_ASSEMBLYBUILDER_SAVE` - enabled support for saving the dynamically generated proxy assembly.
-* `FEATURE_EVENTLOG` - provides a diagnostics logger using the Windows Event Log.
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.
 * `FEATURE_TEST_PEVERIFY` - enables verification of dynamic assemblies using PEVerify during tests. (Only defined on Windows builds since Windows is currently the only platform where PEVerify is available.)

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -45,7 +45,7 @@
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
 		<NetStandard21Constants>TRACE</NetStandard21Constants>
-		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_EVENTLOG;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</CommonDesktopClrConstants>
+		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</CommonDesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants)</DesktopClrConstants>
 		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants);FEATURE_TEST_PEVERIFY</DesktopClrConstants>
 	</PropertyGroup>

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -2001,6 +2001,23 @@ namespace Castle.Core.Logging
         public override Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
         protected override void Log(Castle.Core.Logging.LoggerLevel loggerLevel, string loggerName, string message, System.Exception exception) { }
     }
+    public class DiagnosticsLogger : Castle.Core.Logging.LevelFilteredLogger, System.IDisposable
+    {
+        public DiagnosticsLogger(string logName) { }
+        public DiagnosticsLogger(string logName, string source) { }
+        public DiagnosticsLogger(string logName, string machineName, string source) { }
+        public override Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected override void Finalize() { }
+        protected override void Log(Castle.Core.Logging.LoggerLevel loggerLevel, string loggerName, string message, System.Exception exception) { }
+    }
+    public class DiagnosticsLoggerFactory : Castle.Core.Logging.AbstractLoggerFactory
+    {
+        public DiagnosticsLoggerFactory() { }
+        public override Castle.Core.Logging.ILogger Create(string name) { }
+        public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
+    }
     public interface IContextProperties
     {
         object this[string key] { get; set; }

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -2001,6 +2001,23 @@ namespace Castle.Core.Logging
         public override Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
         protected override void Log(Castle.Core.Logging.LoggerLevel loggerLevel, string loggerName, string message, System.Exception exception) { }
     }
+    public class DiagnosticsLogger : Castle.Core.Logging.LevelFilteredLogger, System.IDisposable
+    {
+        public DiagnosticsLogger(string logName) { }
+        public DiagnosticsLogger(string logName, string source) { }
+        public DiagnosticsLogger(string logName, string machineName, string source) { }
+        public override Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected override void Finalize() { }
+        protected override void Log(Castle.Core.Logging.LoggerLevel loggerLevel, string loggerName, string message, System.Exception exception) { }
+    }
+    public class DiagnosticsLoggerFactory : Castle.Core.Logging.AbstractLoggerFactory
+    {
+        public DiagnosticsLoggerFactory() { }
+        public override Castle.Core.Logging.ILogger Create(string name) { }
+        public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
+    }
     public interface IContextProperties
     {
         object this[string key] { get; set; }

--- a/src/Castle.Core.Tests/Core.Tests/Logging/DiagnosticsLoggerTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/DiagnosticsLoggerTestCase.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_EVENTLOG
 namespace Castle.Core.Logging.Tests
 {
 	using System;
@@ -76,6 +75,7 @@ namespace Castle.Core.Logging.Tests
 		}
 
 		[Test]
+		[Platform(Include = "Win,Mono")]
 		public void SimpleUsage()
 		{
 			DiagnosticsLogger logger = new DiagnosticsLogger("castle_testlog", "test_source");
@@ -91,4 +91,3 @@ namespace Castle.Core.Logging.Tests
 		}
 	}
 }
-#endif

--- a/src/Castle.Core/Castle.Core.csproj
+++ b/src/Castle.Core/Castle.Core.csproj
@@ -36,6 +36,10 @@
 		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netstandard2.1'">
+		<PackageReference Include="System.Diagnostics.EventLog" Version="4.7.0" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<Folder Include="Properties\" />
 	</ItemGroup>

--- a/src/Castle.Core/Core/Logging/DiagnosticsLogger.cs
+++ b/src/Castle.Core/Core/Logging/DiagnosticsLogger.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_EVENTLOG
-
 namespace Castle.Core.Logging
 {
 	using System;
@@ -146,5 +144,3 @@ namespace Castle.Core.Logging
 		}
 	}
 }
-
-#endif

--- a/src/Castle.Core/Core/Logging/DiagnosticsLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/DiagnosticsLoggerFactory.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_EVENTLOG
-
 namespace Castle.Core.Logging
 {
 	using System;
@@ -38,5 +36,3 @@ namespace Castle.Core.Logging
 		}
 	}
 }
-
-#endif


### PR DESCRIPTION
(`EventLog` is nominally supported on `netstandard2.x` via the NuGet package `System.Diagnostics.EventLog`, but will throw `PlatformNotSupportedException` at runtime e.g. with CoreCLR on Linux.)