### PR TITLE
Remove `FEATURE_TEST_PEVERIFY` guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 `FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
-`FEATURE_TEST_PEVERIFY`             | :white_check_mark: | :no_entry_sign:
 ---                                 |                    |
 `DOTNET45`                          | :white_check_mark: | :no_entry_sign:
 
@@ -74,4 +73,3 @@ Symbol                              | .NET 4.5           | .NET Standard 2.x
 * `FEATURE_ASSEMBLYBUILDER_SAVE` - enabled support for saving the dynamically generated proxy assembly.
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.
-* `FEATURE_TEST_PEVERIFY` - enables verification of dynamic assemblies using PEVerify during tests. (Only defined on Windows builds since Windows is currently the only platform where PEVerify is available.)

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -45,9 +45,7 @@
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
 		<NetStandard21Constants>TRACE</NetStandard21Constants>
-		<CommonDesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</CommonDesktopClrConstants>
-		<DesktopClrConstants Condition="'$(OS)'=='Unix'">$(CommonDesktopClrConstants)</DesktopClrConstants>
-		<DesktopClrConstants Condition="'$(OS)'=='Windows_NT'">$(CommonDesktopClrConstants);FEATURE_TEST_PEVERIFY</DesktopClrConstants>
+		<DesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</DesktopClrConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net45|Debug'">

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BaseTestCaseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BaseTestCaseTestCase.cs
@@ -46,7 +46,6 @@ namespace Castle.DynamicProxy.Tests
 			Assert.IsFalse(File.Exists(path));
 		}
 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
 		[Test]
 		public void TearDown_SavesAssembly_IfProxyGenerated()
 		{
@@ -59,9 +58,8 @@ namespace Castle.DynamicProxy.Tests
 			generator.CreateClassProxy(typeof(object), new StandardInterceptor());
 
 			base.TearDown();
-			Assert.IsTrue(File.Exists(path));
+			Assert.AreEqual(IsVerificationPossible, File.Exists(path));
 		}
-#endif
 
 		private void FindVerificationErrors()
 		{
@@ -80,16 +78,15 @@ namespace Castle.DynamicProxy.Tests
 			base.TearDown();
 		}
 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
 		[Test]
-		[Platform(Exclude = "Mono", Reason = "Mono doesn't have peverify, so we can't perform verification.")]
 		public void TearDown_FindsVerificationErrors()
 		{
+			if (!IsVerificationPossible) Assert.Ignore();
+
 			var ex = Assert.Throws<AssertionException>(() => FindVerificationErrors());
 			StringAssert.Contains("PeVerify reported error(s)", ex.Message);
 			StringAssert.Contains("fall through end of the method without returning", ex.Message);
 		}
-#endif
 
 		[Test]
 		public void DisableVerification_DisablesVerificationForTestCase()

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CustomModifiersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CustomModifiersTestCase.cs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#if FEATURE_ASSEMBLYBUILDER_SAVE
 
 namespace Castle.DynamicProxy.Tests
 {
@@ -123,10 +122,13 @@ namespace Castle.DynamicProxy.Tests
 				this.AddTypeWithCustomModifiersAsModreqOnReturnType(moduleScope, partialTypeName, customModifiers);
 			}
 
-#if FEATURE_TEST_PEVERIFY
-			// Let's persist and PE-verify the dynamic assembly before it gets used in tests:
-			var assemblyPath = moduleScope.SaveAssembly();
-			base.RunPEVerifyOnGeneratedAssembly(assemblyPath);
+#if FEATURE_ASSEMBLYBUILDER_SAVE
+			if (IsVerificationPossible)
+			{
+				// Let's persist and PE-verify the dynamic assembly before it gets used in tests:
+				var assemblyPath = moduleScope.SaveAssembly();
+				RunPEVerifyOnGeneratedAssembly(assemblyPath);
+			}
 #endif
 		}
 
@@ -396,5 +398,3 @@ namespace Castle.DynamicProxy.Tests
 		public class Bar { }
 	}
 }
-
-#endif

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
@@ -179,10 +179,13 @@ namespace Castle.DynamicProxy.Tests
 
 			var iHaveMethodWithModOptsType = typeBuilder.CreateTypeInfo();
 
-#if FEATURE_ASSEMBLYBUILDER_SAVE && FEATURE_TEST_PEVERIFY
-			// Let's persist and PE-verify the dynamic assembly before it gets used in tests:
-			var assemblyPath = moduleScope.SaveAssembly();
-			base.RunPEVerifyOnGeneratedAssembly(assemblyPath);
+#if FEATURE_ASSEMBLYBUILDER_SAVE
+			if (IsVerificationPossible)
+			{
+				// Let's persist and PE-verify the dynamic assembly before it gets used in tests:
+				var assemblyPath = moduleScope.SaveAssembly();
+				RunPEVerifyOnGeneratedAssembly(assemblyPath);
+			}
 #endif
 
 			this.iHaveMethodWithModOptsType = iHaveMethodWithModOptsType;


### PR DESCRIPTION
Turns this conditional compilation symbol into runtime checks. Whether or not PEVerify gets used should be a function of its availability during a test run, not of what target framework we compiled for.

(As an aside, this should enable a few more tests on non-Windows platforms.)