### PR TITLE
Move misplaced contributors/generators to right namespaces

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/IInvocationCreationContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/IInvocationCreationContributor.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.DynamicProxy.Generators
+namespace Castle.DynamicProxy.Contributors
 {
 	using System.Reflection;
 

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System;
 	using System.Reflection;
 
+	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.DynamicProxy.Contributors
+namespace Castle.DynamicProxy.Generators
 {
 	using System;
 	using System.Reflection;
 
-	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;

--- a/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
@@ -12,50 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.DynamicProxy.Contributors
+namespace Castle.DynamicProxy.Generators
 {
-	using System.Reflection;
-
-	using Castle.DynamicProxy.Generators;
+	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class MinimialisticMethodGenerator : MethodGenerator
+	internal class ForwardingMethodGenerator : MethodGenerator
 	{
-		public MinimialisticMethodGenerator(MetaMethod method, OverrideMethodDelegate overrideMethod)
+		private readonly GetTargetReferenceDelegate getTargetReference;
+
+		public ForwardingMethodGenerator(MetaMethod method, OverrideMethodDelegate overrideMethod,
+		                                 GetTargetReferenceDelegate getTargetReference)
 			: base(method, overrideMethod)
 		{
+			this.getTargetReference = getTargetReference;
 		}
 
 		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class,
 		                                                        ProxyGenerationOptions options, INamingScope namingScope)
 		{
-			InitOutParameters(emitter, MethodToOverride.GetParameters());
+			var targetReference = getTargetReference(@class, MethodToOverride);
+			var arguments = ArgumentsUtil.ConvertToArgumentReferenceExpression(MethodToOverride.GetParameters());
 
-			if (emitter.ReturnType == typeof(void))
-			{
-				emitter.CodeBuilder.AddStatement(new ReturnStatement());
-			}
-			else
-			{
-				emitter.CodeBuilder.AddStatement(new ReturnStatement(new DefaultValueExpression(emitter.ReturnType)));
-			}
-
+			emitter.CodeBuilder.AddStatement(new ReturnStatement(
+			                                 	new MethodInvocationExpression(
+			                                 		targetReference,
+			                                 		MethodToOverride,
+			                                 		arguments) { VirtualCall = true }));
 			return emitter;
-		}
-
-		private void InitOutParameters(MethodEmitter emitter, ParameterInfo[] parameters)
-		{
-			for (var index = 0; index < parameters.Length; index++)
-			{
-				var parameter = parameters[index];
-				if (parameter.IsOut)
-				{
-					emitter.CodeBuilder.AddStatement(
-						new AssignArgumentStatement(new ArgumentReference(parameter.ParameterType, index + 1),
-						                            new DefaultValueExpression(parameter.ParameterType)));
-				}
-			}
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
@@ -17,6 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System;
 	using System.Reflection;
 
+	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -18,6 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Reflection;
 
+	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.CodeBuilders;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;

--- a/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Castle.DynamicProxy.Contributors
+namespace Castle.DynamicProxy.Generators
 {
 	using System;
 	using System.Reflection;
 
-	using Castle.DynamicProxy.Generators;
+	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 


### PR DESCRIPTION
(This is a low-priority refactoring.)

Some DynamicProxy contributor and generator types have somehow ended up in the wrong namespaces. This puts them back where they belong.