### PR TITLE
Upgrade PublicApiGenerator to version 10.1.2

### DIFF
--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -1545,9 +1545,9 @@ namespace Castle.Components.DictionaryAdapter.Xml
         public override int GetHashCode() { }
         public override string ToString() { }
         public Castle.Components.DictionaryAdapter.Xml.XmlName WithNamespaceUri(string namespaceUri) { }
-        public static bool !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
-        public static bool ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
         public static Castle.Components.DictionaryAdapter.Xml.XmlName ParseQName(string text) { }
+        public static bool operator !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
+        public static bool operator ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
     }
     public class XmlNameComparer : System.Collections.Generic.IEqualityComparer<Castle.Components.DictionaryAdapter.Xml.XmlName>
     {

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -1545,9 +1545,9 @@ namespace Castle.Components.DictionaryAdapter.Xml
         public override int GetHashCode() { }
         public override string ToString() { }
         public Castle.Components.DictionaryAdapter.Xml.XmlName WithNamespaceUri(string namespaceUri) { }
-        public static bool !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
-        public static bool ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
         public static Castle.Components.DictionaryAdapter.Xml.XmlName ParseQName(string text) { }
+        public static bool operator !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
+        public static bool operator ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
     }
     public class XmlNameComparer : System.Collections.Generic.IEqualityComparer<Castle.Components.DictionaryAdapter.Xml.XmlName>
     {

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -1545,9 +1545,9 @@ namespace Castle.Components.DictionaryAdapter.Xml
         public override int GetHashCode() { }
         public override string ToString() { }
         public Castle.Components.DictionaryAdapter.Xml.XmlName WithNamespaceUri(string namespaceUri) { }
-        public static bool !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
-        public static bool ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
         public static Castle.Components.DictionaryAdapter.Xml.XmlName ParseQName(string text) { }
+        public static bool operator !=(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
+        public static bool operator ==(Castle.Components.DictionaryAdapter.Xml.XmlName x, Castle.Components.DictionaryAdapter.Xml.XmlName y) { }
     }
     public class XmlNameComparer : System.Collections.Generic.IEqualityComparer<Castle.Components.DictionaryAdapter.Xml.XmlName>
     {

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -55,7 +55,7 @@
 		<PackageReference Include="System.Net.Primitives" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
-		<PackageReference Include="PublicApiGenerator" Version="10.1.1" />
+		<PackageReference Include="PublicApiGenerator" Version="10.1.2" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not too long after #521 got merged, I found yet another [issue in our `ref/` files](https://github.com/castleproject/Core/blob/1015886d61806061b063bf6f3ef721d3d36dc9f9/ref/Castle.Core-net45.cs#L1548-L1549), see https://github.com/PublicApiGenerator/PublicApiGenerator/issues/192).

This should be fixed by updating PublicApiGenerator once more.