### PR TITLE
Minimize passing around of `ProxyGenerationOptions`

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyInstanceContributor.cs
@@ -54,7 +54,7 @@ namespace Castle.DynamicProxy.Contributors
 			return SelfReference.Self;
 		}
 
-		public override void Generate(ClassEmitter @class, ProxyGenerationOptions options)
+		public override void Generate(ClassEmitter @class)
 		{
 			var interceptors = @class.GetField("__interceptors");
 #if FEATURE_SERIALIZATION

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -57,7 +57,6 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
 			if (methodsToSkip.Contains(method.Method))
@@ -73,10 +72,10 @@ namespace Castle.DynamicProxy.Contributors
 
 			if (ExplicitlyImplementedInterfaceMethod(method))
 			{
-				return ExplicitlyImplementedInterfaceMethodGenerator(method, @class, options, overrideMethod);
+				return ExplicitlyImplementedInterfaceMethodGenerator(method, @class, overrideMethod);
 			}
 
-			var invocation = GetInvocationType(method, @class, options);
+			var invocation = GetInvocationType(method, @class);
 
 			GetTargetExpressionDelegate getTargetTypeExpression = (c, m) => new TypeTokenExpression(targetType);
 
@@ -89,7 +88,7 @@ namespace Castle.DynamicProxy.Contributors
 			                                         null);
 		}
 
-		private Type BuildInvocationType(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options)
+		private Type BuildInvocationType(MetaMethod method, ClassEmitter @class)
 		{
 			var methodInfo = method.Method;
 			if (!method.HasTarget)
@@ -97,14 +96,14 @@ namespace Castle.DynamicProxy.Contributors
 				return new InheritanceInvocationTypeGenerator(targetType,
 				                                              method,
 				                                              null, null)
-					.Generate(@class, options, namingScope)
+					.Generate(@class, namingScope)
 					.BuildType();
 			}
 			var callback = CreateCallbackMethod(@class, methodInfo, method.MethodOnTarget);
 			return new InheritanceInvocationTypeGenerator(callback.DeclaringType,
 			                                              method,
 			                                              callback, null)
-				.Generate(@class, options, namingScope)
+				.Generate(@class, namingScope)
 				.BuildType();
 		}
 
@@ -141,13 +140,12 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		private MethodGenerator ExplicitlyImplementedInterfaceMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                                      ProxyGenerationOptions options,
 		                                                                      OverrideMethodDelegate overrideMethod)
 		{
-			var @delegate = GetDelegateType(method, @class, options);
+			var @delegate = GetDelegateType(method, @class);
 			var contributor = GetContributor(@delegate, method);
 			var invocation = new InheritanceInvocationTypeGenerator(targetType, method, null, contributor)
-				.Generate(@class, options, namingScope)
+				.Generate(@class, namingScope)
 				.BuildType();
 			return new MethodWithInvocationGenerator(method,
 			                                         @class.GetField("__interceptors"),
@@ -168,7 +166,7 @@ namespace Castle.DynamicProxy.Contributors
 			                                                    new FieldReference(InvocationMethods.ProxyObject));
 		}
 
-		private Type GetDelegateType(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options)
+		private Type GetDelegateType(MetaMethod method, ClassEmitter @class)
 		{
 			var scope = @class.ModuleScope;
 			var key = new CacheKey(
@@ -181,14 +179,14 @@ namespace Castle.DynamicProxy.Contributors
 
 			return scope.TypeCache.GetOrAddWithoutTakingLock(key, _ =>
 				new DelegateTypeGenerator(method, targetType)
-				.Generate(@class, options, namingScope)
+				.Generate(@class, namingScope)
 				.BuildType());
 		}
 
-		private Type GetInvocationType(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options)
+		private Type GetInvocationType(MetaMethod method, ClassEmitter @class)
 		{
 			// NOTE: No caching since invocation is tied to this specific proxy type via its invocation method
-			return BuildInvocationType(method, @class, options);
+			return BuildInvocationType(method, @class);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -70,7 +70,7 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected abstract IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook);
 
-		public virtual void Generate(ClassEmitter @class, ProxyGenerationOptions options)
+		public virtual void Generate(ClassEmitter @class)
 		{
 			foreach (var method in methods)
 			{
@@ -81,18 +81,17 @@ namespace Castle.DynamicProxy.Contributors
 
 				ImplementMethod(method,
 				                @class,
-				                options,
 				                @class.CreateMethod);
 			}
 
 			foreach (var property in properties)
 			{
-				ImplementProperty(@class, property, options);
+				ImplementProperty(@class, property);
 			}
 
 			foreach (var @event in events)
 			{
-				ImplementEvent(@class, @event, options);
+				ImplementEvent(@class, @event);
 			}
 		}
 
@@ -106,41 +105,40 @@ namespace Castle.DynamicProxy.Contributors
 			interfaces.Add(@interface);
 		}
 
-		private void ImplementEvent(ClassEmitter emitter, MetaEvent @event, ProxyGenerationOptions options)
+		private void ImplementEvent(ClassEmitter emitter, MetaEvent @event)
 		{
 			@event.BuildEventEmitter(emitter);
-			ImplementMethod(@event.Adder, emitter, options, @event.Emitter.CreateAddMethod);
-			ImplementMethod(@event.Remover, emitter, options, @event.Emitter.CreateRemoveMethod);
+			ImplementMethod(@event.Adder, emitter, @event.Emitter.CreateAddMethod);
+			ImplementMethod(@event.Remover, emitter, @event.Emitter.CreateRemoveMethod);
 		}
 
-		private void ImplementProperty(ClassEmitter emitter, MetaProperty property, ProxyGenerationOptions options)
+		private void ImplementProperty(ClassEmitter emitter, MetaProperty property)
 		{
 			property.BuildPropertyEmitter(emitter);
 			if (property.CanRead)
 			{
-				ImplementMethod(property.Getter, emitter, options, property.Emitter.CreateGetMethod);
+				ImplementMethod(property.Getter, emitter, property.Emitter.CreateGetMethod);
 			}
 
 			if (property.CanWrite)
 			{
-				ImplementMethod(property.Setter, emitter, options, property.Emitter.CreateSetMethod);
+				ImplementMethod(property.Setter, emitter, property.Emitter.CreateSetMethod);
 			}
 		}
 
 		protected abstract MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod);
 
-		private void ImplementMethod(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options,
+		private void ImplementMethod(MetaMethod method, ClassEmitter @class,
 		                             OverrideMethodDelegate overrideMethod)
 		{
 			{
-				var generator = GetMethodGenerator(method, @class, options, overrideMethod);
+				var generator = GetMethodGenerator(method, @class, overrideMethod);
 				if (generator == null)
 				{
 					return;
 				}
-				var proxyMethod = generator.Generate(@class, options, namingScope);
+				var proxyMethod = generator.Generate(@class, namingScope);
 				foreach (var attribute in method.Method.GetNonInheritableAttributes())
 				{
 					proxyMethod.DefineCustomAttribute(attribute.Builder);

--- a/src/Castle.Core/DynamicProxy/Contributors/ITypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ITypeContributor.cs
@@ -24,6 +24,6 @@ namespace Castle.DynamicProxy.Contributors
 	{
 		void CollectElementsToProxy(IProxyGenerationHook hook, MetaType model);
 
-		void Generate(ClassEmitter @class, ProxyGenerationOptions options);
+		void Generate(ClassEmitter @class);
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
@@ -54,7 +54,6 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
 			if (!method.Proxyable)
@@ -64,7 +63,7 @@ namespace Castle.DynamicProxy.Contributors
 				                                     (c, m) => c.GetField("__target"));
 			}
 
-			var invocation = GetInvocationType(method, @class, options);
+			var invocation = GetInvocationType(method, @class);
 
 			return new MethodWithInvocationGenerator(method,
 			                                         @class.GetField("__interceptors"),
@@ -74,7 +73,7 @@ namespace Castle.DynamicProxy.Contributors
 			                                         null);
 		}
 
-		private Type GetInvocationType(MetaMethod method, ClassEmitter @class, ProxyGenerationOptions options)
+		private Type GetInvocationType(MetaMethod method, ClassEmitter @class)
 		{
 			var scope = @class.ModuleScope;
 
@@ -98,7 +97,7 @@ namespace Castle.DynamicProxy.Contributors
 				                                       method.Method,
 				                                       canChangeTarget,
 				                                       null)
-				.Generate(@class, options, namingScope)
+				.Generate(@class, namingScope)
 				.BuildType());
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
@@ -30,7 +30,6 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
 			if (!method.Proxyable)
@@ -38,7 +37,7 @@ namespace Castle.DynamicProxy.Contributors
 				return new OptionallyForwardingMethodGenerator(method, overrideMethod, getTargetReference);
 			}
 
-			return base.GetMethodGenerator(method, @class, options, overrideMethod);
+			return base.GetMethodGenerator(method, @class, overrideMethod);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
@@ -44,7 +44,6 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
 			if (!method.Proxyable)
@@ -52,7 +51,7 @@ namespace Castle.DynamicProxy.Contributors
 				return new MinimialisticMethodGenerator(method, overrideMethod);
 			}
 
-			var invocation = GetInvocationType(method, @class, options);
+			var invocation = GetInvocationType(method, @class);
 			return new MethodWithInvocationGenerator(method,
 			                                         @class.GetField("__interceptors"),
 			                                         invocation,
@@ -61,7 +60,7 @@ namespace Castle.DynamicProxy.Contributors
 			                                         null);
 		}
 
-		private Type GetInvocationType(MetaMethod method, ClassEmitter emitter, ProxyGenerationOptions options)
+		private Type GetInvocationType(MetaMethod method, ClassEmitter emitter)
 		{
 			var scope = emitter.ModuleScope;
 			Type[] invocationInterfaces;
@@ -83,7 +82,7 @@ namespace Castle.DynamicProxy.Contributors
 				                                       method.Method,
 				                                       canChangeTarget,
 				                                       null)
-				.Generate(emitter, options, namingScope)
+				.Generate(emitter, namingScope)
 				.BuildType());
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -54,7 +54,7 @@ namespace Castle.DynamicProxy.Contributors
 			empty.Add(@interface);
 		}
 
-		public override void Generate(ClassEmitter @class, ProxyGenerationOptions options)
+		public override void Generate(ClassEmitter @class)
 		{
 			foreach (var @interface in interfaces)
 			{
@@ -66,7 +66,7 @@ namespace Castle.DynamicProxy.Contributors
 				fields[emptyInterface] = BuildTargetField(@class, emptyInterface);
 			}
 
-			base.Generate(@class, options);
+			base.Generate(@class);
 		}
 
 		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
@@ -89,7 +89,6 @@ namespace Castle.DynamicProxy.Contributors
 		}
 
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
-		                                                      ProxyGenerationOptions options,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
 			if (!method.Proxyable)
@@ -99,7 +98,7 @@ namespace Castle.DynamicProxy.Contributors
 				                                     (c, i) => fields[i.DeclaringType]);
 			}
 
-			var invocation = GetInvocationType(method, @class, options);
+			var invocation = GetInvocationType(method, @class);
 			return new MethodWithInvocationGenerator(method,
 			                                         @class.GetField("__interceptors"),
 			                                         invocation,
@@ -126,7 +125,7 @@ namespace Castle.DynamicProxy.Contributors
 			return @class.CreateField(namingScope.GetUniqueName(name), type);
 		}
 
-		private Type GetInvocationType(MetaMethod method, ClassEmitter emitter, ProxyGenerationOptions options)
+		private Type GetInvocationType(MetaMethod method, ClassEmitter emitter)
 		{
 			var scope = emitter.ModuleScope;
 			Type[] invocationInterfaces;
@@ -148,7 +147,7 @@ namespace Castle.DynamicProxy.Contributors
 				                                       method.Method,
 				                                       canChangeTarget,
 				                                       null)
-				.Generate(emitter, options, namingScope)
+				.Generate(emitter, namingScope)
 				.BuildType());
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyInstanceContributor.cs
@@ -50,7 +50,7 @@ namespace Castle.DynamicProxy.Contributors
 			return GetTargetReference(emitter).ToExpression();
 		}
 
-		public virtual void Generate(ClassEmitter @class, ProxyGenerationOptions options)
+		public virtual void Generate(ClassEmitter @class)
 		{
 			var interceptors = @class.GetField("__interceptors");
 #if FEATURE_SERIALIZATION

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -65,8 +65,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new ClassProxyGenerator(scope, classToProxy) { Logger = logger };
-			return generator.GenerateCode(additionalInterfacesToProxy, options);
+			var generator = new ClassProxyGenerator(scope, classToProxy, options) { Logger = logger };
+			return generator.GenerateCode(additionalInterfacesToProxy);
 		}
 
 		public Type CreateClassProxyTypeWithTarget(Type classToProxy, Type[] additionalInterfacesToProxy,
@@ -89,8 +89,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithTargetGenerator(scope, interfaceToProxy) { Logger = logger };
-			return generator.GenerateCode(targetType, additionalInterfacesToProxy, options);
+			var generator = new InterfaceProxyWithTargetGenerator(scope, interfaceToProxy, options) { Logger = logger };
+			return generator.GenerateCode(targetType, additionalInterfacesToProxy);
 		}
 
 		public Type CreateInterfaceProxyTypeWithTargetInterface(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -100,8 +100,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, interfaceToProxy) { Logger = logger };
-			return generator.GenerateCode(interfaceToProxy, additionalInterfacesToProxy, options);
+			var generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, interfaceToProxy, options) { Logger = logger };
+			return generator.GenerateCode(interfaceToProxy, additionalInterfacesToProxy);
 		}
 
 		public Type CreateInterfaceProxyTypeWithoutTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -111,8 +111,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithoutTargetGenerator(scope, interfaceToProxy) { Logger = logger };
-			return generator.GenerateCode(typeof(object), additionalInterfacesToProxy, options);
+			var generator = new InterfaceProxyWithoutTargetGenerator(scope, interfaceToProxy, options) { Logger = logger };
+			return generator.GenerateCode(typeof(object), additionalInterfacesToProxy);
 		}
 
 		private void AssertValidMixins(ProxyGenerationOptions options, string paramName)

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -174,22 +174,22 @@ namespace Castle.DynamicProxy.Generators
 
 		protected virtual void CreateTypeAttributes(ClassEmitter emitter)
 		{
-			emitter.AddCustomAttributes(ProxyGenerationOptions);
+			emitter.AddCustomAttributes(ProxyGenerationOptions.AdditionalAttributes);
 #if FEATURE_SERIALIZATION
 			emitter.DefineCustomAttribute<XmlIncludeAttribute>(new object[] { targetType });
 #endif
 		}
 
-		protected void EnsureOptionsOverrideEqualsAndGetHashCode(ProxyGenerationOptions options)
+		protected void EnsureOptionsOverrideEqualsAndGetHashCode()
 		{
 			if (Logger.IsWarnEnabled)
 			{
 				// Check the proxy generation hook
-				if (!OverridesEqualsAndGetHashCode(options.Hook.GetType()))
+				if (!OverridesEqualsAndGetHashCode(ProxyGenerationOptions.Hook.GetType()))
 				{
 					Logger.WarnFormat("The IProxyGenerationHook type {0} does not override both Equals and GetHashCode. " +
 					                  "If these are not correctly overridden caching will fail to work causing performance problems.",
-					                  options.Hook.GetType().FullName);
+					                  ProxyGenerationOptions.Hook.GetType().FullName);
 				}
 
 				// Interceptor selectors no longer need to override Equals and GetHashCode
@@ -381,7 +381,7 @@ namespace Castle.DynamicProxy.Generators
 				notFoundInTypeCache = true;
 				Logger.DebugFormat("No cached proxy type was found for target type {0}.", targetType.FullName);
 
-				EnsureOptionsOverrideEqualsAndGetHashCode(ProxyGenerationOptions);
+				EnsureOptionsOverrideEqualsAndGetHashCode();
 
 				var name = Scope.NamingScope.GetUniqueName("Castle.Proxies." + targetType.Name + "Proxy");
 				return factory.Invoke(name, Scope.NamingScope.SafeSubScope());

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -42,10 +42,12 @@ namespace Castle.DynamicProxy.Generators
 		private ILogger logger = NullLogger.Instance;
 		private ProxyGenerationOptions proxyGenerationOptions;
 
-		protected BaseProxyGenerator(ModuleScope scope, Type targetType)
+		protected BaseProxyGenerator(ModuleScope scope, Type targetType, ProxyGenerationOptions proxyGenerationOptions)
 		{
 			this.scope = scope;
 			this.targetType = targetType;
+			this.proxyGenerationOptions = proxyGenerationOptions;
+			this.proxyGenerationOptions.Initialize();
 		}
 
 		public ILogger Logger
@@ -56,22 +58,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected ProxyGenerationOptions ProxyGenerationOptions
 		{
-			get
-			{
-				if (proxyGenerationOptions == null)
-				{
-					throw new InvalidOperationException("ProxyGenerationOptions must be set before being retrieved.");
-				}
-				return proxyGenerationOptions;
-			}
-			set
-			{
-				if (proxyGenerationOptions != null)
-				{
-					throw new InvalidOperationException("ProxyGenerationOptions can only be set once.");
-				}
-				proxyGenerationOptions = value;
-			}
+			get { return proxyGenerationOptions; }
 		}
 
 		protected ModuleScope Scope

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -27,21 +27,18 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class ClassProxyGenerator : BaseProxyGenerator
 	{
-		public ClassProxyGenerator(ModuleScope scope, Type targetType) : base(scope, targetType)
+		public ClassProxyGenerator(ModuleScope scope, Type targetType, ProxyGenerationOptions options)
+			: base(scope, targetType, options)
 		{
 			CheckNotGenericTypeDefinition(targetType, "targetType");
 			EnsureDoesNotImplementIProxyTargetAccessor(targetType, "targetType");
 		}
 
-		public Type GenerateCode(Type[] interfaces, ProxyGenerationOptions options)
+		public Type GenerateCode(Type[] interfaces)
 		{
-			// make sure ProxyGenerationOptions is initialized
-			options.Initialize();
-
 			interfaces = TypeUtil.GetAllInterfaces(interfaces);
 			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
-			ProxyGenerationOptions = options;
-			var cacheKey = new CacheKey(targetType, interfaces, options);
+			var cacheKey = new CacheKey(targetType, interfaces, ProxyGenerationOptions);
 			return ObtainProxyType(cacheKey, (n, s) => GenerateType(n, interfaces, s));
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Generators
 			var constructorArguments = new List<FieldReference>();
 			foreach (var contributor in contributors)
 			{
-				contributor.Generate(emitter, ProxyGenerationOptions);
+				contributor.Generate(emitter);
 
 				// TODO: redo it
 				var mixinContributor = contributor as MixinContributor;

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -192,7 +192,7 @@ namespace Castle.DynamicProxy.Generators
 
 			foreach (var contributor in contributors)
 			{
-				contributor.Generate(emitter, ProxyGenerationOptions);
+				contributor.Generate(emitter);
 
 				// TODO: redo it
 				if (contributor is MixinContributor)

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -34,14 +34,12 @@ namespace Castle.DynamicProxy.Generators
 
 		public ClassProxyWithTargetGenerator(ModuleScope scope, Type classToProxy, Type[] additionalInterfacesToProxy,
 		                                     ProxyGenerationOptions options)
-			: base(scope, classToProxy)
+			: base(scope, classToProxy, options)
 		{
 			CheckNotGenericTypeDefinition(targetType, "targetType");
 			EnsureDoesNotImplementIProxyTargetAccessor(targetType, "targetType");
 			CheckNotGenericTypeDefinitions(additionalInterfacesToProxy, "additionalInterfacesToProxy");
 
-			options.Initialize();
-			ProxyGenerationOptions = options;
 			this.additionalInterfacesToProxy = TypeUtil.GetAllInterfaces(additionalInterfacesToProxy);
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -34,7 +34,6 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected override ArgumentReference[] GetBaseCtorArguments(Type targetFieldType,
-		                                                            ProxyGenerationOptions proxyGenerationOptions,
 		                                                            out ConstructorInfo baseConstructor)
 		{
 			baseConstructor = InvocationMethods.CompositionInvocationConstructor;

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
@@ -38,7 +38,7 @@ namespace Castle.DynamicProxy.Generators
 			this.targetType = targetType;
 		}
 
-		public AbstractTypeEmitter Generate(ClassEmitter @class, ProxyGenerationOptions options, INamingScope namingScope)
+		public AbstractTypeEmitter Generate(ClassEmitter @class, INamingScope namingScope)
 		{
 			var emitter = GetEmitter(@class, namingScope);
 			BuildConstructor(emitter);

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -88,9 +88,9 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			get { return typebuilder; }
 		}
 
-		public void AddCustomAttributes(ProxyGenerationOptions proxyGenerationOptions)
+		public void AddCustomAttributes(IEnumerable<CustomAttributeInfo> additionalAttributes)
 		{
-			foreach (var attribute in proxyGenerationOptions.AdditionalAttributes)
+			foreach (var attribute in additionalAttributes)
 			{
 				typebuilder.SetCustomAttribute(attribute.Builder);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
@@ -30,7 +30,7 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class,
-		                                                        ProxyGenerationOptions options, INamingScope namingScope)
+		                                                        INamingScope namingScope)
 		{
 			var targetReference = getTargetReference(@class, MethodToOverride);
 			var arguments = ArgumentsUtil.ConvertToArgumentReferenceExpression(MethodToOverride.GetParameters());

--- a/src/Castle.Core/DynamicProxy/Generators/IGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/IGenerator.cs
@@ -18,6 +18,6 @@ namespace Castle.DynamicProxy.Generators
 
 	internal interface IGenerator<T>
 	{
-		T Generate(ClassEmitter @class, ProxyGenerationOptions options, INamingScope namingScope);
+		T Generate(ClassEmitter @class, INamingScope namingScope);
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
@@ -33,7 +33,6 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected override ArgumentReference[] GetBaseCtorArguments(Type targetFieldType,
-		                                                            ProxyGenerationOptions proxyGenerationOptions,
 		                                                            out ConstructorInfo baseConstructor)
 		{
 			baseConstructor = InvocationMethods.InheritanceInvocationConstructor;

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -32,8 +32,8 @@ namespace Castle.DynamicProxy.Generators
 	{
 		protected FieldReference targetField;
 
-		public InterfaceProxyWithTargetGenerator(ModuleScope scope, Type @interface)
-			: base(scope, @interface)
+		public InterfaceProxyWithTargetGenerator(ModuleScope scope, Type @interface, ProxyGenerationOptions options)
+			: base(scope, @interface, options)
 		{
 			CheckNotGenericTypeDefinition(@interface, "@interface");
 		}
@@ -48,18 +48,14 @@ namespace Castle.DynamicProxy.Generators
 			get { return ProxyTypeConstants.InterfaceWithTarget; }
 		}
 
-		public Type GenerateCode(Type proxyTargetType, Type[] interfaces, ProxyGenerationOptions options)
+		public Type GenerateCode(Type proxyTargetType, Type[] interfaces)
 		{
-			// make sure ProxyGenerationOptions is initialized
-			options.Initialize();
-
 			CheckNotGenericTypeDefinition(proxyTargetType, "proxyTargetType");
 			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
-			EnsureValidBaseType(options.BaseTypeForInterfaceProxy);
-			ProxyGenerationOptions = options;
+			EnsureValidBaseType(ProxyGenerationOptions.BaseTypeForInterfaceProxy);
 
 			interfaces = TypeUtil.GetAllInterfaces(interfaces);
-			var cacheKey = new CacheKey(proxyTargetType, targetType, interfaces, options);
+			var cacheKey = new CacheKey(proxyTargetType, targetType, interfaces, ProxyGenerationOptions);
 
 			return ObtainProxyType(cacheKey, (n, s) => GenerateType(n, proxyTargetType, interfaces, s));
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -124,7 +124,7 @@ namespace Castle.DynamicProxy.Generators
 
 			foreach (var contributor in contributors)
 			{
-				contributor.Generate(emitter, ProxyGenerationOptions);
+				contributor.Generate(emitter);
 
 				// TODO: redo it
 				if (contributor is MixinContributor)

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -26,8 +26,8 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithTargetInterfaceGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type @interface)
-			: base(scope, @interface)
+		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type @interface, ProxyGenerationOptions options)
+			: base(scope, @interface, options)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -25,7 +25,8 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithoutTargetGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type @interface) : base(scope, @interface)
+		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type @interface, ProxyGenerationOptions options)
+			: base(scope, @interface, options)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -73,7 +73,7 @@ namespace Castle.DynamicProxy.Generators
 
 			foreach (var contributor in contributors)
 			{
-				contributor.Generate(emitter, ProxyGenerationOptions);
+				contributor.Generate(emitter);
 
 				// TODO: redo it
 				if (contributor is MixinContributor)

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -48,14 +48,13 @@ namespace Castle.DynamicProxy.Generators
 		///   <see cref = "AbstractInvocation" />
 		/// </summary>
 		protected abstract ArgumentReference[] GetBaseCtorArguments(Type targetFieldType,
-		                                                            ProxyGenerationOptions proxyGenerationOptions,
 		                                                            out ConstructorInfo baseConstructor);
 
 		protected abstract Type GetBaseType();
 
 		protected abstract FieldReference GetTargetReference();
 
-		public AbstractTypeEmitter Generate(ClassEmitter @class, ProxyGenerationOptions options, INamingScope namingScope)
+		public AbstractTypeEmitter Generate(ClassEmitter @class, INamingScope namingScope)
 		{
 			var methodInfo = method.Method;
 
@@ -71,7 +70,7 @@ namespace Castle.DynamicProxy.Generators
 			// targetType cannot be a generic type definition (YET!)
 			invocation.CopyGenericParametersFromMethod(methodInfo);
 
-			CreateConstructor(invocation, options);
+			CreateConstructor(invocation);
 
 			var targetField = GetTargetReference();
 			if (canChangeTarget)
@@ -211,10 +210,10 @@ namespace Castle.DynamicProxy.Generators
 			invokeMethodOnTarget.CodeBuilder.AddStatement(new EndExceptionBlockStatement());
 		}
 
-		private void CreateConstructor(AbstractTypeEmitter invocation, ProxyGenerationOptions options)
+		private void CreateConstructor(AbstractTypeEmitter invocation)
 		{
 			ConstructorInfo baseConstructor;
-			var baseCtorArguments = GetBaseCtorArguments(targetType, options, out baseConstructor);
+			var baseCtorArguments = GetBaseCtorArguments(targetType, out baseConstructor);
 
 			var constructor = CreateConstructor(invocation, baseCtorArguments);
 			constructor.CodeBuilder.InvokeBaseConstructor(baseConstructor, baseCtorArguments);

--- a/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
@@ -41,12 +41,12 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected abstract MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class,
-		                                                        ProxyGenerationOptions options, INamingScope namingScope);
+		                                                        INamingScope namingScope);
 
-		public MethodEmitter Generate(ClassEmitter @class, ProxyGenerationOptions options, INamingScope namingScope)
+		public MethodEmitter Generate(ClassEmitter @class, INamingScope namingScope)
 		{
 			var methodEmitter = overrideMethod(method.Name, method.Attributes, MethodToOverride);
-			var proxiedMethod = BuildProxiedMethodBody(methodEmitter, @class, options, namingScope);
+			var proxiedMethod = BuildProxiedMethodBody(methodEmitter, @class, namingScope);
 
 			if (MethodToOverride.DeclaringType.IsInterface)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Generators
 			return methodInterceptors;
 		}
 
-		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class, ProxyGenerationOptions options, INamingScope namingScope)
+		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class, INamingScope namingScope)
 		{
 			var invocationType = invocation;
 

--- a/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
@@ -28,7 +28,7 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class,
-		                                                        ProxyGenerationOptions options, INamingScope namingScope)
+		                                                        INamingScope namingScope)
 		{
 			InitOutParameters(emitter, MethodToOverride.GetParameters());
 

--- a/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
@@ -34,7 +34,7 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 		protected override MethodEmitter BuildProxiedMethodBody(MethodEmitter emitter, ClassEmitter @class,
-		                                                        ProxyGenerationOptions options, INamingScope namingScope)
+		                                                        INamingScope namingScope)
 		{
 			var targetReference = getTargetReference(@class, MethodToOverride);
 

--- a/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
@@ -144,15 +144,15 @@ namespace Castle.DynamicProxy.Serialization
 			InterfaceProxyWithTargetGenerator generator;
 			if (generatorType == ProxyTypeConstants.InterfaceWithTarget)
 			{
-				generator = new InterfaceProxyWithTargetGenerator(scope, @interface);
+				generator = new InterfaceProxyWithTargetGenerator(scope, @interface, proxyGenerationOptions);
 			}
 			else if (generatorType == ProxyTypeConstants.InterfaceWithoutTarget)
 			{
-				generator = new InterfaceProxyWithoutTargetGenerator(scope, @interface);
+				generator = new InterfaceProxyWithoutTargetGenerator(scope, @interface, proxyGenerationOptions);
 			}
 			else if (generatorType == ProxyTypeConstants.InterfaceWithTargetInterface)
 			{
-				generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, @interface);
+				generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, @interface, proxyGenerationOptions);
 			}
 			else
 			{
@@ -162,14 +162,14 @@ namespace Castle.DynamicProxy.Serialization
 						generatorType));
 			}
 
-			var proxyType = generator.GenerateCode(targetType, interfaces, proxyGenerationOptions);
+			var proxyType = generator.GenerateCode(targetType, interfaces);
 			return FormatterServices.GetSafeUninitializedObject(proxyType);
 		}
 
 		public object RecreateClassProxy()
 		{
-			var generator = new ClassProxyGenerator(scope, baseType);
-			var proxyType = generator.GenerateCode(interfaces, proxyGenerationOptions);
+			var generator = new ClassProxyGenerator(scope, baseType, proxyGenerationOptions);
+			var proxyType = generator.GenerateCode(interfaces);
 			return InstantiateClassProxy(proxyType);
 		}
 


### PR DESCRIPTION
While doing some prototyping for #517, I noticed that `ProxyGenerationOptions` instances get passed around a lot needlessly. This refactoring PR gets rid of all excess `options` parameters that I could identify, and changes some remaining usages to favour constructor injection.

One caveat: Some of these removals may only be temporary. DynamicProxy weaves a web of fairly tightly coupled objects during proxy type generation (generators, collectors, contributors, emitters, etc.). If you need `options` somewhere, chances are that you'll have to pass them through a whole lot of other objects first. Yet, removing the excess now may be a good thing as it will confront us with that problem all the more in the future, and that may lead us to consider alternative solutions&mdash;e.g. refactoring towards loose coupling, simplifying the internal object graphs, making `options` available through an ambient context, etc.