### PR TITLE
Added SPDX license identifiers

### DIFF
--- a/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
+++ b/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
@@ -18,6 +18,7 @@
 		<SignAssembly>True</SignAssembly>
 		<PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
 		<PackageTags>castle logging NLog</PackageTags>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
+++ b/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
@@ -18,6 +18,7 @@
 		<SignAssembly>True</SignAssembly>
 		<PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
 		<PackageTags>castle logging serilog</PackageTags>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
+++ b/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
@@ -18,6 +18,7 @@
 		<SignAssembly>True</SignAssembly>
 		<PublicSign Condition="'$(OS)'=='Unix'">true</PublicSign>
 		<PackageTags>castle logging log4net</PackageTags>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.