### PR TITLE
Fix build by updating `ref/` contracts

### DIFF
--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Castle.Core.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010077f5e87030dadccce6902c6adab7a987bd69cb5819991531f560785eacfc89b6fcddf6bb2a00743a7194e454c0273447fc6eec36474ba8e5a3823147d214298e4f9a631b1afee1a51ffeae4672d498f14b000e3d321453cdd8ac064de7e1cf4d222b7e81f54d4fd46725370d702a05b48738cc29d09228f1aa722ae1a9ca02fb")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Castle.Core.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010077f5e87030dadccce6902c6adab7a987bd69cb5819991531f560785eacfc89b6fcddf6bb2a00743a7194e454c0273447fc6eec36474ba8e5a3823147d214298e4f9a631b1afee1a51ffeae4672d498f14b000e3d321453cdd8ac064de7e1cf4d222b7e81f54d4fd46725370d702a05b48738cc29d09228f1aa722ae1a9ca02fb")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Castle.Core.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010077f5e87030dadccce6902c6adab7a987bd69cb5819991531f560785eacfc89b6fcddf6bb2a00743a7194e454c0273447fc6eec36474ba8e5a3823147d214298e4f9a631b1afee1a51ffeae4672d498f14b000e3d321453cdd8ac064de7e1cf4d222b7e81f54d4fd46725370d702a05b48738cc29d09228f1aa722ae1a9ca02fb")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]

--- a/ref/Castle.Services.Logging.NLogIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-net45.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
 namespace Castle.Services.Logging.NLogIntegration

--- a/ref/Castle.Services.Logging.NLogIntegration-netstandard2.0.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-netstandard2.0.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.NLogIntegration

--- a/ref/Castle.Services.Logging.NLogIntegration-netstandard2.1.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-netstandard2.1.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.NLogIntegration

--- a/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-net45.cs
@@ -1,3 +1,4 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
 namespace Castle.Services.Logging.SerilogIntegration
 {

--- a/ref/Castle.Services.Logging.SerilogIntegration-netstandard2.0.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-netstandard2.0.cs
@@ -1,3 +1,4 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.SerilogIntegration
 {

--- a/ref/Castle.Services.Logging.SerilogIntegration-netstandard2.1.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-netstandard2.1.cs
@@ -1,3 +1,4 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.SerilogIntegration
 {

--- a/ref/Castle.Services.Logging.log4netIntegration-net45.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net45.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
 namespace Castle.Services.Logging.Log4netIntegration

--- a/ref/Castle.Services.Logging.log4netIntegration-netstandard2.0.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-netstandard2.0.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.Log4netIntegration

--- a/ref/Castle.Services.Logging.log4netIntegration-netstandard2.1.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-netstandard2.1.cs
@@ -1,4 +1,5 @@
 [assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Castle.Services.Logging.Log4netIntegration


### PR DESCRIPTION
(.NET compilers have started emitting an `assembly: [AssemblyMetadata]` attribute for the `<RepositoryUrl>` build property.)