### PR TITLE
Mark DynamicProxy's internal classes as `sealed`

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -27,7 +27,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class ClassProxyTargetContributor : CompositeTypeContributor
+	internal sealed class ClassProxyTargetContributor : CompositeTypeContributor
 	{
 		private readonly IList<MethodInfo> methodsToSkip;
 		private readonly Type targetType;

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class ClassProxyWithTargetTargetContributor : CompositeTypeContributor
+	internal sealed class ClassProxyWithTargetTargetContributor : CompositeTypeContributor
 	{
 		private readonly IList<MethodInfo> methodsToSkip;
 		private readonly Type targetType;

--- a/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using System;
 	using System.Collections.Generic;
 
-	internal class FieldReferenceComparer : IComparer<Type>
+	internal sealed class FieldReferenceComparer : IComparer<Type>
 	{
 		public int Compare(Type x, Type y)
 		{

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceMembersCollector : MembersCollector
+	internal sealed class InterfaceMembersCollector : MembersCollector
 	{
 		public InterfaceMembersCollector(Type @interface)
 			: base(@interface)

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceMembersOnClassCollector : MembersCollector
+	internal sealed class InterfaceMembersOnClassCollector : MembersCollector
 	{
 		private readonly InterfaceMapping map;
 		private readonly bool onlyProxyVirtual;

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyInstanceContributor.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InterfaceProxyInstanceContributor : ProxyInstanceContributor
+	internal sealed class InterfaceProxyInstanceContributor : ProxyInstanceContributor
 	{
 		protected override Reference GetTargetReference(ClassEmitter emitter)
 		{

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class InterfaceProxyWithOptionalTargetContributor : InterfaceProxyWithoutTargetContributor
+	internal sealed class InterfaceProxyWithOptionalTargetContributor : InterfaceProxyWithoutTargetContributor
 	{
 		private readonly GetTargetReferenceDelegate getTargetReference;
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceProxyWithTargetInterfaceTargetContributor : InterfaceProxyTargetContributor
+	internal sealed class InterfaceProxyWithTargetInterfaceTargetContributor : InterfaceProxyTargetContributor
 	{
 		public InterfaceProxyWithTargetInterfaceTargetContributor(Type proxyTargetType, bool allowChangeTarget,
 		                                                          INamingScope namingScope)

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InvocationWithDelegateContributor : IInvocationCreationContributor
+	internal sealed class InvocationWithDelegateContributor : IInvocationCreationContributor
 	{
 		private readonly Type delegateType;
 		private readonly MetaMethod method;

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InvocationWithGenericDelegateContributor : IInvocationCreationContributor
+	internal sealed class InvocationWithGenericDelegateContributor : IInvocationCreationContributor
 	{
 		private readonly Type delegateType;
 		private readonly MetaMethod method;

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -24,7 +24,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;
 
-	internal class MixinContributor : CompositeTypeContributor
+	internal sealed class MixinContributor : CompositeTypeContributor
 	{
 		private readonly bool canChangeTarget;
 		private readonly IList<Type> empty = new List<Type>();

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Internal;
 
-	internal class WrappedClassMembersCollector : ClassMembersCollector
+	internal sealed class WrappedClassMembersCollector : ClassMembersCollector
 	{
 		public WrappedClassMembersCollector(Type type) : base(type)
 		{
@@ -52,13 +52,13 @@ namespace Castle.DynamicProxy.Contributors
 			return new MetaMethod(method, method, isStandalone, accepted, hasTarget: true);
 		}
 
-		protected bool IsGeneratedByTheCompiler(FieldInfo field)
+		private bool IsGeneratedByTheCompiler(FieldInfo field)
 		{
 			// for example fields backing autoproperties
 			return field.IsDefined(typeof(CompilerGeneratedAttribute));
 		}
 
-		protected virtual bool IsOKToBeOnProxy(FieldInfo field)
+		private bool IsOKToBeOnProxy(FieldInfo field)
 		{
 			return IsGeneratedByTheCompiler(field);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	internal class CacheKey
+	internal sealed class CacheKey
 	{
 		private readonly MemberInfo target;
 		private readonly Type[] interfaces;

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Serialization;
 
-	internal class ClassProxyGenerator : BaseProxyGenerator
+	internal sealed class ClassProxyGenerator : BaseProxyGenerator
 	{
 		public ClassProxyGenerator(ModuleScope scope, Type targetType, Type[] interfaces, ProxyGenerationOptions options)
 			: base(scope, targetType, interfaces, options)
@@ -94,8 +94,7 @@ namespace Castle.DynamicProxy.Generators
 			return proxyType;
 		}
 
-		protected virtual IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors,
-																	  INamingScope namingScope)
+		private IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors, INamingScope namingScope)
 		{
 			var methodsToSkip = new List<MethodInfo>();
 			var proxyInstance = new ClassProxyInstanceContributor(targetType, methodsToSkip, interfaces, ProxyTypeConstants.Class);

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -28,7 +28,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Serialization;
 
-	internal class ClassProxyWithTargetGenerator : BaseProxyGenerator
+	internal sealed class ClassProxyWithTargetGenerator : BaseProxyGenerator
 	{
 		public ClassProxyWithTargetGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
 		                                     ProxyGenerationOptions options)
@@ -37,8 +37,7 @@ namespace Castle.DynamicProxy.Generators
 			EnsureDoesNotImplementIProxyTargetAccessor(targetType, "targetType");
 		}
 
-		protected virtual IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors,
-		                                                              INamingScope namingScope)
+		private IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors, INamingScope namingScope)
 		{
 			var methodsToSkip = new List<MethodInfo>();
 			var proxyInstance = new ClassProxyWithTargetInstanceContributor(targetType, methodsToSkip, interfaces,

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class CompositionInvocationTypeGenerator : InvocationTypeGenerator
+	internal sealed class CompositionInvocationTypeGenerator : InvocationTypeGenerator
 	{
 		public static readonly Type BaseType = typeof(CompositionInvocation);
 

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;
 
-	internal class DelegateTypeGenerator : IGenerator<AbstractTypeEmitter>
+	internal sealed class DelegateTypeGenerator : IGenerator<AbstractTypeEmitter>
 	{
 		private const TypeAttributes DelegateFlags = TypeAttributes.Class |
 		                                             TypeAttributes.Public |

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal abstract class ArgumentsUtil
+	internal static class ArgumentsUtil
 	{
 		public static Expression[] ConvertArgumentReferenceToExpression(ArgumentReference[] args)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 	using Castle.DynamicProxy.Internal;
 
-	internal class ClassEmitter : AbstractTypeEmitter
+	internal sealed class ClassEmitter : AbstractTypeEmitter
 	{
 		internal const TypeAttributes DefaultAttributes =
 			TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Serializable;
@@ -81,8 +81,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			get { return StrongNameUtil.IsAssemblySigned(TypeBuilder.Assembly); }
 		}
 
-		protected virtual IEnumerable<Type> InitializeGenericArgumentsFromBases(ref Type baseType,
-		                                                                        IEnumerable<Type> interfaces)
+		private IEnumerable<Type> InitializeGenericArgumentsFromBases(ref Type baseType, IEnumerable<Type> interfaces)
 		{
 			if (baseType != null && baseType.IsGenericTypeDefinition)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/ConstructorCodeBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/ConstructorCodeBuilder.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class ConstructorCodeBuilder : AbstractCodeBuilder
+	internal sealed class ConstructorCodeBuilder : AbstractCodeBuilder
 	{
 		private readonly Type baseType;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/MethodCodeBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilders/MethodCodeBuilder.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.CodeBuilders
 {
 	using System.Reflection.Emit;
 
-	internal class MethodCodeBuilder : AbstractCodeBuilder
+	internal sealed class MethodCodeBuilder : AbstractCodeBuilder
 	{
 		public MethodCodeBuilder(ILGenerator generator) : base(generator)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class EventEmitter : IMemberEmitter
+	internal sealed class EventEmitter : IMemberEmitter
 	{
 		private readonly EventBuilder eventBuilder;
 		private readonly Type type;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 	internal delegate GenericTypeParameterBuilder[] ApplyGenArgs(string[] argumentNames);
 
-	internal class GenericUtil
+	internal sealed class GenericUtil
 	{
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -26,7 +26,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using Castle.DynamicProxy.Internal;
 
 	[DebuggerDisplay("{builder.Name}")]
-	internal class MethodEmitter : IMemberEmitter
+	internal sealed class MethodEmitter : IMemberEmitter
 	{
 		private readonly MethodBuilder builder;
 		private readonly GenericTypeParameterBuilder[] genericTypeParams;
@@ -35,7 +35,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		private MethodCodeBuilder codebuilder;
 
-		protected internal MethodEmitter(MethodBuilder builder)
+		private MethodEmitter(MethodBuilder builder)
 		{
 			this.builder = builder;
 		}
@@ -76,7 +76,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			get { return arguments; }
 		}
 
-		public virtual MethodCodeBuilder CodeBuilder
+		public MethodCodeBuilder CodeBuilder
 		{
 			get
 			{
@@ -129,7 +129,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			ArgumentsUtil.InitializeArgumentsByPosition(arguments, MethodBuilder.IsStatic);
 		}
 
-		public virtual void EnsureValidCodeBlock()
+		public void EnsureValidCodeBlock()
 		{
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
@@ -138,7 +138,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			}
 		}
 
-		public virtual void Generate()
+		public void Generate()
 		{
 			if (ImplementedByRuntime)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class NestedClassEmitter : AbstractTypeEmitter
+	internal sealed class NestedClassEmitter : AbstractTypeEmitter
 	{
 		public NestedClassEmitter(AbstractTypeEmitter maintype, string name, Type baseType, Type[] interfaces)
 			: this(

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal abstract class OpCodeUtil
+	internal static class OpCodeUtil
 	{
 		/// <summary>
 		///   Emits a load indirect opcode of the appropriate type for a value or object reference.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class PropertyEmitter : IMemberEmitter
+	internal sealed class PropertyEmitter : IMemberEmitter
 	{
 		private readonly PropertyBuilder builder;
 		private readonly AbstractTypeEmitter parentTypeEmitter;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AddressOfReferenceExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AddressOfReferenceExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AddressOfReferenceExpression : Expression
+	internal sealed class AddressOfReferenceExpression : Expression
 	{
 		private readonly Reference reference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("argument {Type}")]
-	internal class ArgumentReference : TypeReference
+	internal sealed class ArgumentReference : TypeReference
 	{
 		public ArgumentReference(Type argumentType)
 			: base(argumentType)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{reference} as {type}")]
-	internal class AsTypeReference : Reference
+	internal sealed class AsTypeReference : Reference
 	{
 		private readonly Reference reference;
 		private readonly Type type;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignArgumentStatement : Statement
+	internal sealed class AssignArgumentStatement : Statement
 	{
 		private readonly ArgumentReference argument;
 		private readonly Expression expression;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignArrayStatement : Statement
+	internal sealed class AssignArrayStatement : Statement
 	{
 		private readonly Reference targetArray;
 		private readonly int targetPosition;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignStatement : Statement
+	internal sealed class AssignStatement : Statement
 	{
 		private readonly Expression expression;
 		private readonly Reference target;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BindDelegateExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BindDelegateExpression.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	using Castle.DynamicProxy.Internal;
 
-	internal class BindDelegateExpression : Expression
+	internal sealed class BindDelegateExpression : Expression
 	{
 		private readonly ConstructorInfo delegateCtor;
 		private readonly MethodInfo methodToBindTo;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 
 	[DebuggerDisplay("&{localReference}")]
-	internal class ByRefReference : TypeReference
+	internal sealed class ByRefReference : TypeReference
 	{
 		private readonly LocalReference localReference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstReference.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{value}")]
-	internal class ConstReference : TypeReference
+	internal sealed class ConstReference : TypeReference
 	{
 		private readonly object value;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ConstructorInvocationStatement : Statement
+	internal sealed class ConstructorInvocationStatement : Statement
 	{
 		private readonly Expression[] args;
 		private readonly ConstructorInfo cmethod;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ConvertExpression : Expression
+	internal sealed class ConvertExpression : Expression
 	{
 		private readonly Expression right;
 		private Type fromType;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class DefaultValueExpression : Expression
+	internal sealed class DefaultValueExpression : Expression
 	{
 		private readonly Type type;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class EndExceptionBlockStatement : Statement
+	internal sealed class EndExceptionBlockStatement : Statement
 	{
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ExpressionStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ExpressionStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class ExpressionStatement : Statement
+	internal sealed class ExpressionStatement : Statement
 	{
 		private readonly Expression expression;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{fieldbuilder.Name} ({fieldbuilder.FieldType})")]
-	internal class FieldReference : Reference
+	internal sealed class FieldReference : Reference
 	{
 		private readonly FieldInfo field;
 		private readonly FieldBuilder fieldbuilder;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class FinallyStatement : Statement
+	internal sealed class FinallyStatement : Statement
 	{
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class IfNullExpression : Expression
+	internal sealed class IfNullExpression : Expression
 	{
 		private readonly IILEmitter ifNotNull;
 		private readonly IILEmitter ifNull;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
@@ -24,7 +24,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	///   ByRef and provides indirect load/store support.
 	/// </summary>
 	[DebuggerDisplay("&{OwnerReference}")]
-	internal class IndirectReference : TypeReference
+	internal sealed class IndirectReference : TypeReference
 	{
 		public IndirectReference(TypeReference byRefReference) :
 			base(byRefReference, byRefReference.Type.GetElementType())

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LiteralIntExpression : Expression
+	internal sealed class LiteralIntExpression : Expression
 	{
 		private readonly int value;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadArrayElementExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class LoadArrayElementExpression : Expression
+	internal sealed class LoadArrayElementExpression : Expression
 	{
 		private readonly Reference arrayReference;
 		private readonly ConstReference index;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LoadRefArrayElementExpression : Expression
+	internal sealed class LoadRefArrayElementExpression : Expression
 	{
 		private readonly Reference arrayReference;
 		private readonly ConstReference index;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("local {Type}")]
-	internal class LocalReference : TypeReference
+	internal sealed class LocalReference : TypeReference
 	{
 		private LocalBuilder localbuilder;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
@@ -17,11 +17,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class MethodInvocationExpression : Expression
+	internal sealed class MethodInvocationExpression : Expression
 	{
-		protected readonly Expression[] args;
-		protected readonly MethodInfo method;
-		protected readonly Reference owner;
+		private readonly Expression[] args;
+		private readonly MethodInfo method;
+		private readonly Reference owner;
 
 		public MethodInvocationExpression(MethodInfo method, params Expression[] args) :
 			this(SelfReference.Self, method, args)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	using Castle.DynamicProxy.Tokens;
 
-	internal class MethodTokenExpression : Expression
+	internal sealed class MethodTokenExpression : Expression
 	{
 		private readonly MethodInfo method;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MultiStatementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MultiStatementExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Collections.Generic;
 	using System.Reflection.Emit;
 
-	internal class MultiStatementExpression : Expression
+	internal sealed class MultiStatementExpression : Expression
 	{
 		private readonly List<Statement> statements = new List<Statement>();
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class NewArrayExpression : Expression
+	internal sealed class NewArrayExpression : Expression
 	{
 		private readonly Type arrayType;
 		private readonly int size;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class NewInstanceExpression : Expression
+	internal sealed class NewInstanceExpression : Expression
 	{
 		private readonly Expression[] arguments;
 		private ConstructorInfo constructor;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NopStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NopStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class NopStatement : Statement
+	internal sealed class NopStatement : Statement
 	{
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class NullCoalescingOperatorExpression : Expression
+	internal sealed class NullCoalescingOperatorExpression : Expression
 	{
 		private readonly Expression @default;
 		private readonly Expression expression;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
@@ -16,11 +16,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class NullExpression : Expression
+	internal sealed class NullExpression : Expression
 	{
 		public static readonly NullExpression Instance = new NullExpression();
 
-		protected NullExpression()
+		private NullExpression()
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferenceExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferenceExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class ReferenceExpression : Expression
+	internal sealed class ReferenceExpression : Expression
 	{
 		private readonly Reference reference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ReferencesToObjectArrayExpression : Expression
+	internal sealed class ReferencesToObjectArrayExpression : Expression
 	{
 		private readonly TypeReference[] args;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class ReturnStatement : Statement
+	internal sealed class ReturnStatement : Statement
 	{
 		private readonly Expression expression;
 		private readonly Reference reference;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
@@ -19,11 +19,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("this")]
-	internal class SelfReference : Reference
+	internal sealed class SelfReference : Reference
 	{
 		public static readonly SelfReference Self = new SelfReference();
 
-		protected SelfReference() : base(null)
+		private SelfReference() : base(null)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ThrowStatement : Statement
+	internal sealed class ThrowStatement : Statement
 	{
 		private readonly string errorMessage;
 		private readonly Type exceptionType;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class TryStatement : Statement
+	internal sealed class TryStatement : Statement
 	{
 		public override void Emit(IMemberEmitter member, ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	using Castle.DynamicProxy.Tokens;
 
-	internal class TypeTokenExpression : Expression
+	internal sealed class TypeTokenExpression : Expression
 	{
 		private readonly Type type;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class TypeConstructorEmitter : ConstructorEmitter
+	internal sealed class TypeConstructorEmitter : ConstructorEmitter
 	{
 		internal TypeConstructorEmitter(AbstractTypeEmitter maintype)
 			: base(maintype, maintype.TypeBuilder.DefineTypeInitializer())

--- a/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class ForwardingMethodGenerator : MethodGenerator
+	internal sealed class ForwardingMethodGenerator : MethodGenerator
 	{
 		private readonly GetTargetReferenceDelegate getTargetReference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InheritanceInvocationTypeGenerator : InvocationTypeGenerator
+	internal sealed class InheritanceInvocationTypeGenerator : InvocationTypeGenerator
 	{
 		public static readonly Type BaseType = typeof(InheritanceInvocation);
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -24,7 +24,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Serialization;
 
-	internal class InterfaceProxyWithTargetInterfaceGenerator : InterfaceProxyWithTargetGenerator
+	internal sealed class InterfaceProxyWithTargetInterfaceGenerator : InterfaceProxyWithTargetGenerator
 	{
 		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
 		                                                  Type proxyTargetType, ProxyGenerationOptions options)

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Serialization;
 
-	internal class InterfaceProxyWithoutTargetGenerator : InterfaceProxyWithTargetGenerator
+	internal sealed class InterfaceProxyWithoutTargetGenerator : InterfaceProxyWithTargetGenerator
 	{
 		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
 		                                            Type proxyTargetType, ProxyGenerationOptions options)

--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class MetaEvent : MetaTypeElement, IEquatable<MetaEvent>
+	internal sealed class MetaEvent : MetaTypeElement, IEquatable<MetaEvent>
 	{
 		private readonly MetaMethod adder;
 		private readonly MetaMethod remover;

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Reflection;
 
 	[DebuggerDisplay("{Method}")]
-	internal class MetaMethod : MetaTypeElement, IEquatable<MetaMethod>
+	internal sealed class MetaMethod : MetaTypeElement, IEquatable<MetaMethod>
 	{
 		private const MethodAttributes ExplicitImplementationAttributes = MethodAttributes.Virtual |
 		                                                                  MethodAttributes.Public |

--- a/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class MetaProperty : MetaTypeElement, IEquatable<MetaProperty>
+	internal sealed class MetaProperty : MetaTypeElement, IEquatable<MetaProperty>
 	{
 		private readonly Type[] arguments;
 		private readonly PropertyAttributes attributes;

--- a/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators
 {
 	using System.Collections.Generic;
 
-	internal class MetaType
+	internal sealed class MetaType
 	{
 		private readonly ICollection<MetaEvent> events = new TypeElementCollection<MetaEvent>();
 		private readonly ICollection<MetaMethod> methods = new TypeElementCollection<MetaMethod>();

--- a/src/Castle.Core/DynamicProxy/Generators/MethodFinder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodFinder.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Generators
 	///   Returns the methods implemented by a type. Use this instead of Type.GetMethods() to work around a CLR issue
 	///   where duplicate MethodInfos are returned by Type.GetMethods() after a token of a generic type's method was loaded.
 	/// </summary>
-	internal class MethodFinder
+	internal sealed class MethodFinder
 	{
 		private static readonly Dictionary<Type, MethodInfo[]> cachedMethodInfosByType = new Dictionary<Type, MethodInfo[]>();
 		private static readonly object lockObject = new object();

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Reflection;
 
-	internal class MethodSignatureComparer : IEqualityComparer<MethodInfo>
+	internal sealed class MethodSignatureComparer : IEqualityComparer<MethodInfo>
 	{
 		public static readonly MethodSignatureComparer Instance = new MethodSignatureComparer();
 

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -29,7 +29,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class MethodWithInvocationGenerator : MethodGenerator
+	internal sealed class MethodWithInvocationGenerator : MethodGenerator
 	{
 		private readonly IInvocationCreationContributor contributor;
 		private readonly GetTargetExpressionDelegate getTargetExpression;
@@ -57,7 +57,7 @@ namespace Castle.DynamicProxy.Generators
 			this.contributor = contributor;
 		}
 
-		protected FieldReference BuildMethodInterceptorsField(ClassEmitter @class, MethodInfo method, INamingScope namingScope)
+		private FieldReference BuildMethodInterceptorsField(ClassEmitter @class, MethodInfo method, INamingScope namingScope)
 		{
 			var methodInterceptors = @class.CreateField(
 				namingScope.GetUniqueName(string.Format("interceptors_{0}", method.Name)),

--- a/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class MinimialisticMethodGenerator : MethodGenerator
+	internal sealed class MinimialisticMethodGenerator : MethodGenerator
 	{
 		public MinimialisticMethodGenerator(MetaMethod method, OverrideMethodDelegate overrideMethod)
 			: base(method, overrideMethod)

--- a/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Diagnostics;
 
-	internal class NamingScope : INamingScope
+	internal sealed class NamingScope : INamingScope
 	{
 		private readonly IDictionary<string, int> names = new Dictionary<string, int>();
 		private readonly INamingScope parentScope;

--- a/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class OptionallyForwardingMethodGenerator : MethodGenerator
+	internal sealed class OptionallyForwardingMethodGenerator : MethodGenerator
 	{
 		// TODO: This class largely duplicates code from Forwarding and Minimalistic generators. Should be refactored to change that
 		private readonly GetTargetReferenceDelegate getTargetReference;

--- a/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/TypeElementCollection.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections;
 	using System.Collections.Generic;
 
-	internal class TypeElementCollection<TElement> : ICollection<TElement>
+	internal sealed class TypeElementCollection<TElement> : ICollection<TElement>
 		where TElement : MetaTypeElement, IEquatable<TElement>
 	{
 		private readonly ICollection<TElement> items = new List<TElement>();


### PR DESCRIPTION
DynamicProxy's internals have been stable over the past few years, and now that they are no longer public (see #505), we can view their type hierarchy as essentially frozen&mdash;at least for the time being. Marking internal classes that have no subclasses of their own as `sealed` formalizes this.

Being able to recognize final classes at a glance can be helpful when we want to refactor them.

(A few refactorings are included here because the C# compiler will warn about / disallow new `protected` or `virtual` members in `sealed` types.)

**Update:** Converting to draft, this PR should perhaps also devirtualize non-overridden members, and make them `private` where possible.