### PR TITLE
Add support for `System.UIntPtr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Enhancements:
 - .NET Standard 2.0 and 2.1 support (@lg2de, #485)
 
+Bugfixes:
+- `System.UIntPtr` unsupported (@stakx, #546)
+
 Deprecations:
  - Removed support for the .NET Framework < 4.5 and .NET Standard 1.x. (@stakx, #495, #496)
  - Removed support for Code Access Security (CAS). (@stakx, #502)

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutUIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutUIntPtr.cs
@@ -1,0 +1,23 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	using System;
+
+	public interface IFooWithOutUIntPtr
+	{
+		int Bar(out UIntPtr i);
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithUIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithUIntPtr.cs
@@ -1,0 +1,23 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Interfaces
+{
+	using System;
+
+	public interface IFooWithUIntPtr
+	{
+		UIntPtr Buffer(UInt32 index);
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMethodsNoTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMethodsNoTargetTestCase.cs
@@ -159,6 +159,15 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+		public void Target_method_UIntPtr()
+		{
+			var proxy = CreateProxy<IFooWithUIntPtr>();
+			var result = new UIntPtr(123);
+			Assert.DoesNotThrow(() => result = proxy.Buffer(1u));
+			Assert.AreEqual(UIntPtr.Zero, result);
+		}
+
+		[Test]
 		public void Target_method_Nullable_parameters()
 		{
 			var proxy = CreateProxy<INullable>();
@@ -190,6 +199,15 @@ namespace Castle.DynamicProxy.Tests
 			var result = new IntPtr(123);
 			Assert.DoesNotThrow(() => proxy.Bar(out result));
 			Assert.AreEqual(IntPtr.Zero, result);
+		}
+
+		[Test]
+		public void Target_method_out_UIntPtr()
+		{
+			var proxy = CreateProxy<IFooWithOutUIntPtr>();
+			var result = new UIntPtr(123);
+			Assert.DoesNotThrow(() => proxy.Bar(out result));
+			Assert.AreEqual(UIntPtr.Zero, result);
 		}
 
 		[Test]

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
@@ -72,7 +72,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 		private bool IsPrimitiveOrClass(Type type)
 		{
-			if ((type.IsPrimitive && type != typeof(IntPtr)))
+			if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{
 				return true;
 			}


### PR DESCRIPTION
Fixes #546.

(The one longish commit message isn't strictly necessary for understanding this bugfix... in fact, it's quite unrelated. I was originally going to optimize the emitted IL a little, but decided to defer that to a later time. I'm leaving the commit message for later reference.)