### PR TITLE
Remove delegate-based roundtrip from `ObtainProxyType` to `GenerateType`

### DIFF
--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -66,7 +66,7 @@ namespace Castle.DynamicProxy
 			AssertValidMixins(options, nameof(options));
 
 			var generator = new ClassProxyGenerator(scope, classToProxy, additionalInterfacesToProxy, options) { Logger = logger };
-			return generator.GenerateCode();
+			return generator.GetProxyType();
 		}
 
 		public Type CreateClassProxyTypeWithTarget(Type classToProxy, Type[] additionalInterfacesToProxy,
@@ -78,7 +78,7 @@ namespace Castle.DynamicProxy
 
 			var generator = new ClassProxyWithTargetGenerator(scope, classToProxy, additionalInterfacesToProxy, options)
 			{ Logger = logger };
-			return generator.GenerateCode();
+			return generator.GetProxyType();
 		}
 
 		public Type CreateInterfaceProxyTypeWithTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -90,7 +90,7 @@ namespace Castle.DynamicProxy
 			AssertValidMixins(options, nameof(options));
 
 			var generator = new InterfaceProxyWithTargetGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, targetType, options) { Logger = logger };
-			return generator.GenerateCode();
+			return generator.GetProxyType();
 		}
 
 		public Type CreateInterfaceProxyTypeWithTargetInterface(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -101,7 +101,7 @@ namespace Castle.DynamicProxy
 			AssertValidMixins(options, nameof(options));
 
 			var generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, interfaceToProxy, options) { Logger = logger };
-			return generator.GenerateCode();
+			return generator.GetProxyType();
 		}
 
 		public Type CreateInterfaceProxyTypeWithoutTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -112,7 +112,7 @@ namespace Castle.DynamicProxy
 			AssertValidMixins(options, nameof(options));
 
 			var generator = new InterfaceProxyWithoutTargetGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, typeof(object), options) { Logger = logger };
-			return generator.GenerateCode();
+			return generator.GetProxyType();
 		}
 
 		private void AssertValidMixins(ProxyGenerationOptions options, string paramName)

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -65,8 +65,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new ClassProxyGenerator(scope, classToProxy, options) { Logger = logger };
-			return generator.GenerateCode(additionalInterfacesToProxy);
+			var generator = new ClassProxyGenerator(scope, classToProxy, additionalInterfacesToProxy, options) { Logger = logger };
+			return generator.GenerateCode();
 		}
 
 		public Type CreateClassProxyTypeWithTarget(Type classToProxy, Type[] additionalInterfacesToProxy,
@@ -78,7 +78,7 @@ namespace Castle.DynamicProxy
 
 			var generator = new ClassProxyWithTargetGenerator(scope, classToProxy, additionalInterfacesToProxy, options)
 			{ Logger = logger };
-			return generator.GetGeneratedType();
+			return generator.GenerateCode();
 		}
 
 		public Type CreateInterfaceProxyTypeWithTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -89,8 +89,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithTargetGenerator(scope, interfaceToProxy, options) { Logger = logger };
-			return generator.GenerateCode(targetType, additionalInterfacesToProxy);
+			var generator = new InterfaceProxyWithTargetGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, targetType, options) { Logger = logger };
+			return generator.GenerateCode();
 		}
 
 		public Type CreateInterfaceProxyTypeWithTargetInterface(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -100,8 +100,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, interfaceToProxy, options) { Logger = logger };
-			return generator.GenerateCode(interfaceToProxy, additionalInterfacesToProxy);
+			var generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, interfaceToProxy, options) { Logger = logger };
+			return generator.GenerateCode();
 		}
 
 		public Type CreateInterfaceProxyTypeWithoutTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
@@ -111,8 +111,8 @@ namespace Castle.DynamicProxy
 			AssertValidTypes(additionalInterfacesToProxy, nameof(additionalInterfacesToProxy));
 			AssertValidMixins(options, nameof(options));
 
-			var generator = new InterfaceProxyWithoutTargetGenerator(scope, interfaceToProxy, options) { Logger = logger };
-			return generator.GenerateCode(typeof(object), additionalInterfacesToProxy);
+			var generator = new InterfaceProxyWithoutTargetGenerator(scope, interfaceToProxy, additionalInterfacesToProxy, typeof(object), options) { Logger = logger };
+			return generator.GenerateCode();
 		}
 
 		private void AssertValidMixins(ProxyGenerationOptions options, string paramName)

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -38,14 +38,19 @@ namespace Castle.DynamicProxy.Generators
 	internal abstract class BaseProxyGenerator
 	{
 		protected readonly Type targetType;
+		protected readonly Type[] interfaces;
 		private readonly ModuleScope scope;
 		private ILogger logger = NullLogger.Instance;
 		private ProxyGenerationOptions proxyGenerationOptions;
 
-		protected BaseProxyGenerator(ModuleScope scope, Type targetType, ProxyGenerationOptions proxyGenerationOptions)
+		protected BaseProxyGenerator(ModuleScope scope, Type targetType, Type[] interfaces, ProxyGenerationOptions proxyGenerationOptions)
 		{
+			CheckNotGenericTypeDefinition(targetType, "targetType");
+			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
+
 			this.scope = scope;
 			this.targetType = targetType;
+			this.interfaces = TypeUtil.GetAllInterfaces(interfaces);
 			this.proxyGenerationOptions = proxyGenerationOptions;
 			this.proxyGenerationOptions.Initialize();
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -346,8 +346,7 @@ namespace Castle.DynamicProxy.Generators
 			return emitter.CreateTypeConstructor();
 		}
 
-		protected void HandleExplicitlyPassedProxyTargetAccessor(ICollection<Type> targetInterfaces,
-		                                                         ICollection<Type> additionalInterfaces)
+		protected void HandleExplicitlyPassedProxyTargetAccessor(ICollection<Type> targetInterfaces)
 		{
 			var interfaceName = typeof(IProxyTargetAccessor).ToString();
 			//ok, let's determine who tried to sneak the IProxyTargetAccessor in...
@@ -369,7 +368,7 @@ namespace Castle.DynamicProxy.Generators
 						mixinType.Name, interfaceName);
 				throw new InvalidOperationException("This is a DynamicProxy2 error: " + message);
 			}
-			else if (additionalInterfaces.Contains(typeof(IProxyTargetAccessor)))
+			else if (interfaces.Contains(typeof(IProxyTargetAccessor)))
 			{
 				message =
 					string.Format(

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -27,18 +27,10 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class ClassProxyGenerator : BaseProxyGenerator
 	{
-		private readonly Type[] interfaces;
-
 		public ClassProxyGenerator(ModuleScope scope, Type targetType, Type[] interfaces, ProxyGenerationOptions options)
-			: base(scope, targetType, options)
+			: base(scope, targetType, interfaces, options)
 		{
-			CheckNotGenericTypeDefinition(targetType, "targetType");
 			EnsureDoesNotImplementIProxyTargetAccessor(targetType, "targetType");
-
-			interfaces = TypeUtil.GetAllInterfaces(interfaces);
-			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
-
-			this.interfaces = interfaces;
 		}
 
 		protected override CacheKey GetCacheKey()

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -27,22 +27,27 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class ClassProxyGenerator : BaseProxyGenerator
 	{
-		public ClassProxyGenerator(ModuleScope scope, Type targetType, ProxyGenerationOptions options)
+		private readonly Type[] interfaces;
+
+		public ClassProxyGenerator(ModuleScope scope, Type targetType, Type[] interfaces, ProxyGenerationOptions options)
 			: base(scope, targetType, options)
 		{
 			CheckNotGenericTypeDefinition(targetType, "targetType");
 			EnsureDoesNotImplementIProxyTargetAccessor(targetType, "targetType");
-		}
 
-		public Type GenerateCode(Type[] interfaces)
-		{
 			interfaces = TypeUtil.GetAllInterfaces(interfaces);
 			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
-			var cacheKey = new CacheKey(targetType, interfaces, ProxyGenerationOptions);
-			return ObtainProxyType(cacheKey, (n, s) => GenerateType(n, interfaces, s));
+
+			this.interfaces = interfaces;
 		}
 
-		protected virtual Type GenerateType(string name, Type[] interfaces, INamingScope namingScope)
+		public Type GenerateCode()
+		{
+			var cacheKey = new CacheKey(targetType, interfaces, ProxyGenerationOptions);
+			return ObtainProxyType(cacheKey, GenerateType);
+		}
+
+		protected virtual Type GenerateType(string name, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
 			var implementedInterfaces = GetTypeImplementerMapping(interfaces, out contributors, namingScope);

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -41,13 +41,12 @@ namespace Castle.DynamicProxy.Generators
 			this.interfaces = interfaces;
 		}
 
-		public Type GenerateCode()
+		protected override CacheKey GetCacheKey()
 		{
-			var cacheKey = new CacheKey(targetType, interfaces, ProxyGenerationOptions);
-			return ObtainProxyType(cacheKey, GenerateType);
+			return new CacheKey(targetType, interfaces, ProxyGenerationOptions);
 		}
 
-		protected virtual Type GenerateType(string name, INamingScope namingScope)
+		protected override Type GenerateType(string name, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
 			var implementedInterfaces = GetTypeImplementerMapping(interfaces, out contributors, namingScope);

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -117,7 +117,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			catch (ArgumentException)
 			{
-				HandleExplicitlyPassedProxyTargetAccessor(targetInterfaces, interfaces);
+				HandleExplicitlyPassedProxyTargetAccessor(targetInterfaces);
 			}
 
 			contributors = new List<ITypeContributor>
@@ -160,7 +160,7 @@ namespace Castle.DynamicProxy.Generators
 		protected override Type GenerateType(string name, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
-			var implementedInterfaces = GetTypeImplementerMapping(out contributors, namingScope);
+			var allInterfaces = GetTypeImplementerMapping(out contributors, namingScope);
 
 			var model = new MetaType();
 			// Collect methods
@@ -170,7 +170,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			ProxyGenerationOptions.Hook.MethodsInspected();
 
-			var emitter = BuildClassEmitter(name, targetType, implementedInterfaces);
+			var emitter = BuildClassEmitter(name, targetType, allInterfaces);
 
 			CreateFields(emitter);
 			CreateTypeAttributes(emitter);

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -43,12 +43,6 @@ namespace Castle.DynamicProxy.Generators
 			this.additionalInterfacesToProxy = TypeUtil.GetAllInterfaces(additionalInterfacesToProxy);
 		}
 
-		public Type GenerateCode()
-		{
-			var cacheKey = new CacheKey(targetType, targetType, additionalInterfacesToProxy, ProxyGenerationOptions);
-			return ObtainProxyType(cacheKey, GenerateType);
-		}
-
 		protected virtual IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors,
 		                                                              INamingScope namingScope)
 		{
@@ -164,7 +158,12 @@ namespace Castle.DynamicProxy.Generators
 			throw new ArgumentException(message, name);
 		}
 
-		private Type GenerateType(string name, INamingScope namingScope)
+		protected override CacheKey GetCacheKey()
+		{
+			return new CacheKey(targetType, targetType, additionalInterfacesToProxy, ProxyGenerationOptions);
+		}
+
+		protected override Type GenerateType(string name, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
 			var implementedInterfaces = GetTypeImplementerMapping(out contributors, namingScope);

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -43,7 +43,7 @@ namespace Castle.DynamicProxy.Generators
 			this.additionalInterfacesToProxy = TypeUtil.GetAllInterfaces(additionalInterfacesToProxy);
 		}
 
-		public Type GetGeneratedType()
+		public Type GenerateCode()
 		{
 			var cacheKey = new CacheKey(targetType, targetType, additionalInterfacesToProxy, ProxyGenerationOptions);
 			return ObtainProxyType(cacheKey, GenerateType);

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -57,12 +57,6 @@ namespace Castle.DynamicProxy.Generators
 			get { return ProxyTypeConstants.InterfaceWithTarget; }
 		}
 
-		public Type GenerateCode()
-		{
-			var cacheKey = new CacheKey(proxyTargetType, targetType, interfaces, ProxyGenerationOptions);
-			return ObtainProxyType(cacheKey, GenerateType);
-		}
-
 		protected virtual ITypeContributor AddMappingForTargetType(IDictionary<Type, ITypeContributor> typeImplementerMapping,
 		                                                           Type proxyTargetType, ICollection<Type> targetInterfaces,
 		                                                           ICollection<Type> additionalInterfaces,
@@ -98,7 +92,12 @@ namespace Castle.DynamicProxy.Generators
 		}
 #endif
 
-		protected virtual Type GenerateType(string typeName, INamingScope namingScope)
+		protected override CacheKey GetCacheKey()
+		{
+			return new CacheKey(proxyTargetType, targetType, interfaces, ProxyGenerationOptions);
+		}
+
+		protected override Type GenerateType(string typeName, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
 			var allInterfaces = GetTypeImplementerMapping(interfaces, proxyTargetType, out contributors, namingScope);

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -30,21 +30,18 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithTargetGenerator : BaseProxyGenerator
 	{
-		protected readonly Type[] interfaces;
 		protected readonly Type proxyTargetType;
 
 		protected FieldReference targetField;
 
-		public InterfaceProxyWithTargetGenerator(ModuleScope scope, Type @interface, Type[] interfaces, Type proxyTargetType, ProxyGenerationOptions options)
-			: base(scope, @interface, options)
+		public InterfaceProxyWithTargetGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
+		                                         Type proxyTargetType, ProxyGenerationOptions options)
+			: base(scope, targetType, interfaces, options)
 		{
-			CheckNotGenericTypeDefinition(@interface, "@interface");
-			CheckNotGenericTypeDefinitions(interfaces, "interfaces");
 			CheckNotGenericTypeDefinition(proxyTargetType, "proxyTargetType");
 			EnsureValidBaseType(ProxyGenerationOptions.BaseTypeForInterfaceProxy);
 
 			this.proxyTargetType = proxyTargetType;
-			this.interfaces = TypeUtil.GetAllInterfaces(interfaces);
 		}
 
 		protected virtual bool AllowChangeTarget

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -26,8 +26,8 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithTargetInterfaceGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type @interface, ProxyGenerationOptions options)
-			: base(scope, @interface, options)
+		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type @interface, Type[] interfaces, Type proxyTargetType, ProxyGenerationOptions options)
+			: base(scope, @interface, interfaces, proxyTargetType, options)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -26,8 +26,9 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithTargetInterfaceGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type @interface, Type[] interfaces, Type proxyTargetType, ProxyGenerationOptions options)
-			: base(scope, @interface, interfaces, proxyTargetType, options)
+		public InterfaceProxyWithTargetInterfaceGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
+		                                                  Type proxyTargetType, ProxyGenerationOptions options)
+			: base(scope, targetType, interfaces, proxyTargetType, options)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -44,7 +44,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected override ITypeContributor AddMappingForTargetType(
 			IDictionary<Type, ITypeContributor> typeImplementerMapping, Type proxyTargetType, ICollection<Type> targetInterfaces,
-			ICollection<Type> additionalInterfaces, INamingScope namingScope)
+			INamingScope namingScope)
 		{
 			var contributor = new InterfaceProxyWithTargetInterfaceTargetContributor(
 				proxyTargetType,

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -38,7 +38,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected override ITypeContributor AddMappingForTargetType(
 			IDictionary<Type, ITypeContributor> interfaceTypeImplementerMapping, Type proxyTargetType,
-			ICollection<Type> targetInterfaces, ICollection<Type> additionalInterfaces, INamingScope namingScope)
+			ICollection<Type> targetInterfaces, INamingScope namingScope)
 		{
 			var contributor = new InterfaceProxyWithoutTargetContributor(namingScope, (c, m) => NullExpression.Instance)
 			{ Logger = Logger };
@@ -53,7 +53,7 @@ namespace Castle.DynamicProxy.Generators
 		protected override Type GenerateType(string typeName, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
-			var allInterfaces = GetTypeImplementerMapping(interfaces, targetType, out contributors, namingScope);
+			var allInterfaces = GetTypeImplementerMapping(targetType, out contributors, namingScope);
 			var model = new MetaType();
 			// collect elements
 			foreach (var contributor in contributors)

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -25,8 +25,9 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithoutTargetGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type @interface, ProxyGenerationOptions options)
-			: base(scope, @interface, options)
+		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type @interface, Type[] interfaces,
+		                                            Type proxyTargetType, ProxyGenerationOptions options)
+			: base(scope, @interface, interfaces, proxyTargetType, options)
 		{
 		}
 
@@ -49,8 +50,7 @@ namespace Castle.DynamicProxy.Generators
 			return contributor;
 		}
 
-		protected override Type GenerateType(string typeName, Type proxyTargetType, Type[] interfaces,
-		                                     INamingScope namingScope)
+		protected override Type GenerateType(string typeName, INamingScope namingScope)
 		{
 			IEnumerable<ITypeContributor> contributors;
 			var allInterfaces = GetTypeImplementerMapping(interfaces, targetType, out contributors, namingScope);

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -25,9 +25,9 @@ namespace Castle.DynamicProxy.Generators
 
 	internal class InterfaceProxyWithoutTargetGenerator : InterfaceProxyWithTargetGenerator
 	{
-		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type @interface, Type[] interfaces,
+		public InterfaceProxyWithoutTargetGenerator(ModuleScope scope, Type targetType, Type[] interfaces,
 		                                            Type proxyTargetType, ProxyGenerationOptions options)
-			: base(scope, @interface, interfaces, proxyTargetType, options)
+			: base(scope, targetType, interfaces, proxyTargetType, options)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
@@ -132,7 +132,7 @@ namespace Castle.DynamicProxy.Serialization
 		private object RecreateClassProxyWithTarget()
 		{
 			var generator = new ClassProxyWithTargetGenerator(scope, baseType, interfaces, proxyGenerationOptions);
-			var proxyType = generator.GenerateCode();
+			var proxyType = generator.GetProxyType();
 			return InstantiateClassProxy(proxyType);
 		}
 
@@ -162,14 +162,14 @@ namespace Castle.DynamicProxy.Serialization
 						generatorType));
 			}
 
-			var proxyType = generator.GenerateCode();
+			var proxyType = generator.GetProxyType();
 			return FormatterServices.GetSafeUninitializedObject(proxyType);
 		}
 
 		public object RecreateClassProxy()
 		{
 			var generator = new ClassProxyGenerator(scope, baseType, interfaces, proxyGenerationOptions);
-			var proxyType = generator.GenerateCode();
+			var proxyType = generator.GetProxyType();
 			return InstantiateClassProxy(proxyType);
 		}
 

--- a/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
@@ -132,7 +132,7 @@ namespace Castle.DynamicProxy.Serialization
 		private object RecreateClassProxyWithTarget()
 		{
 			var generator = new ClassProxyWithTargetGenerator(scope, baseType, interfaces, proxyGenerationOptions);
-			var proxyType = generator.GetGeneratedType();
+			var proxyType = generator.GenerateCode();
 			return InstantiateClassProxy(proxyType);
 		}
 
@@ -144,15 +144,15 @@ namespace Castle.DynamicProxy.Serialization
 			InterfaceProxyWithTargetGenerator generator;
 			if (generatorType == ProxyTypeConstants.InterfaceWithTarget)
 			{
-				generator = new InterfaceProxyWithTargetGenerator(scope, @interface, proxyGenerationOptions);
+				generator = new InterfaceProxyWithTargetGenerator(scope, @interface, interfaces, targetType, proxyGenerationOptions);
 			}
 			else if (generatorType == ProxyTypeConstants.InterfaceWithoutTarget)
 			{
-				generator = new InterfaceProxyWithoutTargetGenerator(scope, @interface, proxyGenerationOptions);
+				generator = new InterfaceProxyWithoutTargetGenerator(scope, @interface, interfaces, targetType, proxyGenerationOptions);
 			}
 			else if (generatorType == ProxyTypeConstants.InterfaceWithTargetInterface)
 			{
-				generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, @interface, proxyGenerationOptions);
+				generator = new InterfaceProxyWithTargetInterfaceGenerator(scope, @interface, interfaces, targetType, proxyGenerationOptions);
 			}
 			else
 			{
@@ -162,14 +162,14 @@ namespace Castle.DynamicProxy.Serialization
 						generatorType));
 			}
 
-			var proxyType = generator.GenerateCode(targetType, interfaces);
+			var proxyType = generator.GenerateCode();
 			return FormatterServices.GetSafeUninitializedObject(proxyType);
 		}
 
 		public object RecreateClassProxy()
 		{
-			var generator = new ClassProxyGenerator(scope, baseType, proxyGenerationOptions);
-			var proxyType = generator.GenerateCode(interfaces);
+			var generator = new ClassProxyGenerator(scope, baseType, interfaces, proxyGenerationOptions);
+			var proxyType = generator.GenerateCode();
 			return InstantiateClassProxy(proxyType);
 		}
 


### PR DESCRIPTION
One bit in DynamicProxy that I've always found surprisingly complicated: The proxy builder calls the proxy type builder's `GenerateCode` method (somewhat inaccurate name btw.), which then calls `ObtainProxyType` in the base class, providing it with a delegate to its `GenerateType` method.

https://github.com/castleproject/Core/blob/c2428ea8b7c879155d38c06b8faae8be2561e7f7/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs#L37-L46

This PR's commits can speak for themselves, but here's a short prose summary of this refactoring anyway:

* We can simplify the issue described above by declaring `GenerateType` as an abstract method in the base class so that `ObtainProxyType` can call it directly (without the delegate scenic drive).

* This entails moving excess parameters from `GenerateType` into the ctor. Once done, we end up with duplicated code in all proxy type generator ctors that can be pushed down into the base class ctor.

* `GenerateCode` then ends up doing almost nothing besides computing a cache key, so the method is turned into `GetCacheKey`. `ObtainProxyType` becomes a public method `GetProxyType`, which is what the proxy builder now calls.

* Finally, I'm standardizing a few field and parameter names so they become easiler to distinguish and track across methods.