### PR TITLE
Skip unnecessary contributors during proxy type generation

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
@@ -114,10 +114,11 @@ namespace Castle.DynamicProxy.Generators
 			contributorsList.Add(proxyTarget);
 
 			// 2. then mixins
-			var mixins = new MixinContributor(namingScope, false) { Logger = Logger };
-			contributorsList.Add(mixins);
 			if (ProxyGenerationOptions.HasMixins)
 			{
+				var mixins = new MixinContributor(namingScope, false) { Logger = Logger };
+				contributorsList.Add(mixins);
+
 				foreach (var mixinInterface in ProxyGenerationOptions.MixinData.MixinInterfaces)
 				{
 					if (targetInterfaces.Contains(mixinInterface))
@@ -144,27 +145,29 @@ namespace Castle.DynamicProxy.Generators
 			}
 
 			// 3. then additional interfaces
-			var additionalInterfacesContributor = new InterfaceProxyWithoutTargetContributor(namingScope,
-			                                                                                 (c, m) => NullExpression.Instance)
-			{ Logger = Logger };
-			contributorsList.Add(additionalInterfacesContributor);
-			foreach (var @interface in interfaces)
+			if (interfaces.Length > 0)
 			{
-				if (targetInterfaces.Contains(@interface))
-				{
-					if (typeImplementerMapping.ContainsKey(@interface))
-					{
-						continue;
-					}
+				var additionalInterfacesContributor = new InterfaceProxyWithoutTargetContributor(namingScope, (c, m) => NullExpression.Instance) { Logger = Logger };
+				contributorsList.Add(additionalInterfacesContributor);
 
-					// we intercept the interface, and forward calls to the target type
-					AddMappingNoCheck(@interface, proxyTarget, typeImplementerMapping);
-					proxyTarget.AddInterfaceToProxy(@interface);
-				}
-				else if (ProxyGenerationOptions.MixinData.ContainsMixin(@interface) == false)
+				foreach (var @interface in interfaces)
 				{
-					additionalInterfacesContributor.AddInterfaceToProxy(@interface);
-					AddMapping(@interface, additionalInterfacesContributor, typeImplementerMapping);
+					if (targetInterfaces.Contains(@interface))
+					{
+						if (typeImplementerMapping.ContainsKey(@interface))
+						{
+							continue;
+						}
+
+						// we intercept the interface, and forward calls to the target type
+						AddMappingNoCheck(@interface, proxyTarget, typeImplementerMapping);
+						proxyTarget.AddInterfaceToProxy(@interface);
+					}
+					else if (ProxyGenerationOptions.MixinData.ContainsMixin(@interface) == false)
+					{
+						additionalInterfacesContributor.AddInterfaceToProxy(@interface);
+						AddMapping(@interface, additionalInterfacesContributor, typeImplementerMapping);
+					}
 				}
 			}
 

--- a/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
@@ -156,10 +156,11 @@ namespace Castle.DynamicProxy.Generators
 			contributorsList.Add(target);
 
 			// 2. then mixins
-			var mixins = new MixinContributor(namingScope, AllowChangeTarget) { Logger = Logger };
-			contributorsList.Add(mixins);
 			if (ProxyGenerationOptions.HasMixins)
 			{
+				var mixins = new MixinContributor(namingScope, AllowChangeTarget) { Logger = Logger };
+				contributorsList.Add(mixins);
+
 				foreach (var mixinInterface in ProxyGenerationOptions.MixinData.MixinInterfaces)
 				{
 					if (targetInterfaces.Contains(mixinInterface))
@@ -185,21 +186,25 @@ namespace Castle.DynamicProxy.Generators
 			}
 
 			// 3. then additional interfaces
-			var additionalInterfacesContributor = GetContributorForAdditionalInterfaces(namingScope);
-			contributorsList.Add(additionalInterfacesContributor);
-			foreach (var @interface in interfaces)
+			if (interfaces.Length > 0)
 			{
-				if (typeImplementerMapping.ContainsKey(@interface))
-				{
-					continue;
-				}
-				if (ProxyGenerationOptions.MixinData.ContainsMixin(@interface))
-				{
-					continue;
-				}
+				var additionalInterfacesContributor = GetContributorForAdditionalInterfaces(namingScope);
+				contributorsList.Add(additionalInterfacesContributor);
 
-				additionalInterfacesContributor.AddInterfaceToProxy(@interface);
-				AddMappingNoCheck(@interface, additionalInterfacesContributor, typeImplementerMapping);
+				foreach (var @interface in interfaces)
+				{
+					if (typeImplementerMapping.ContainsKey(@interface))
+					{
+						continue;
+					}
+					if (ProxyGenerationOptions.MixinData.ContainsMixin(@interface))
+					{
+						continue;
+					}
+
+					additionalInterfacesContributor.AddInterfaceToProxy(@interface);
+					AddMappingNoCheck(@interface, additionalInterfacesContributor, typeImplementerMapping);
+				}
 			}
 
 			// 4. plus special interfaces

--- a/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
@@ -147,15 +147,16 @@ namespace Castle.DynamicProxy.Generators
 		                                                              INamingScope namingScope)
 		{
 			var contributorsList = new List<ITypeContributor>(capacity: 4);
+			var targetInterfaces = proxyTargetType.GetAllInterfaces();
 			IDictionary<Type, ITypeContributor> typeImplementerMapping = new Dictionary<Type, ITypeContributor>();
-			var mixins = new MixinContributor(namingScope, AllowChangeTarget) { Logger = Logger };
+
 			// Order of interface precedence:
 			// 1. first target
-			var targetInterfaces = proxyTargetType.GetAllInterfaces();
 			var target = AddMappingForTargetType(typeImplementerMapping, proxyTargetType, targetInterfaces, namingScope);
 			contributorsList.Add(target);
 
 			// 2. then mixins
+			var mixins = new MixinContributor(namingScope, AllowChangeTarget) { Logger = Logger };
 			contributorsList.Add(mixins);
 			if (ProxyGenerationOptions.HasMixins)
 			{
@@ -183,8 +184,8 @@ namespace Castle.DynamicProxy.Generators
 				}
 			}
 
-			var additionalInterfacesContributor = GetContributorForAdditionalInterfaces(namingScope);
 			// 3. then additional interfaces
+			var additionalInterfacesContributor = GetContributorForAdditionalInterfaces(namingScope);
 			contributorsList.Add(additionalInterfacesContributor);
 			foreach (var @interface in interfaces)
 			{


### PR DESCRIPTION
Not all proxy types are going to have additional interfaces or mixins. Whenever those are absent, we can skip the associated contributors.

This PR's commits are mostly single refactoring steps for easier reviewing, they can be squashed when merging.