### PR TITLE
Prevent double `GetObjectData` implementation for badly implemented serializable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Enhancements:
 - .NET Standard 2.0 and 2.1 support (@lg2de, #485)
 
 Bugfixes:
+- Proxying certain `[Serializable]` classes produces proxy types that fail PEVerify test (@stakx, #367)
 - `private protected` methods are not intercepted (@CrispyDrone, #535)
 - `System.UIntPtr` unsupported (@stakx, #546)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/SerializableClassTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/SerializableClassTestCase.cs
@@ -591,6 +591,19 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(current, otherProxy.Current);
 		}
 
+		[Test]
+		public void BadSerializable()
+		{
+			const int expectedValue = 13;
+
+			var proxy = generator.CreateClassProxy<BadSerializable>();
+			proxy.Value = expectedValue;
+
+			var otherProxy = SerializeAndDeserialize(proxy);
+
+			Assert.AreEqual(expectedValue, otherProxy.Value);
+		}
+
 		public override void TearDown()
 		{
 			base.TearDown();

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/BadSerializable.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/BadSerializable.cs
@@ -1,0 +1,31 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if FEATURE_SERIALIZATION
+
+namespace Castle.DynamicProxy.Tests.Serialization
+{
+	using System;
+	using System.Runtime.Serialization;
+
+	[Serializable]
+	public abstract class BadSerializable
+	{
+		public int Value { get; set; }
+
+		public abstract void GetObjectData(SerializationInfo info, StreamingContext context);
+	}
+}
+
+#endif

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
@@ -18,6 +18,7 @@ namespace Castle.DynamicProxy.Contributors
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Reflection;
 	using System.Runtime.Serialization;
 
@@ -30,7 +31,6 @@ namespace Castle.DynamicProxy.Contributors
 	internal class ClassProxySerializableContributor : SerializableContributor
 	{
 		private readonly bool delegateToBaseGetObjectData;
-		private readonly bool implementISerializable;
 		private ConstructorInfo serializationConstructor;
 		private readonly IList<FieldReference> serializedFields = new List<FieldReference>();
 
@@ -38,20 +38,15 @@ namespace Castle.DynamicProxy.Contributors
 		                                     string typeId)
 			: base(targetType, interfaces, typeId)
 		{
-			if (targetType.IsSerializable)
-			{
-				implementISerializable = true;
-				delegateToBaseGetObjectData = VerifyIfBaseImplementsGetObjectData(targetType, methodsToSkip);
-			}
+			Debug.Assert(targetType.IsSerializable, "This contributor is intended for serializable types only.");
+
+			delegateToBaseGetObjectData = VerifyIfBaseImplementsGetObjectData(targetType, methodsToSkip);
 		}
 
 		public override void Generate(ClassEmitter @class)
 		{
-			if (implementISerializable)
-			{
-				ImplementGetObjectData(@class);
-				Constructor(@class);
-			}
+			ImplementGetObjectData(@class);
+			Constructor(@class);
 		}
 
 		protected override void AddAddValueInvocation(ArgumentReference serializationInfo, MethodEmitter getObjectData,

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
@@ -67,7 +67,7 @@ namespace Castle.DynamicProxy.Contributors
 
 				if (getObjectDataMethod != null)
 				{
-					getObjectData = model.Methods.FirstOrDefault(m => m.Method == getObjectDataMethod);
+					getObjectData = model.FindMethod(getObjectDataMethod);
 				}
 			}
 
@@ -223,7 +223,7 @@ namespace Castle.DynamicProxy.Contributors
 				throw new ArgumentException(message);
 			}
 
-			getObjectData = model.Methods.FirstOrDefault(m => m.Method == getObjectDataMethod);
+			getObjectData = model.FindMethod(getObjectDataMethod);
 
 			serializationConstructor = baseType.GetConstructor(
 				BindingFlags.Instance | BindingFlags.Public |

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -29,14 +29,12 @@ namespace Castle.DynamicProxy.Contributors
 
 	internal class ClassProxyTargetContributor : CompositeTypeContributor
 	{
-		private readonly IList<MethodInfo> methodsToSkip;
 		private readonly Type targetType;
 
-		public ClassProxyTargetContributor(Type targetType, IList<MethodInfo> methodsToSkip, INamingScope namingScope)
+		public ClassProxyTargetContributor(Type targetType, INamingScope namingScope)
 			: base(namingScope)
 		{
 			this.targetType = targetType;
-			this.methodsToSkip = methodsToSkip;
 		}
 
 		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
@@ -59,7 +57,7 @@ namespace Castle.DynamicProxy.Contributors
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
-			if (methodsToSkip.Contains(method.Method))
+			if (method.Ignore)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -27,15 +27,12 @@ namespace Castle.DynamicProxy.Contributors
 
 	internal class ClassProxyWithTargetTargetContributor : CompositeTypeContributor
 	{
-		private readonly IList<MethodInfo> methodsToSkip;
 		private readonly Type targetType;
 
-		public ClassProxyWithTargetTargetContributor(Type targetType, IList<MethodInfo> methodsToSkip,
-		                                             INamingScope namingScope)
+		public ClassProxyWithTargetTargetContributor(Type targetType, INamingScope namingScope)
 			: base(namingScope)
 		{
 			this.targetType = targetType;
-			this.methodsToSkip = methodsToSkip;
 		}
 
 		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
@@ -58,7 +55,7 @@ namespace Castle.DynamicProxy.Contributors
 		protected override MethodGenerator GetMethodGenerator(MetaMethod method, ClassEmitter @class,
 		                                                      OverrideMethodDelegate overrideMethod)
 		{
-			if (methodsToSkip.Contains(method.Method))
+			if (method.Ignore)
 			{
 				return null;
 			}

--- a/src/Castle.Core/DynamicProxy/Contributors/SerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/SerializableContributor.cs
@@ -150,7 +150,7 @@ namespace Castle.DynamicProxy.Contributors
 		protected abstract void CustomizeGetObjectData(AbstractCodeBuilder builder, ArgumentReference serializationInfo,
 		                                               ArgumentReference streamingContext, ClassEmitter emitter);
 
-		public void CollectElementsToProxy(IProxyGenerationHook hook, MetaType model)
+		public virtual void CollectElementsToProxy(IProxyGenerationHook hook, MetaType model)
 		{
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
@@ -34,10 +34,10 @@ namespace Castle.DynamicProxy.Generators
 		protected abstract FieldReference TargetField { get; }
 
 #if FEATURE_SERIALIZATION
-		protected abstract SerializableContributor GetSerializableContributor(List<MethodInfo> methodsToSkip);
+		protected abstract SerializableContributor GetSerializableContributor();
 #endif
 
-		protected abstract CompositeTypeContributor GetProxyTargetContributor(List<MethodInfo> methodsToSkip, INamingScope namingScope);
+		protected abstract CompositeTypeContributor GetProxyTargetContributor(INamingScope namingScope);
 
 		protected abstract ProxyTargetAccessorContributor GetProxyTargetAccessorContributor();
 
@@ -109,7 +109,6 @@ namespace Castle.DynamicProxy.Generators
 		private IEnumerable<Type> GetTypeImplementerMapping(out IEnumerable<ITypeContributor> contributors, INamingScope namingScope)
 		{
 			var contributorsList = new List<ITypeContributor>(capacity: 5);
-			var methodsToSkip = new List<MethodInfo>();  // TODO: the trick with methodsToSkip is not very nice...
 			var targetInterfaces = targetType.GetAllInterfaces();
 			var typeImplementerMapping = new Dictionary<Type, ITypeContributor>();
 
@@ -117,7 +116,7 @@ namespace Castle.DynamicProxy.Generators
 
 			// 1. first target
 			// target is not an interface so we do nothing
-			var targetContributor = GetProxyTargetContributor(methodsToSkip, namingScope);
+			var targetContributor = GetProxyTargetContributor(namingScope);
 			contributorsList.Add(targetContributor);
 
 			// 2. then mixins
@@ -183,7 +182,7 @@ namespace Castle.DynamicProxy.Generators
 #if FEATURE_SERIALIZATION
 			if (targetType.IsSerializable)
 			{
-				var serializableContributor = GetSerializableContributor(methodsToSkip);
+				var serializableContributor = GetSerializableContributor();
 				contributorsList.Add(serializableContributor);
 				AddMappingForISerializable(typeImplementerMapping, serializableContributor);
 			}

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -37,15 +37,15 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 #if FEATURE_SERIALIZATION
-		protected override SerializableContributor GetSerializableContributor(List<MethodInfo> methodsToSkip)
+		protected override SerializableContributor GetSerializableContributor()
 		{
-			return new ClassProxySerializableContributor(targetType, methodsToSkip, interfaces, ProxyTypeConstants.Class);
+			return new ClassProxySerializableContributor(targetType, interfaces, ProxyTypeConstants.Class);
 		}
 #endif
 
-		protected override CompositeTypeContributor GetProxyTargetContributor(List<MethodInfo> methodsToSkip, INamingScope namingScope)
+		protected override CompositeTypeContributor GetProxyTargetContributor(INamingScope namingScope)
 		{
-			return new ClassProxyTargetContributor(targetType, methodsToSkip, namingScope) { Logger = Logger };
+			return new ClassProxyTargetContributor(targetType, namingScope) { Logger = Logger };
 		}
 
 		protected override ProxyTargetAccessorContributor GetProxyTargetAccessorContributor()

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -51,15 +51,15 @@ namespace Castle.DynamicProxy.Generators
 		}
 
 #if FEATURE_SERIALIZATION
-		protected override SerializableContributor GetSerializableContributor(List<MethodInfo> methodsToSkip)
+		protected override SerializableContributor GetSerializableContributor()
 		{
-			return new ClassProxySerializableContributor(targetType, methodsToSkip, interfaces, ProxyTypeConstants.ClassWithTarget);
+			return new ClassProxySerializableContributor(targetType, interfaces, ProxyTypeConstants.ClassWithTarget);
 		}
 #endif
 
-		protected override CompositeTypeContributor GetProxyTargetContributor(List<MethodInfo> methodsToSkip, INamingScope namingScope)
+		protected override CompositeTypeContributor GetProxyTargetContributor(INamingScope namingScope)
 		{
-			return new ClassProxyWithTargetTargetContributor(targetType, methodsToSkip, namingScope) { Logger = Logger };
+			return new ClassProxyWithTargetTargetContributor(targetType, namingScope) { Logger = Logger };
 		}
 
 		protected override ProxyTargetAccessorContributor GetProxyTargetAccessorContributor()

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -52,6 +52,8 @@ namespace Castle.DynamicProxy.Generators
 			get { return name; }
 		}
 
+		public bool Ignore { get; internal set; }
+
 		public bool Proxyable { get; private set; }
 
 		public bool Standalone { get; private set; }

--- a/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
@@ -15,11 +15,13 @@
 namespace Castle.DynamicProxy.Generators
 {
 	using System.Collections.Generic;
+	using System.Reflection;
 
 	internal class MetaType
 	{
 		private readonly ICollection<MetaEvent> events = new TypeElementCollection<MetaEvent>();
 		private readonly ICollection<MetaMethod> methods = new TypeElementCollection<MetaMethod>();
+		private readonly Dictionary<MethodInfo, MetaMethod> methodsIndex = new Dictionary<MethodInfo, MetaMethod>();
 		private readonly ICollection<MetaProperty> properties = new TypeElementCollection<MetaProperty>();
 
 		public IEnumerable<MetaEvent> Events
@@ -46,11 +48,17 @@ namespace Castle.DynamicProxy.Generators
 		public void AddMethod(MetaMethod method)
 		{
 			methods.Add(method);
+			methodsIndex.Add(method.Method, method);  // shouldn't get added twice
 		}
 
 		public void AddProperty(MetaProperty property)
 		{
 			properties.Add(property);
+		}
+
+		public MetaMethod FindMethod(MethodInfo method)
+		{
+			return methodsIndex.TryGetValue(method, out var metaMethod) ? metaMethod : null;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #367. As an additional bonus, gets rid of this:

https://github.com/castleproject/Core/blob/9143de2e453347f533df8ebc9129d9cb6e05e5a5/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs#L112

See commit messages and code comments for details.