### PR TITLE
Fix interception for `private protected` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Enhancements:
 - .NET Standard 2.0 and 2.1 support (@lg2de, #485)
 
 Bugfixes:
+- `private protected` methods are not intercepted (@CrispyDrone, #535)
 - `System.UIntPtr` unsupported (@stakx, #546)
 
 Deprecations:

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -223,7 +223,7 @@ namespace Castle.DynamicProxy.Contributors
 			}
 
 			//can only proxy methods that are public or protected (or internals that have already been checked above)
-			if ((method.IsPublic || method.IsFamily || method.IsAssembly || method.IsFamilyOrAssembly) == false)
+			if ((method.IsPublic || method.IsFamily || method.IsAssembly || method.IsFamilyOrAssembly || method.IsFamilyAndAssembly) == false)
 			{
 				return false;
 			}


### PR DESCRIPTION
Fixes #535.

(I've checked all code locations mentioning either `IsFamilyOrAssembly` or `FamORAssem`. The one being changed here was the only place where there wasn't already an accompanying check for `IsFamilyAndAssembly` or `FamANDAssem`.)