### PR TITLE
Run build and tests on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,6 @@ jobs:
       # Build
       # -----
 
-      # This step is a workaround for dotnet/core#5881.
-      # It was originally described in actions/setup-dotnet#155.
-      # Without it, the NuGet package restore may fail unpredictably.
-      - name: Clean
-        run: dotnet clean ./Castle.Core.sln --configuration Release && dotnet nuget locals all --clear
-
       - name: Restore NuGet packages
         run: dotnet restore
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build
+
+on: push
+
+env:
+  MONO_TAG: "6.0.0.334"
+
+jobs:
+
+  build-and-test:
+    name: Build and test
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Several .NET Core versions will be used during the test run.
+      # The lowest version gets installed first in order to prevent
+      # "a newer version is already installed" install errors.
+
+      - name: Install .NET Core 2.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.x
+
+      - name: Install .NET Core 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
+      # Building requires an up-to-date .NET SDK.
+
+      - name: Install .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
+      # -----
+      # Build
+      # -----
+
+      # This step is a workaround for dotnet/core#5881.
+      # It was originally described in actions/setup-dotnet#155.
+      # Without it, the NuGet package restore may fail unpredictably.
+      - name: Clean
+        run: dotnet clean ./Castle.Core.sln --configuration Release && dotnet nuget locals all --clear
+
+      - name: Restore NuGet packages
+        run: dotnet restore
+
+      - name: Build all targets
+        run: dotnet build -c Release --no-restore
+
+      # ----
+      # Test
+      # ----
+
+      - name: Test on .NET Core 2.1
+        run: dotnet test -c Release -f netcoreapp2.1 --no-build --no-restore -l "console;verbosity=detailed"
+
+      - name: Test on .NET Core 3.1
+        run: dotnet test -c Release -f netcoreapp3.1 --no-build --no-restore -l "console;verbosity=detailed"
+
+      - name: Test on .NET Framework 4.6.1 (Windows only)
+        if: matrix.os == 'windows-latest'
+        run: dotnet test -c Release -f net461 --no-build --no-restore -l "console;verbosity=detailed"
+
+      - name: Test on .NET Framework 4.6.1 using Mono (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          docker run --rm -v "$PWD":'/project' -w='/project' mono:$MONO_TAG bash -c 'mono ./src/Castle.Core.Tests/bin/Release/net461/Castle.Core.Tests.exe && mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net461/Castle.Core.Tests.WeakNamed.exe'

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Browse the [contributing section](https://github.com/castleproject/Home#its-comm
 
 ## Building
 
-| Platforms       | Build Status | NuGet Feed |
-|-----------------|-------------:|------------|
-| Windows & Linux | [![Build status](https://ci.appveyor.com/api/projects/status/49a6i0ydiku56r5b/branch/master?svg=true)](https://ci.appveyor.com/project/castleproject/core/branch/master) | [Preview Feed](https://ci.appveyor.com/nuget/core-0mhe40ifodk8)
+| Platforms       | NuGet Feed |
+|-----------------|------------|
+| Windows & Linux | [Preview Feed](https://ci.appveyor.com/nuget/core-0mhe40ifodk8)
 
 ### On Windows
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Let's get started on migrating our CI build from Appveyor to GitHub Actions (#497). I haven't got very far yet. At the moment, this includes the build and test runs&mdash;with the addition of .NET Core test runs on MacOS&mdash;but no NuGet deployment-specific build steps.

You can [see this in action over at my fork](https://github.com/stakx/Castle.Core/actions?query=workflow%3ABuild).

I haven't yet found an easy way to only build once, then reuse the build output for different OS builds. The reason is that a build will not copy all required binaries from NuGet packages to the output folder; one would need to `dotnet publish --self-contained` to get complete output. A self-contained publish however produces runtime & platform specific output which is not what we want. Only speeding up the NuGet package restore by caching the package folder across OS builds doesn't help a lot time-wise due to the relatively large data volume (> 0.5 GB). Due to all of this, I suggest we do what's most straightforward and perform a complete restore, build, and test run cycle for every OS.

What's still missing? (Feel free to add to this list.)

* [ ] Running our ExplicitVersions tool to sync the auxiliary packages' versions with the main package's version.
* [ ] Anything else NuGet deployment related.
* [ ] Further tests to ensure that the build fails under certain conditions:
      - failed unit test
      - failed PEVerify execution
* [x] Structuring the workflow definition file a little nicer
* [x] ~~Possibly separating this commit into several commits~~