### PR TITLE
Forward non-intercepted methods on class proxies to target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Enhancements:
 - .NET Standard 2.0 and 2.1 support (@lg2de, #485)
+- Non-intercepted methods on a class proxy with target are now forwarded to the target (@stakx, #571)
 
 Bugfixes:
 - Proxying certain `[Serializable]` classes produces proxy types that fail PEVerify test (@stakx, #367)

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/GitHubIssue536.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/GitHubIssue536.cs
@@ -1,0 +1,63 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.BugsReported
+{
+	using System;
+	using System.Reflection;
+	using System.Threading.Tasks;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class GitHubIssue536 : BasePEVerifyTestCase
+	{
+		[Test]
+		public void DynamicProxy_NonIntercepted_Property_Leaked()
+		{
+			var instance = new TestClassForCache();
+			var toProxy = instance.GetType();
+
+			var proxyGenerationOptions = new ProxyGenerationOptions(new TestCacheProxyGenerationHook());
+
+			var generator = new ProxyGenerator();
+			var proxy = generator.CreateClassProxyWithTarget(toProxy,
+				instance,
+				proxyGenerationOptions);
+
+			var accessor = (ITestCacheInterface)proxy;
+			accessor.InstanceProperty = 1;
+
+			Assert.AreEqual(accessor.InstanceProperty, instance.InstanceProperty);
+		}
+
+		public class TestCacheProxyGenerationHook : AllMethodsHook
+		{
+			public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+			{
+				return false;
+			}
+		}
+
+		public interface ITestCacheInterface
+		{
+			int InstanceProperty { get; set; }
+		}
+
+		public class TestClassForCache : ITestCacheInterface
+		{
+			public virtual int InstanceProperty { get; set; }
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
@@ -1,0 +1,21 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	public class HasVirtualStringAutoProperty
+	{
+		public virtual string Property { get; set; }
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedTargetMethodsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedTargetMethodsTestCase.cs
@@ -145,5 +145,23 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual("hello world", target.Property);
 			Assert.AreEqual("hello world", proxy.Property);
 		}
+
+		[Test]
+		public void Unproxied_public_method_should_not_invoke_interceptor()
+		{
+			var target = new VirtualClassWithMethod();
+			var options = new ProxyGenerationOptions(new ProxyNothingHook());
+			var proxy = generator.CreateClassProxyWithTarget(target, options, new ThrowingInterceptor());
+			proxy.Method();  // the hook says "don't proxy anything", so this should not call the throwing interceptor
+		}
+
+		[Test]
+		public void Unproxied_non_public_method_should_not_invoke_interceptor()
+		{
+			var target = new ClassWithProtectedMethod();
+			var options = new ProxyGenerationOptions(new ProxyNothingHook());
+			var proxy = generator.CreateClassProxyWithTarget(target, options, new ThrowingInterceptor());
+			proxy.PublicMethod();
+		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
@@ -1,0 +1,41 @@
+// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+	using System.Reflection;
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	public class ProxySomeMethodsHook : IProxyGenerationHook
+	{
+		private readonly Func<Type, MethodInfo, bool> shouldInterceptMethod;
+
+		public ProxySomeMethodsHook(Func<Type, MethodInfo, bool> shouldInterceptMethod)
+		{
+			this.shouldInterceptMethod = shouldInterceptMethod;
+		}
+
+		public bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+		{
+			return shouldInterceptMethod(type, methodInfo);
+		}
+
+		void IProxyGenerationHook.MethodsInspected() { }
+
+		void IProxyGenerationHook.NonProxyableMemberNotification(Type type, MemberInfo memberInfo) { }
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -56,15 +56,14 @@ namespace Castle.DynamicProxy.Contributors
 				return null;
 			}
 
-			if (!method.Proxyable)
-			{
-				return new MinimialisticMethodGenerator(method,
-				                                        overrideMethod);
-			}
-
 			if (IsDirectlyAccessible(method) == false)
 			{
 				return IndirectlyCalledMethodGenerator(method, @class, overrideMethod);
+			}
+
+			if (!method.Proxyable)
+			{
+				return new ForwardingMethodGenerator(method, overrideMethod, (c, m) => c.GetField("__target"));
 			}
 
 			var invocation = GetInvocationType(method, @class);

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -164,6 +164,18 @@ namespace Castle.DynamicProxy.Contributors
 		/// </summary>
 		protected bool AcceptMethod(MethodInfo method, bool onlyVirtuals, IProxyGenerationHook hook)
 		{
+			return AcceptMethodPreScreen(method, onlyVirtuals, hook) && hook.ShouldInterceptMethod(type, method);
+		}
+
+		/// <summary>
+		///   Performs some basic screening to filter out non-interceptable methods.
+		/// </summary>
+		/// <remarks>
+		///   The <paramref name="hook"/> will get invoked for non-interceptable method notification only;
+		///   it does not get asked whether or not to intercept the <paramref name="method"/>.
+		/// </remarks>
+		protected bool AcceptMethodPreScreen(MethodInfo method, bool onlyVirtuals, IProxyGenerationHook hook)
+		{
 			if (IsInternalAndNotVisibleToDynamicProxy(method))
 			{
 				return false;
@@ -207,7 +219,7 @@ namespace Castle.DynamicProxy.Contributors
 				return false;
 			}
 
-			return hook.ShouldInterceptMethod(type, method);
+			return true;
 		}
 
 		private static bool IsInternalAndNotVisibleToDynamicProxy(MethodInfo method)

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -42,12 +42,14 @@ namespace Castle.DynamicProxy.Contributors
 				return null;
 			}
 
-			var accepted = AcceptMethod(method, true, hook);
-			if (!accepted && !method.IsAbstract)
+			var interceptable = AcceptMethodPreScreen(method, true, hook);
+			if (!interceptable)
 			{
 				//we don't need to do anything...
 				return null;
 			}
+
+			var accepted = hook.ShouldInterceptMethod(type, method);
 
 			return new MetaMethod(method, method, isStandalone, accepted, hasTarget: true);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -34,17 +34,17 @@ namespace Castle.DynamicProxy.Generators
 		private readonly IInvocationCreationContributor contributor;
 		private readonly GetTargetExpressionDelegate getTargetExpression;
 		private readonly GetTargetExpressionDelegate getTargetTypeExpression;
-		private readonly Reference interceptors;
+		private readonly IExpression interceptors;
 		private readonly Type invocation;
 
-		public MethodWithInvocationGenerator(MetaMethod method, Reference interceptors, Type invocation,
+		public MethodWithInvocationGenerator(MetaMethod method, IExpression interceptors, Type invocation,
 		                                     GetTargetExpressionDelegate getTargetExpression,
 		                                     OverrideMethodDelegate createMethod, IInvocationCreationContributor contributor)
 			: this(method, interceptors, invocation, getTargetExpression, null, createMethod, contributor)
 		{
 		}
 
-		public MethodWithInvocationGenerator(MetaMethod method, Reference interceptors, Type invocation,
+		public MethodWithInvocationGenerator(MetaMethod method, IExpression interceptors, Type invocation,
 		                                     GetTargetExpressionDelegate getTargetExpression,
 		                                     GetTargetExpressionDelegate getTargetTypeExpression,
 		                                     OverrideMethodDelegate createMethod, IInvocationCreationContributor contributor)


### PR DESCRIPTION
This is a redo of my previous PR #450, which got stalled because I was under the impression that forwarding to non-public methods on the target would require special handling (and thus a lot of additional work). I've since discovered that the necessary bits are already in place:

When one proceeds from an intercepted non-public method of a class proxy to the target, the target method will likely be non-public, too, and therefore not directly callable from the outside. DynamicProxy solves this by calling the non-public target method through a delegate. This present PR simply piggybacks on that mechanism.

I found an issue with delegate type generation while working on this; see #570, which is a prerequisite for this PR and needs to be merged first. <del>(#570's commits are included here to avoid unrelated test failures; I'll rebase them away once it has been merged. For now, please ignore the first three commits of this PR.)</del>  <ins>**Update:** I've merged #570 and updated this PR.</ins>

Fixes #67, fixes #536.