### PR TITLE
Share `CompositeTypeContributor`'s type element collections with `MembersCollector`

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -37,19 +37,15 @@ namespace Castle.DynamicProxy.Contributors
 			this.targetType = targetType;
 		}
 
-		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
+		protected override IEnumerable<MembersCollector> GetCollectors()
 		{
-			Debug.Assert(hook != null, "hook != null");
-
 			var targetItem = new ClassMembersCollector(targetType) { Logger = Logger };
-			targetItem.CollectMembersToProxy(hook);
 			yield return targetItem;
 
 			foreach (var @interface in interfaces)
 			{
 				var item = new InterfaceMembersOnClassCollector(@interface, true,
 					targetType.GetInterfaceMap(@interface)) { Logger = Logger };
-				item.CollectMembersToProxy(hook);
 				yield return item;
 			}
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -35,19 +35,15 @@ namespace Castle.DynamicProxy.Contributors
 			this.targetType = targetType;
 		}
 
-		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
+		protected override IEnumerable<MembersCollector> GetCollectors()
 		{
-			Debug.Assert(hook != null, "hook != null");
-
 			var targetItem = new WrappedClassMembersCollector(targetType) { Logger = Logger };
-			targetItem.CollectMembersToProxy(hook);
 			yield return targetItem;
 
 			foreach (var @interface in interfaces)
 			{
 				var item = new InterfaceMembersOnClassCollector(@interface, true,
 					targetType.GetInterfaceMap(@interface)) { Logger = Logger };
-				item.CollectMembersToProxy(hook);
 				yield return item;
 			}
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -49,26 +49,13 @@ namespace Castle.DynamicProxy.Contributors
 		public void CollectElementsToProxy(IProxyGenerationHook hook, MetaType model)
 		{
 			Debug.Assert(hook != null);
+			Debug.Assert(model != null);
+
+			var sink = new MembersCollectorSink(model, this);
 
 			foreach (var collector in GetCollectors())
 			{
-				collector.CollectMembersToProxy(hook);
-
-				foreach (var method in collector.Methods)
-				{
-					model.AddMethod(method);
-					methods.Add(method);
-				}
-				foreach (var @event in collector.Events)
-				{
-					model.AddEvent(@event);
-					events.Add(@event);
-				}
-				foreach (var property in collector.Properties)
-				{
-					model.AddProperty(property);
-					properties.Add(property);
-				}
+				collector.CollectMembersToProxy(hook, sink);
 			}
 		}
 
@@ -147,6 +134,36 @@ namespace Castle.DynamicProxy.Contributors
 				{
 					proxyMethod.DefineCustomAttribute(attribute.Builder);
 				}
+			}
+		}
+
+		private sealed class MembersCollectorSink : IMembersCollectorSink
+		{
+			private readonly MetaType model;
+			private readonly CompositeTypeContributor contributor;
+
+			public MembersCollectorSink(MetaType model, CompositeTypeContributor contributor)
+			{
+				this.model = model;
+				this.contributor = contributor;
+			}
+
+			public void Add(MetaEvent @event)
+			{
+				model.AddEvent(@event);
+				contributor.events.Add(@event);
+			}
+
+			public void Add(MetaMethod method)
+			{
+				model.AddMethod(method);
+				contributor.methods.Add(method);
+			}
+
+			public void Add(MetaProperty property)
+			{
+				model.AddProperty(property);
+				contributor.properties.Add(property);
 			}
 		}
 	}

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -31,9 +31,9 @@ namespace Castle.DynamicProxy.Contributors
 		protected readonly ICollection<Type> interfaces = new HashSet<Type>();
 		
 		private ILogger logger = NullLogger.Instance;
-		private readonly ICollection<MetaProperty> properties = new TypeElementCollection<MetaProperty>();
-		private readonly ICollection<MetaEvent> events = new TypeElementCollection<MetaEvent>();
-		private readonly ICollection<MetaMethod> methods = new TypeElementCollection<MetaMethod>();
+		private readonly List<MetaProperty> properties = new List<MetaProperty>();
+		private readonly List<MetaEvent> events = new List<MetaEvent>();
+		private readonly List<MetaMethod> methods = new List<MetaMethod>();
 
 		protected CompositeTypeContributor(INamingScope namingScope)
 		{

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -148,6 +148,20 @@ namespace Castle.DynamicProxy.Contributors
 				this.contributor = contributor;
 			}
 
+			// You may have noticed that most contributors do not query `MetaType` at all,
+			// but only their own collections. So perhaps you are wondering why collected
+			// type elements are added to `model` at all, and not just to `contributor`?
+			//
+			// TL;DR: This prevents member name collisions in the generated proxy type.
+			//
+			// `MetaType` uses `TypeElementCollection`s internally, which switches members
+			// to explicit implementation whenever a name collision with a previously added
+			// member occurs.
+			//
+			// It would be pointless to do this at the level of the individual contributor,
+			// because name collisions could still occur across several contributors. This
+			// is why they all share the same `MetaType` instance.
+
 			public void Add(MetaEvent @event)
 			{
 				model.AddEvent(@event);

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -48,8 +48,12 @@ namespace Castle.DynamicProxy.Contributors
 
 		public void CollectElementsToProxy(IProxyGenerationHook hook, MetaType model)
 		{
-			foreach (var collector in CollectElementsToProxyInternal(hook))
+			Debug.Assert(hook != null);
+
+			foreach (var collector in GetCollectors())
 			{
+				collector.CollectMembersToProxy(hook);
+
 				foreach (var method in collector.Methods)
 				{
 					model.AddMethod(method);
@@ -68,7 +72,7 @@ namespace Castle.DynamicProxy.Contributors
 			}
 		}
 
-		protected abstract IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook);
+		protected abstract IEnumerable<MembersCollector> GetCollectors();
 
 		public virtual void Generate(ClassEmitter @class)
 		{

--- a/src/Castle.Core/DynamicProxy/Contributors/IMembersCollectorSink.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/IMembersCollectorSink.cs
@@ -1,0 +1,25 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Contributors
+{
+	using Castle.DynamicProxy.Generators;
+
+	internal interface IMembersCollectorSink
+	{
+		void Add(MetaEvent @event);
+		void Add(MetaMethod method);
+		void Add(MetaProperty property);
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
@@ -34,15 +34,12 @@ namespace Castle.DynamicProxy.Contributors
 			this.canChangeTarget = canChangeTarget;
 		}
 
-		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
+		protected override IEnumerable<MembersCollector> GetCollectors()
 		{
-			Debug.Assert(hook != null, "hook != null");
-
 			foreach (var @interface in interfaces)
 			{
 				var item = GetCollectorForInterface(@interface);
 				item.Logger = Logger;
-				item.CollectMembersToProxy(hook);
 				yield return item;
 			}
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
@@ -32,13 +32,11 @@ namespace Castle.DynamicProxy.Contributors
 			getTargetExpression = getTarget;
 		}
 
-		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
+		protected override IEnumerable<MembersCollector> GetCollectors()
 		{
-			Debug.Assert(hook != null, "hook != null");
 			foreach (var @interface in interfaces)
 			{
 				var item = new InterfaceMembersCollector(@interface);
-				item.CollectMembersToProxy(hook);
 				yield return item;
 			}
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -174,10 +174,6 @@ namespace Castle.DynamicProxy.Contributors
 			}
 			checkedMethods.Add(method);
 
-			if (methods.ContainsKey(method))
-			{
-				return null;
-			}
 			var methodToGenerate = GetMethodToGenerate(method, hook, isStandalone);
 			if (methodToGenerate != null)
 			{

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -29,9 +29,9 @@ namespace Castle.DynamicProxy.Contributors
 		private ILogger logger = NullLogger.Instance;
 
 		private HashSet<MethodInfo> checkedMethods = new HashSet<MethodInfo>();
-		private readonly IDictionary<PropertyInfo, MetaProperty> properties = new Dictionary<PropertyInfo, MetaProperty>();
-		private readonly IDictionary<EventInfo, MetaEvent> events = new Dictionary<EventInfo, MetaEvent>();
-		private readonly IDictionary<MethodInfo, MetaMethod> methods = new Dictionary<MethodInfo, MetaMethod>();
+		private readonly List<MetaProperty> properties = new List<MetaProperty>();
+		private readonly List<MetaEvent> events = new List<MetaEvent>();
+		private readonly List<MetaMethod> methods = new List<MetaMethod>();
 
 		protected readonly Type type;
 
@@ -48,17 +48,17 @@ namespace Castle.DynamicProxy.Contributors
 
 		public IEnumerable<MetaMethod> Methods
 		{
-			get { return methods.Values; }
+			get { return methods; }
 		}
 
 		public IEnumerable<MetaProperty> Properties
 		{
-			get { return properties.Values; }
+			get { return properties; }
 		}
 
 		public IEnumerable<MetaEvent> Events
 		{
-			get { return events.Values; }
+			get { return events; }
 		}
 
 		public virtual void CollectMembersToProxy(IProxyGenerationHook hook)
@@ -131,13 +131,13 @@ namespace Castle.DynamicProxy.Contributors
 			var nonInheritableAttributes = property.GetNonInheritableAttributes();
 			var arguments = property.GetIndexParameters();
 
-			properties[property] = new MetaProperty(property.Name,
-			                                        property.PropertyType,
-			                                        property.DeclaringType,
-			                                        getter,
-			                                        setter,
-			                                        nonInheritableAttributes.Select(a => a.Builder),
-			                                        arguments.Select(a => a.ParameterType).ToArray());
+			properties.Add(new MetaProperty(property.Name,
+			                                property.PropertyType,
+			                                property.DeclaringType,
+			                                getter,
+			                                setter,
+			                                nonInheritableAttributes.Select(a => a.Builder),
+			                                arguments.Select(a => a.ParameterType).ToArray()));
 		}
 
 		private void AddEvent(EventInfo @event, IProxyGenerationHook hook)
@@ -162,8 +162,8 @@ namespace Castle.DynamicProxy.Contributors
 				return;
 			}
 
-			events[@event] = new MetaEvent(@event.Name,
-			                               @event.DeclaringType, @event.EventHandlerType, adder, remover, EventAttributes.None);
+			events.Add(new MetaEvent(@event.Name,
+			                         @event.DeclaringType, @event.EventHandlerType, adder, remover, EventAttributes.None));
 		}
 
 		private MetaMethod AddMethod(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
@@ -176,7 +176,7 @@ namespace Castle.DynamicProxy.Contributors
 			var methodToGenerate = GetMethodToGenerate(method, hook, isStandalone);
 			if (methodToGenerate != null)
 			{
-				methods[method] = methodToGenerate;
+				methods.Add(methodToGenerate);
 			}
 
 			return methodToGenerate;

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -28,7 +28,7 @@ namespace Castle.DynamicProxy.Contributors
 		private const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 		private ILogger logger = NullLogger.Instance;
 
-		private ICollection<MethodInfo> checkedMethods = new HashSet<MethodInfo>();
+		private HashSet<MethodInfo> checkedMethods = new HashSet<MethodInfo>();
 		private readonly IDictionary<PropertyInfo, MetaProperty> properties = new Dictionary<PropertyInfo, MetaProperty>();
 		private readonly IDictionary<EventInfo, MetaEvent> events = new Dictionary<EventInfo, MetaEvent>();
 		private readonly IDictionary<MethodInfo, MetaMethod> methods = new Dictionary<MethodInfo, MetaMethod>();
@@ -168,11 +168,10 @@ namespace Castle.DynamicProxy.Contributors
 
 		private MetaMethod AddMethod(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (checkedMethods.Contains(method))
+			if (checkedMethods.Add(method) == false)
 			{
 				return null;
 			}
-			checkedMethods.Add(method);
 
 			var methodToGenerate = GetMethodToGenerate(method, hook, isStandalone);
 			if (methodToGenerate != null)

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -69,7 +69,7 @@ namespace Castle.DynamicProxy.Contributors
 			base.Generate(@class);
 		}
 
-		protected override IEnumerable<MembersCollector> CollectElementsToProxyInternal(IProxyGenerationHook hook)
+		protected override IEnumerable<MembersCollector> GetCollectors()
 		{
 			foreach (var @interface in interfaces)
 			{
@@ -83,7 +83,6 @@ namespace Castle.DynamicProxy.Contributors
 					Debug.Assert(@interface.IsDelegateType());
 					item = new DelegateTypeMembersCollector(@interface);
 				}
-				item.CollectMembersToProxy(hook);
 				yield return item;
 			}
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -28,9 +28,9 @@ namespace Castle.DynamicProxy.Contributors
 		{
 		}
 
-		public override void CollectMembersToProxy(IProxyGenerationHook hook)
+		public override void CollectMembersToProxy(IProxyGenerationHook hook, IMembersCollectorSink sink)
 		{
-			base.CollectMembersToProxy(hook);
+			base.CollectMembersToProxy(hook, sink);
 			CollectFields(hook);
 			// TODO: perhaps we should also look for nested classes...
 		}


### PR DESCRIPTION
During proxy type generation, collected events, methods, and properties are stored at three distinct levels:

1. in a `MetaType` model (which is shared by all involved contributors)
2. in each contributor (i.e. subclasses of `CompositeTypeContributor`)
3. in each member collector (i.e. subclasses of `MembersCollector`)

It turns out that member collectors don't need to hold on to the members they're collecting; their members are only ever queried in order to be transferred into `MetaType` and the owning contributor.

This PR refactors existing code such that member collectors can directly send the collected members to where they need to end up. By doing so, we can avoid unnecessary collection allocations and element copying.