### PR TITLE
Speed up interface proxy w/o target type generation significantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Enhancements:
 - .NET Standard 2.0 and 2.1 support (@lg2de, #485)
 - Non-intercepted methods on a class proxy with target are now forwarded to the target (@stakx, #571)
+- Significant performance improvements with proxy type generation for interface proxies without target. (Up until now, DynamicProxy generated a separate `IInvocation` implementation type for every single proxied method &ndash; it is now able to reuse a single predefined type in many cases, thereby reducing the total amount of dynamic type generation.) (@stakx, #573)
 
 Bugfixes:
 - Proxying certain `[Serializable]` classes produces proxy types that fail PEVerify test (@stakx, #367)

--- a/ref/Castle.Core-net45.cs
+++ b/ref/Castle.Core-net45.cs
@@ -2787,6 +2787,15 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    [System.Serializable]
+    public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
+    {
+        public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        public override object InvocationTarget { get; }
+        public override System.Reflection.MethodInfo MethodInvocationTarget { get; }
+        public override System.Type TargetType { get; }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public static class TypeUtil
     {
         public static System.Type[] GetAllInterfaces(this System.Type type) { }

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -2740,6 +2740,14 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
+    {
+        public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        public override object InvocationTarget { get; }
+        public override System.Reflection.MethodInfo MethodInvocationTarget { get; }
+        public override System.Type TargetType { get; }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public static class TypeUtil
     {
         public static System.Type[] GetAllInterfaces(this System.Type type) { }

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -2740,6 +2740,14 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
+    {
+        public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        public override object InvocationTarget { get; }
+        public override System.Reflection.MethodInfo MethodInvocationTarget { get; }
+        public override System.Type TargetType { get; }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public static class TypeUtil
     {
         public static System.Type[] GetAllInterfaces(this System.Type type) { }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+
+	using Castle.DynamicProxy.Internal;
+
+	using NUnit.Framework;
+
+	/// <summary>
+	///   This fixture checks which <see cref="IInvocation"/> types get used for proxied methods.
+	///   Usually, DynamicProxy generates a separate implementation type per proxied method, but
+	///   in some cases, it can reuse predefined implementation types. Because this is beneficial
+	///   for runtime performance (as it reduces the amount of dynamic type generation performed),
+	///   we want to ensure that those predefined types do in fact get picked when they should be.
+	/// </summary>
+	[TestFixture]
+	public class InvocationTypeReuseTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public void Non_generic_method_of_interface_proxy_without_target__uses__InterfaceMethodWithoutTargetInvocation()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IWithNonGenericMethod>(recorder);
+			proxy.Method();
+
+			Assert.AreEqual(typeof(InterfaceMethodWithoutTargetInvocation), recorder.InvocationType);
+		}
+
+		public interface IWithNonGenericMethod
+		{
+			void Method();
+		}
+
+		private sealed class InvocationTypeRecorder : IInterceptor
+		{
+			public Type InvocationType { get; private set; }
+
+			public void Intercept(IInvocation invocation)
+			{
+				InvocationType = invocation.GetType();
+			}
+		}
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
@@ -41,9 +41,25 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(typeof(InterfaceMethodWithoutTargetInvocation), recorder.InvocationType);
 		}
 
+		[Test]
+		public void Generic_method_of_interface_proxy_without_target__uses__InterfaceMethodWithoutTargetInvocation()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IWithGenericMethod>(recorder);
+			proxy.Method(42);
+
+			Assert.AreEqual(typeof(InterfaceMethodWithoutTargetInvocation), recorder.InvocationType);
+		}
+
 		public interface IWithNonGenericMethod
 		{
 			void Method();
+		}
+
+		public interface IWithGenericMethod
+		{
+			void Method<T>(T arg);
 		}
 
 		private sealed class InvocationTypeRecorder : IInterceptor

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
@@ -63,7 +63,7 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var methodInfo = method.Method;
 
-			if (canChangeTarget == false && methodInfo.IsAbstract && methodInfo.IsGenericMethod == false && methodInfo.IsGenericMethodDefinition == false)
+			if (canChangeTarget == false && methodInfo.IsAbstract)
 			{
 				// We do not need to generate a custom invocation type because no custom implementation
 				// for `InvokeMethodOnTarget` will be needed (proceeding to target isn't possible here):

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -73,7 +73,6 @@ namespace Castle.DynamicProxy.Generators
 		{
 			var invocationType = invocation;
 
-			Trace.Assert(MethodToOverride.IsGenericMethod == invocationType.IsGenericTypeDefinition);
 			var genericArguments = Type.EmptyTypes;
 
 			var constructor = invocation.GetConstructors()[0];
@@ -81,13 +80,16 @@ namespace Castle.DynamicProxy.Generators
 			IExpression proxiedMethodTokenExpression;
 			if (MethodToOverride.IsGenericMethod)
 			{
-				// bind generic method arguments to invocation's type arguments
-				genericArguments = emitter.MethodBuilder.GetGenericArguments();
-				invocationType = invocationType.MakeGenericType(genericArguments);
-				constructor = TypeBuilder.GetConstructor(invocationType, constructor);
-
 				// Not in the cache: generic method
+				genericArguments = emitter.MethodBuilder.GetGenericArguments();
 				proxiedMethodTokenExpression = new MethodTokenExpression(MethodToOverride.MakeGenericMethod(genericArguments));
+
+				if (invocationType.IsGenericTypeDefinition)
+				{
+					// bind generic method arguments to invocation's type arguments
+					invocationType = invocationType.MakeGenericType(genericArguments);
+					constructor = TypeBuilder.GetConstructor(invocationType, constructor);
+				}
 			}
 			else
 			{

--- a/src/Castle.Core/DynamicProxy/Internal/InterfaceMethodWithoutTargetInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InterfaceMethodWithoutTargetInvocation.cs
@@ -1,0 +1,61 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Internal
+{
+	using System;
+	using System.ComponentModel;
+	using System.Diagnostics;
+	using System.Reflection;
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public sealed class InterfaceMethodWithoutTargetInvocation : AbstractInvocation
+	{
+		public InterfaceMethodWithoutTargetInvocation(object target, object proxy, IInterceptor[] interceptors, MethodInfo proxiedMethod, object[] arguments)
+			: base(proxy, interceptors, proxiedMethod, arguments)
+		{
+			// This invocation type is suitable for interface method invocations that cannot proceed
+			// to a target, i.e. where `InvokeMethodOnTarget` will always throw:
+
+			Debug.Assert(target == null, $"{nameof(InterfaceMethodWithoutTargetInvocation)} does not support targets.");
+			Debug.Assert(proxiedMethod.IsAbstract, $"{nameof(InterfaceMethodWithoutTargetInvocation)} does not support non-abstract methods.");
+
+			// Why this restriction? Because it greatly benefits proxy type generation performance.
+			//
+			// For invocations that can proceed to a target, `InvokeMethodOnTarget`'s implementation
+			// depends on the target method's signature. Because of this, DynamicProxy needs to
+			// dynamically generate a separate invocation type per such method. Type generation is
+			// always expensive... that is, slow.
+			//
+			// However, if it is known that `InvokeMethodOnTarget` won't forward, but throw,
+			// no custom (dynamically generated) invocation type is needed at all, and we can use
+			// this unspecific invocation type instead.
+		}
+
+		// The next three properties mimick the behavior seen with an interface proxy without target.
+		// (This is why this type's name starts with `Interface`.) A similar type could be written
+		// for class proxies without target, but the values returned here would be different.
+
+		public override object InvocationTarget => null;
+
+		public override MethodInfo MethodInvocationTarget => null;
+
+		public override Type TargetType => null;
+
+		protected override void InvokeMethodOnTarget() => ThrowOnNoTarget();
+	}
+}


### PR DESCRIPTION
DynamicProxy's runtime performance is directly tied to the amount of System.Reflection.Emit-ting done. If we do less dynamic type generation, DynamicProxy becomes faster.

I've recently realised that the main reason why DynamicProxy generates dedicated invocation types for every proxied method is because the invocation's `InvokeMethodOnTarget` implementation depends on the proxied method's signature.

However, if an invocation cannot proceed to a (method on a) target, we don't need a custom implementation for `InvokeMethodOnTarget`, and thus no custom invocation type; we can use a pre-defined invocation type instead!

This PR is a realization of this idea. I'm starting with ~~non-generic~~ methods on interface proxies without target. It should be possible to cover more methods &mdash; ~~generic ones (I think), and~~ abstract methods on class proxies without target &mdash; but those will take more work.

I expect this to be very beneficial to some core DynamicProxy usage scenarios, i.e. mocking libraries used in unit testing, where interface mocks are frequently backed by interfaces proxies without target.

I've tested this PR against Moq 4's test suite. Test execution time has dropped by a factor of 2.5x for both the .NET Framework and .NET Core. Another simple `Stopwatch` benchmark suggests roughly the same speed-up.