### PR TITLE
PRs should trigger GitHub Actions workflow, too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: push
+on: [ push, pull_request ]
 
 env:
   MONO_TAG: "6.0.0.334"


### PR DESCRIPTION
I originally omitted the `pull_request` workflow trigger because it seemed as if PRs would then trigger _two_ workflows: once for `push`, once for `pull_request`. Omitting it, however, means that PRs won't trigger any workflow at all, which is even worse.

I'm not observing double workflow triggers now, so I might have made an incorrect assumption earlier.

Should that problem resurface, we could prevent it by restricting the `push` event to the `master` branch; this would only be a slight problem when working in topic branches for which no PR gets opened.