### PR TITLE
Match generic parameters by position, not by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enhancements:
 - Significant performance improvements with proxy type generation for interface proxies without target. (Up until now, DynamicProxy generated a separate `IInvocation` implementation type for every single proxied method &ndash; it is now able to reuse a single predefined type in many cases, thereby reducing the total amount of dynamic type generation.) (@stakx, #573)
 
 Bugfixes:
+- Generic method with differently named generic arguments to parent throws `KeyNotFoundException` (@stakx, #106)
 - Proxying certain `[Serializable]` classes produces proxy types that fail PEVerify test (@stakx, #367)
 - `private protected` methods are not intercepted (@CrispyDrone, #535)
 - `System.UIntPtr` unsupported (@stakx, #546)

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericMethodsProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericMethodsProxyTestCase.cs
@@ -92,5 +92,32 @@ namespace Castle.DynamicProxy.Tests
 		{
 			generator.CreateInterfaceProxyWithoutTarget<GenericMethodWhereOneGenParamInheritsTheOther>();
 		}
+
+		[Test]
+		[TestCase(typeof(Test))]
+		[TestCase(typeof(TestVirtual))]
+		public void GenericMethodDifferentlyNamedGenericArguments(Type classType)
+		{
+			generator.CreateClassProxy(classType, new[] { typeof(ITest) });
+		}
+
+		public interface ITest
+		{
+			void Hi<T>();
+		}
+
+		public class Test : ITest
+		{
+			public void Hi<U>()
+			{
+			}
+		}
+
+		public class TestVirtual : ITest
+		{
+			public virtual void Hi<U>()
+			{
+			}
+		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -36,7 +36,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		private readonly List<MethodEmitter> methods;
 
-		private readonly Dictionary<string, GenericTypeParameterBuilder> name2GenericType;
 		private readonly List<NestedClassEmitter> nested;
 		private readonly List<PropertyEmitter> properties;
 		private readonly TypeBuilder typebuilder;
@@ -51,7 +50,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			constructors = new List<ConstructorEmitter>();
 			properties = new List<PropertyEmitter>();
 			events = new List<EventEmitter>();
-			name2GenericType = new Dictionary<string, GenericTypeParameterBuilder>();
 		}
 
 		public Type BaseType
@@ -113,7 +111,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				throw new InvalidOperationException("Cannot invoke me twice");
 			}
 
-			SetGenericTypeParameters(GenericUtil.CopyGenericArguments(methodToCopyGenericsFrom, typebuilder, name2GenericType));
+			SetGenericTypeParameters(GenericUtil.CopyGenericArguments(methodToCopyGenericsFrom, typebuilder));
 		}
 
 		public ConstructorEmitter CreateConstructor(params ArgumentReference[] arguments)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -284,7 +284,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 			if (parameter.IsGenericParameter)
 			{
-				return GetGenericArgument(parameter.Name);
+				return GetGenericArgument(parameter.GenericParameterPosition);
 			}
 
 			if (parameter.IsArray)
@@ -320,23 +320,18 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			}
 		}
 
-		public Type GetGenericArgument(string genericArgumentName)
+		public Type GetGenericArgument(int position)
 		{
-			if (name2GenericType.TryGetValue(genericArgumentName, out var genericTypeParameterBuilder))
-				return genericTypeParameterBuilder;
+			Debug.Assert(0 <= position && position < genericTypeParams.Length);
 
-			return null;
+			return genericTypeParams[position];
 		}
 
 		public Type[] GetGenericArgumentsFor(MethodInfo genericMethod)
 		{
-			var types = new List<Type>();
-			foreach (var genType in genericMethod.GetGenericArguments())
-			{
-				types.Add(name2GenericType[genType.Name]);
-			}
+			Debug.Assert(genericMethod.GetGenericArguments().Length == genericTypeParams.Length);
 
-			return types.ToArray();
+			return genericTypeParams;
 		}
 
 		public void SetGenericTypeParameters(GenericTypeParameterBuilder[] genericTypeParameterBuilders)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -268,13 +268,13 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		public Type GetClosedParameterType(Type parameter)
 		{
-			if (parameter.IsGenericTypeDefinition)
-			{
-				return parameter.GetGenericTypeDefinition().MakeGenericType(GetGenericArgumentsFor(parameter));
-			}
-
 			if (parameter.IsGenericType)
 			{
+				// ECMA-335 section II.9.4: "The CLI does not support partial instantiation
+				// of generic types. And generic types shall not appear uninstantiated any-
+				// where in metadata signature blobs." (And parameters are defined there!)
+				Debug.Assert(parameter.IsGenericTypeDefinition == false);
+
 				var arguments = parameter.GetGenericArguments();
 				if (CloseGenericParametersIfAny(arguments))
 				{
@@ -326,25 +326,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 				return genericTypeParameterBuilder;
 
 			return null;
-		}
-
-		public Type[] GetGenericArgumentsFor(Type genericType)
-		{
-			var types = new List<Type>();
-
-			foreach (var genType in genericType.GetGenericArguments())
-			{
-				if (genType.IsGenericParameter)
-				{
-					types.Add(name2GenericType[genType.Name]);
-				}
-				else
-				{
-					types.Add(genType);
-				}
-			}
-
-			return types.ToArray();
 		}
 
 		public Type[] GetGenericArgumentsFor(MethodInfo genericMethod)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -29,12 +29,10 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	{
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,
-			TypeBuilder builder,
-			Dictionary<string, GenericTypeParameterBuilder> name2GenericType)
+			TypeBuilder builder)
 		{
-			return
-				CopyGenericArguments(methodToCopyGenericsFrom, name2GenericType,
-				                     builder.DefineGenericParameters);
+			var _ = new Dictionary<string, GenericTypeParameterBuilder>();
+			return CopyGenericArguments(methodToCopyGenericsFrom, _, builder.DefineGenericParameters);
 		}
 
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -37,70 +37,10 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,
-			MethodBuilder builder,
-			Dictionary<string, GenericTypeParameterBuilder> name2GenericType)
+			MethodBuilder builder)
 		{
-			return
-				CopyGenericArguments(methodToCopyGenericsFrom, name2GenericType,
-				                     builder.DefineGenericParameters);
-		}
-
-		public static Type ExtractCorrectType(Type paramType, Dictionary<string, GenericTypeParameterBuilder> name2GenericType)
-		{
-			if (paramType.IsArray)
-			{
-				var rank = paramType.GetArrayRank();
-
-				var underlyingType = paramType.GetElementType();
-
-				if (underlyingType.IsGenericParameter)
-				{
-					GenericTypeParameterBuilder genericType;
-					if (name2GenericType.TryGetValue(underlyingType.Name, out genericType) == false)
-					{
-						return paramType;
-					}
-
-					if (rank == 1)
-					{
-						return genericType.MakeArrayType();
-					}
-					return genericType.MakeArrayType(rank);
-				}
-				if (rank == 1)
-				{
-					return underlyingType.MakeArrayType();
-				}
-				return underlyingType.MakeArrayType(rank);
-			}
-
-			if (paramType.IsGenericParameter)
-			{
-				GenericTypeParameterBuilder value;
-				if (name2GenericType.TryGetValue(paramType.Name, out value))
-				{
-					return value;
-				}
-			}
-
-			return paramType;
-		}
-
-		public static Type[] ExtractParametersTypes(
-			ParameterInfo[] baseMethodParameters,
-			Dictionary<string, GenericTypeParameterBuilder> name2GenericType)
-		{
-			var newParameters = new Type[baseMethodParameters.Length];
-
-			for (var i = 0; i < baseMethodParameters.Length; i++)
-			{
-				var param = baseMethodParameters[i];
-				var paramType = param.ParameterType;
-
-				newParameters[i] = ExtractCorrectType(paramType, name2GenericType);
-			}
-
-			return newParameters;
+			var _ = new Dictionary<string, GenericTypeParameterBuilder>();
+			return CopyGenericArguments(methodToCopyGenericsFrom, _, builder.DefineGenericParameters);
 		}
 
 		private static Type AdjustConstraintToNewGenericParameters(

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -103,21 +103,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			return newParameters;
 		}
 
-		public static Dictionary<string, GenericTypeParameterBuilder> GetGenericArgumentsMap(AbstractTypeEmitter parentEmitter)
-		{
-			if (parentEmitter.GenericTypeParams == null || parentEmitter.GenericTypeParams.Length == 0)
-			{
-				return new Dictionary<string, GenericTypeParameterBuilder>(0);
-			}
-
-			var name2GenericType = new Dictionary<string, GenericTypeParameterBuilder>(parentEmitter.GenericTypeParams.Length);
-			foreach (var genType in parentEmitter.GenericTypeParams)
-			{
-				name2GenericType.Add(genType.Name, genType);
-			}
-			return name2GenericType;
-		}
-
 		private static Type AdjustConstraintToNewGenericParameters(
 			Type constraint, MethodInfo methodToCopyGenericsFrom, Type[] originalGenericParameters,
 			GenericTypeParameterBuilder[] newGenericParameters)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -15,7 +15,6 @@
 namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using System;
-	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Reflection;
 	using System.Reflection.Emit;
@@ -31,16 +30,14 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			MethodInfo methodToCopyGenericsFrom,
 			TypeBuilder builder)
 		{
-			var _ = new Dictionary<string, GenericTypeParameterBuilder>();
-			return CopyGenericArguments(methodToCopyGenericsFrom, _, builder.DefineGenericParameters);
+			return CopyGenericArguments(methodToCopyGenericsFrom, builder.DefineGenericParameters);
 		}
 
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,
 			MethodBuilder builder)
 		{
-			var _ = new Dictionary<string, GenericTypeParameterBuilder>();
-			return CopyGenericArguments(methodToCopyGenericsFrom, _, builder.DefineGenericParameters);
+			return CopyGenericArguments(methodToCopyGenericsFrom, builder.DefineGenericParameters);
 		}
 
 		private static Type AdjustConstraintToNewGenericParameters(
@@ -107,7 +104,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		private static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,
-			Dictionary<string, GenericTypeParameterBuilder> name2GenericType,
 			ApplyGenArgs genericParameterGenerator)
 		{
 			var originalGenericArguments = methodToCopyGenericsFrom.GetGenericArguments();
@@ -136,8 +132,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 					newGenericParameters[i].SetGenericParameterAttributes(GenericParameterAttributes.None);
 				}
-
-				name2GenericType[argumentNames[i]] = newGenericParameters[i];
 			}
 
 			return newGenericParameters;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -15,6 +15,7 @@
 namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using System;
+	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Globalization;
 	using System.Linq;
@@ -57,7 +58,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		                       MethodAttributes attributes, MethodInfo methodToUseAsATemplate)
 			: this(owner, name, attributes)
 		{
-			var name2GenericType = GenericUtil.GetGenericArgumentsMap(owner);
+			// All code paths leading up to this constructor can be traced back to
+			// proxy type generation code. At present, proxy types are never generic.
+			Debug.Assert(owner.GenericTypeParams == null || owner.GenericTypeParams.Length == 0);
+
+			var name2GenericType = new Dictionary<string, GenericTypeParameterBuilder>(0);
 
 			var returnType = GenericUtil.ExtractCorrectType(methodToUseAsATemplate.ReturnType, name2GenericType);
 			var baseMethodParameters = methodToUseAsATemplate.GetParameters();

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -62,13 +62,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			// proxy type generation code. At present, proxy types are never generic.
 			Debug.Assert(owner.GenericTypeParams == null || owner.GenericTypeParams.Length == 0);
 
-			var name2GenericType = new Dictionary<string, GenericTypeParameterBuilder>(0);
-
-			var returnType = GenericUtil.ExtractCorrectType(methodToUseAsATemplate.ReturnType, name2GenericType);
+			var returnType = methodToUseAsATemplate.ReturnType;
 			var baseMethodParameters = methodToUseAsATemplate.GetParameters();
-			var parameters = GenericUtil.ExtractParametersTypes(baseMethodParameters, name2GenericType);
+			var parameters = ArgumentsUtil.GetTypes(baseMethodParameters);
 
-			genericTypeParams = GenericUtil.CopyGenericArguments(methodToUseAsATemplate, builder, name2GenericType);
+			genericTypeParams = GenericUtil.CopyGenericArguments(methodToUseAsATemplate, builder);
 			SetParameters(parameters);
 			SetReturnType(returnType);
 			SetSignature(returnType, methodToUseAsATemplate.ReturnParameter, parameters, baseMethodParameters);

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -98,44 +98,6 @@ namespace Castle.DynamicProxy.Internal
 			return GetAllInterfaces(new[] { type });
 		}
 
-		internal static Type GetClosedParameterType(this AbstractTypeEmitter type, Type parameter)
-		{
-			if (parameter.IsGenericTypeDefinition)
-			{
-				return parameter.GetGenericTypeDefinition().MakeGenericType(type.GetGenericArgumentsFor(parameter));
-			}
-
-			if (parameter.IsGenericType)
-			{
-				var arguments = parameter.GetGenericArguments();
-				if (CloseGenericParametersIfAny(type, arguments))
-				{
-					return parameter.GetGenericTypeDefinition().MakeGenericType(arguments);
-				}
-			}
-
-			if (parameter.IsGenericParameter)
-			{
-				return type.GetGenericArgument(parameter.Name);
-			}
-
-			if (parameter.IsArray)
-			{
-				var elementType = GetClosedParameterType(type, parameter.GetElementType());
-				int rank = parameter.GetArrayRank();
-				return rank == 1
-					? elementType.MakeArrayType()
-					: elementType.MakeArrayType(rank);
-			}
-
-			if (parameter.IsByRef)
-			{
-				var elementType = GetClosedParameterType(type, parameter.GetElementType());
-				return elementType.MakeByRefType();
-			}
-
-			return parameter;
-		}
 
 		public static Type GetTypeOrNull(object target)
 		{
@@ -230,21 +192,6 @@ namespace Castle.DynamicProxy.Internal
 		internal static bool IsDelegateType(this Type type)
 		{
 			return type.BaseType == typeof(MulticastDelegate);
-		}
-
-		private static bool CloseGenericParametersIfAny(AbstractTypeEmitter emitter, Type[] arguments)
-		{
-			var hasAnyGenericParameters = false;
-			for (var i = 0; i < arguments.Length; i++)
-			{
-				var newType = GetClosedParameterType(emitter, arguments[i]);
-				if (newType != null && !ReferenceEquals(newType, arguments[i]))
-				{
-					arguments[i] = newType;
-					hasAnyGenericParameters = true;
-				}
-			}
-			return hasAnyGenericParameters;
 		}
 
 		private static Type[] Sort(ICollection<Type> types)


### PR DESCRIPTION
Fixes #106. See commit messages for further explanations.

This is a redo of #465, which we closed because I needed more time to study how DynamicProxy deals with generics. I think I've now got an understanding of the bigger picture, and am feeling more confident that the proposed change is sound.

---

One might think that some of the infrastructure being removed here could have come in handy once we decide to support open generic proxy type generation (#448). However, I don't think this is the case:

* As one commit message remarks, some of the parameter mapping code appears to be incomplete. Worse than that, it might even be buggy. It is hard to tell which because we don't have any test cases nor real-world scenarios that cover it (which also makes it so much harder to even understand what the code was supposed to achieve).

* More importantly, matching arguments by name fundamentally seems like the wrong approach, because that is not how the underlying platform works: the CLI generally identifies generic parameters by their position.

I think we're better off basing future developments on new (position-based) code instead of the `name2GenericType` infrastructure being removed here.