### PR TITLE
Upgrade log4net to 2.0.13 (latest)

### DIFF
--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -47,7 +47,7 @@
 		<PackageReference Include="NUnit.Console" Version="3.11.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
 		<PackageReference Include="NUnitLite" Version="3.12.0" />
-		<PackageReference Include="log4net" Version="2.0.12" />
+		<PackageReference Include="log4net" Version="2.0.13" />
 		<PackageReference Include="NLog" Version="4.5.0" />
 		<PackageReference Include="Serilog" Version="2.0.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />

--- a/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
+++ b/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="log4net" Version="2.0.12" />
+		<PackageReference Include="log4net" Version="2.0.13" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
log4net 2.0.12 has issues when using the netstandard2.0 binaries with a net72 web application.

This PR upgrades log4net to 2.0.13 which solves those issues.