### PR TITLE
Update to net462 as a minimum target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,11 +62,11 @@ jobs:
       - name: Test on .NET Core 3.1
         run: dotnet test -c Release -f netcoreapp3.1 --no-build --no-restore -l "console;verbosity=detailed"
 
-      - name: Test on .NET Framework 4.6.1 (Windows only)
+      - name: Test on .NET Framework 4.6.2 (Windows only)
         if: matrix.os == 'windows-latest'
-        run: dotnet test -c Release -f net461 --no-build --no-restore -l "console;verbosity=detailed"
+        run: dotnet test -c Release -f net462 --no-build --no-restore -l "console;verbosity=detailed"
 
-      - name: Test on .NET Framework 4.6.1 using Mono (Linux only)
+      - name: Test on .NET Framework 4.6.2 using Mono (Linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          docker run --rm -v "$PWD":'/project' -w='/project' mono:$MONO_TAG bash -c 'mono ./src/Castle.Core.Tests/bin/Release/net461/Castle.Core.Tests.exe && mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net461/Castle.Core.Tests.WeakNamed.exe'
+          docker run --rm -v "$PWD":'/project' -w='/project' mono:$MONO_TAG bash -c 'mono ./src/Castle.Core.Tests/bin/Release/net462/Castle.Core.Tests.exe && mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net462/Castle.Core.Tests.WeakNamed.exe'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bugfixes:
 - Upgrade log4net to v2.0.13 (@jonorossi, @stakx, @dschwartzni, #574, #605)
 
 Deprecations:
- - Removed support for the .NET Framework < 4.5 and .NET Standard 1.x. (@stakx, #495, #496)
+ - Removed support for the .NET Framework < 4.6.2 and .NET Standard 1.x. (@stakx, #495, #496; @Jevonius, #614)
  - Removed support for Code Access Security (CAS). (@stakx, #502)
  - Removed support for Remoting. This library no longer defines any types deriving from `MarshalByRefObject`, and `ProxyUtil.IsProxy` (which used to recognize remoting/"transparent" proxies) now tests only for DynamicProxy proxies. (@stakx, #507)
  - The following public members have been removed:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ build.cmd
 
 Compilation requires a C# 9 compiler, an up-to-date .NET Core SDK, and MSBuild 15+ (which should be included in the former).
 
-Running the unit tests additionally requires the .NET Framework 4.6.1+ as well as the .NET Core 2.1 and 3.1 runtimes to be installed. (If you do not have all of those installed, you can run the tests for a specific target framework using `dotnet test -f <framework>`.)
+Running the unit tests additionally requires the .NET Framework 4.6.2+ as well as the .NET Core 2.1 and 3.1 runtimes to be installed. (If you do not have all of those installed, you can run the tests for a specific target framework using `dotnet test -f <framework>`.)
 
 These requirements should be covered by Visual Studio 2019 and the .NET 5 SDK.
 
@@ -60,14 +60,14 @@ For known Mono defects, check [our issue tracker](https://github.com/castleproje
 
 The following conditional compilation symbols (vertical) are currently defined for each of the build configurations (horizontal):
 
-Symbol                              | .NET 4.5           | .NET Standard 2.x
+Symbol                              | .NET 4.6.2         | .NET Standard 2.x
 ----------------------------------- | ------------------ | ------------------
 `FEATURE_APPDOMAIN`                 | :white_check_mark: | :no_entry_sign:
 `FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:
 `FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
 `FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
 ---                                 |                    |
-`DOTNET45`                          | :white_check_mark: | :no_entry_sign:
+`DOTNET462`                         | :white_check_mark: | :no_entry_sign:
 
 * `FEATURE_APPDOMAIN` - enables support for features that make use of an AppDomain in the host.
 * `FEATURE_ASSEMBLYBUILDER_SAVE` - enabled support for saving the dynamically generated proxy assembly.

--- a/build.sh
+++ b/build.sh
@@ -41,11 +41,11 @@ echo "OSNAME: $OSNAME"
 dotnet build --configuration Release || exit 1
 
 echo --------------------
-echo Running NET461 Tests
+echo Running NET462 Tests
 echo --------------------
 
-mono ./src/Castle.Core.Tests/bin/Release/net461/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3
-mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net461/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3
+mono ./src/Castle.Core.Tests/bin/Release/net462/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3
+mono ./src/Castle.Core.Tests.WeakNamed/bin/Release/net462/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3
 
 echo ---------------------------
 echo Running NETCOREAPP3.1 Tests

--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -34,11 +34,11 @@ GOTO test
 :test
 
 echo --------------------
-echo Running NET461 Tests
+echo Running NET462 Tests
 echo --------------------
 
-%UserProfile%\.nuget\packages\nunit.consolerunner\3.11.1\tools\nunit3-console.exe src/Castle.Core.Tests/bin/%Configuration%/net461/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3 || exit /b 1
-%UserProfile%\.nuget\packages\nunit.consolerunner\3.11.1\tools\nunit3-console.exe src/Castle.Core.Tests.WeakNamed/bin/%Configuration%/net461/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3 || exit /b 1
+%UserProfile%\.nuget\packages\nunit.consolerunner\3.11.1\tools\nunit3-console.exe src/Castle.Core.Tests/bin/%Configuration%/net462/Castle.Core.Tests.exe --result=DesktopClrTestResults.xml;format=nunit3 || exit /b 1
+%UserProfile%\.nuget\packages\nunit.consolerunner\3.11.1\tools\nunit3-console.exe src/Castle.Core.Tests.WeakNamed/bin/%Configuration%/net462/Castle.Core.Tests.WeakNamed.exe --result=DesktopClrWeakNamedTestResults.xml;format=nunit3 || exit /b 1
 
 echo ---------------------------
 echo Running NETCOREAPP3.1 Tests

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -50,20 +50,12 @@
 		<DesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</DesktopClrConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net45|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants);DOTNET45</DefineConstants>
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net462|Debug'">
+		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants);DOTNET462</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net45|Release'">
-		<DefineConstants>$(DesktopClrConstants);DOTNET45;</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Debug'">
-		<DefineConstants>$(DiagnosticsConstants);$(DesktopClrConstants);DOTNET45</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net461|Release'">
-		<DefineConstants>$(DesktopClrConstants);DOTNET45</DefineConstants>
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net462|Release'">
+		<DefineConstants>$(DesktopClrConstants);DOTNET462</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netstandard2.0|Debug'">

--- a/docs/dynamicproxy-introduction.md
+++ b/docs/dynamicproxy-introduction.md
@@ -9,7 +9,7 @@ DynamicProxy differs from the proxy implementation built into the CLR which requ
 To use Castle DynamicProxy you need the following environment:
 
 * one of the following runtimes installed
-  * .NET Framework 4.5+
+  * .NET Framework 4.6.2+
   * .NET Core 2.1+
   * any another .NET platform that supports .NET Standard 2.0+ and runtime type generation using System.Reflection.Emit
 * `Castle.Core.dll` (assembly where DynamicProxy lives)

--- a/ref/Castle.Core-net462.cs
+++ b/ref/Castle.Core-net462.cs
@@ -2,7 +2,7 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Castle.Core.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010077f5e87030dadccce6902c6adab7a987bd69cb5819991531f560785eacfc89b6fcddf6bb2a00743a7194e454c0273447fc6eec36474ba8e5a3823147d214298e4f9a631b1afee1a51ffeae4672d498f14b000e3d321453cdd8ac064de7e1cf4d222b7e81f54d4fd46725370d702a05b48738cc29d09228f1aa722ae1a9ca02fb")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace Castle.Components.DictionaryAdapter
 {
     public abstract class AbstractDictionaryAdapter : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable

--- a/ref/Castle.Services.Logging.NLogIntegration-net462.cs
+++ b/ref/Castle.Services.Logging.NLogIntegration-net462.cs
@@ -1,27 +1,54 @@
+[assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
-namespace Castle.Services.Logging.SerilogIntegration
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
+namespace Castle.Services.Logging.NLogIntegration
 {
-    public class SerilogFactory : Castle.Core.Logging.AbstractLoggerFactory
+    public class ExtendedNLogFactory : Castle.Core.Logging.AbstractExtendedLoggerFactory
     {
-        public SerilogFactory() { }
-        public SerilogFactory(Serilog.ILogger logger) { }
+        public ExtendedNLogFactory() { }
+        public ExtendedNLogFactory(NLog.Config.LoggingConfiguration loggingConfiguration) { }
+        public ExtendedNLogFactory(bool configuredExternally) { }
+        public ExtendedNLogFactory(string configFile) { }
+        public override Castle.Core.Logging.IExtendedLogger Create(string name) { }
+        public override Castle.Core.Logging.IExtendedLogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
+    }
+    public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
+    {
+        public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
+        public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
+        public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
+        public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
+        protected new Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        public override Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
+        public Castle.Core.Logging.IExtendedLogger CreateExtendedChildLogger(string name) { }
+    }
+    public class GlobalContextProperties : Castle.Core.Logging.IContextProperties
+    {
+        public GlobalContextProperties() { }
+        public object this[string key] { get; set; }
+    }
+    public class NLogFactory : Castle.Core.Logging.AbstractLoggerFactory
+    {
+        public NLogFactory() { }
+        public NLogFactory(NLog.Config.LoggingConfiguration loggingConfiguration) { }
+        public NLogFactory(bool configuredExternally) { }
+        public NLogFactory(string configFile) { }
         public override Castle.Core.Logging.ILogger Create(string name) { }
         public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
-    [System.Serializable]
-    public class SerilogLogger : Castle.Core.Logging.ILogger
+    public class NLogLogger : Castle.Core.Logging.ILogger
     {
-        public SerilogLogger(Serilog.ILogger logger, Castle.Services.Logging.SerilogIntegration.SerilogFactory factory) { }
-        protected Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
+        public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
+        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected Serilog.ILogger Logger { get; set; }
-        public Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
+        protected NLog.Logger Logger { get; set; }
+        public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(System.Func<string> messageFactory) { }
         public void Debug(string message) { }
         public void Debug(string message, System.Exception exception) { }
@@ -65,5 +92,23 @@ namespace Castle.Services.Logging.SerilogIntegration
         public void WarnFormat(System.Exception exception, string format, params object[] args) { }
         public void WarnFormat(System.IFormatProvider formatProvider, string format, params object[] args) { }
         public void WarnFormat(System.Exception exception, System.IFormatProvider formatProvider, string format, params object[] args) { }
+    }
+    public class ThreadContextProperties : Castle.Core.Logging.IContextProperties
+    {
+        public ThreadContextProperties() { }
+        public object this[string key] { get; set; }
+    }
+    public class ThreadContextStack : Castle.Core.Logging.IContextStack
+    {
+        public ThreadContextStack() { }
+        public int Count { get; }
+        public void Clear() { }
+        public string Pop() { }
+        public System.IDisposable Push(string message) { }
+    }
+    public class ThreadContextStacks : Castle.Core.Logging.IContextStacks
+    {
+        public ThreadContextStacks() { }
+        public Castle.Core.Logging.IContextStack this[string key] { get; }
     }
 }

--- a/ref/Castle.Services.Logging.SerilogIntegration-net462.cs
+++ b/ref/Castle.Services.Logging.SerilogIntegration-net462.cs
@@ -1,56 +1,27 @@
-[assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
-[assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
-namespace Castle.Services.Logging.Log4netIntegration
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
+namespace Castle.Services.Logging.SerilogIntegration
 {
-    public class ExtendedLog4netFactory : Castle.Core.Logging.AbstractExtendedLoggerFactory
+    public class SerilogFactory : Castle.Core.Logging.AbstractLoggerFactory
     {
-        public ExtendedLog4netFactory() { }
-        public ExtendedLog4netFactory(bool configuredExternally) { }
-        public ExtendedLog4netFactory(System.IO.Stream config) { }
-        public ExtendedLog4netFactory(string configFile) { }
-        public override Castle.Core.Logging.IExtendedLogger Create(string name) { }
-        public override Castle.Core.Logging.IExtendedLogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
-    }
-    public class ExtendedLog4netLogger : Castle.Services.Logging.Log4netIntegration.Log4netLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
-    {
-        public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
-        public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
-        public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
-        public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
-        protected new Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
-        public override Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
-        public Castle.Core.Logging.IExtendedLogger CreateExtendedChildLogger(string name) { }
-    }
-    public class GlobalContextProperties : Castle.Core.Logging.IContextProperties
-    {
-        public GlobalContextProperties() { }
-        public object this[string key] { get; set; }
-    }
-    public class Log4netFactory : Castle.Core.Logging.AbstractLoggerFactory
-    {
-        public Log4netFactory() { }
-        public Log4netFactory(bool configuredExternally) { }
-        public Log4netFactory(System.IO.Stream config) { }
-        public Log4netFactory(string configFile) { }
+        public SerilogFactory() { }
+        public SerilogFactory(Serilog.ILogger logger) { }
         public override Castle.Core.Logging.ILogger Create(string name) { }
         public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
     [System.Serializable]
-    public class Log4netLogger : Castle.Core.Logging.ILogger
+    public class SerilogLogger : Castle.Core.Logging.ILogger
     {
-        public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
-        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
+        public SerilogLogger(Serilog.ILogger logger, Castle.Services.Logging.SerilogIntegration.SerilogFactory factory) { }
+        protected Castle.Services.Logging.SerilogIntegration.SerilogFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected log4net.Core.ILogger Logger { get; set; }
-        public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
+        protected Serilog.ILogger Logger { get; set; }
+        public Castle.Core.Logging.ILogger CreateChildLogger(string loggerName) { }
         public void Debug(System.Func<string> messageFactory) { }
         public void Debug(string message) { }
         public void Debug(string message, System.Exception exception) { }
@@ -94,23 +65,5 @@ namespace Castle.Services.Logging.Log4netIntegration
         public void WarnFormat(System.Exception exception, string format, params object[] args) { }
         public void WarnFormat(System.IFormatProvider formatProvider, string format, params object[] args) { }
         public void WarnFormat(System.Exception exception, System.IFormatProvider formatProvider, string format, params object[] args) { }
-    }
-    public class ThreadContextProperties : Castle.Core.Logging.IContextProperties
-    {
-        public ThreadContextProperties() { }
-        public object this[string key] { get; set; }
-    }
-    public class ThreadContextStack : Castle.Core.Logging.IContextStack
-    {
-        public ThreadContextStack(log4net.Util.ThreadContextStack log4netStack) { }
-        public int Count { get; }
-        public void Clear() { }
-        public string Pop() { }
-        public System.IDisposable Push(string message) { }
-    }
-    public class ThreadContextStacks : Castle.Core.Logging.IContextStacks
-    {
-        public ThreadContextStacks() { }
-        public Castle.Core.Logging.IContextStack this[string key] { get; }
     }
 }

--- a/ref/Castle.Services.Logging.log4netIntegration-net462.cs
+++ b/ref/Castle.Services.Logging.log4netIntegration-net462.cs
@@ -1,25 +1,26 @@
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/castleproject/Core")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
-namespace Castle.Services.Logging.NLogIntegration
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
+namespace Castle.Services.Logging.Log4netIntegration
 {
-    public class ExtendedNLogFactory : Castle.Core.Logging.AbstractExtendedLoggerFactory
+    public class ExtendedLog4netFactory : Castle.Core.Logging.AbstractExtendedLoggerFactory
     {
-        public ExtendedNLogFactory() { }
-        public ExtendedNLogFactory(NLog.Config.LoggingConfiguration loggingConfiguration) { }
-        public ExtendedNLogFactory(bool configuredExternally) { }
-        public ExtendedNLogFactory(string configFile) { }
+        public ExtendedLog4netFactory() { }
+        public ExtendedLog4netFactory(bool configuredExternally) { }
+        public ExtendedLog4netFactory(System.IO.Stream config) { }
+        public ExtendedLog4netFactory(string configFile) { }
         public override Castle.Core.Logging.IExtendedLogger Create(string name) { }
         public override Castle.Core.Logging.IExtendedLogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
-    public class ExtendedNLogLogger : Castle.Services.Logging.NLogIntegration.NLogLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
+    public class ExtendedLog4netLogger : Castle.Services.Logging.Log4netIntegration.Log4netLogger, Castle.Core.Logging.IExtendedLogger, Castle.Core.Logging.ILogger
     {
-        public ExtendedNLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory factory) { }
+        public ExtendedLog4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
+        public ExtendedLog4netLogger(log4net.ILog log, Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory factory) { }
         public Castle.Core.Logging.IContextProperties GlobalProperties { get; }
         public Castle.Core.Logging.IContextProperties ThreadProperties { get; }
         public Castle.Core.Logging.IContextStacks ThreadStacks { get; }
-        protected new Castle.Services.Logging.NLogIntegration.ExtendedNLogFactory Factory { get; set; }
+        protected new Castle.Services.Logging.Log4netIntegration.ExtendedLog4netFactory Factory { get; set; }
         public override Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public Castle.Core.Logging.IExtendedLogger CreateExtendedChildLogger(string name) { }
     }
@@ -28,26 +29,27 @@ namespace Castle.Services.Logging.NLogIntegration
         public GlobalContextProperties() { }
         public object this[string key] { get; set; }
     }
-    public class NLogFactory : Castle.Core.Logging.AbstractLoggerFactory
+    public class Log4netFactory : Castle.Core.Logging.AbstractLoggerFactory
     {
-        public NLogFactory() { }
-        public NLogFactory(NLog.Config.LoggingConfiguration loggingConfiguration) { }
-        public NLogFactory(bool configuredExternally) { }
-        public NLogFactory(string configFile) { }
+        public Log4netFactory() { }
+        public Log4netFactory(bool configuredExternally) { }
+        public Log4netFactory(System.IO.Stream config) { }
+        public Log4netFactory(string configFile) { }
         public override Castle.Core.Logging.ILogger Create(string name) { }
         public override Castle.Core.Logging.ILogger Create(string name, Castle.Core.Logging.LoggerLevel level) { }
     }
-    public class NLogLogger : Castle.Core.Logging.ILogger
+    [System.Serializable]
+    public class Log4netLogger : Castle.Core.Logging.ILogger
     {
-        public NLogLogger(NLog.Logger logger, Castle.Services.Logging.NLogIntegration.NLogFactory factory) { }
-        protected Castle.Services.Logging.NLogIntegration.NLogFactory Factory { get; set; }
+        public Log4netLogger(log4net.Core.ILogger logger, Castle.Services.Logging.Log4netIntegration.Log4netFactory factory) { }
+        protected Castle.Services.Logging.Log4netIntegration.Log4netFactory Factory { get; set; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsFatalEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsTraceEnabled { get; }
         public bool IsWarnEnabled { get; }
-        protected NLog.Logger Logger { get; set; }
+        protected log4net.Core.ILogger Logger { get; set; }
         public virtual Castle.Core.Logging.ILogger CreateChildLogger(string name) { }
         public void Debug(System.Func<string> messageFactory) { }
         public void Debug(string message) { }
@@ -100,7 +102,7 @@ namespace Castle.Services.Logging.NLogIntegration
     }
     public class ThreadContextStack : Castle.Core.Logging.IContextStack
     {
-        public ThreadContextStack() { }
+        public ThreadContextStack(log4net.Util.ThreadContextStack log4netStack) { }
         public int Count { get; }
         public void Clear() { }
         public string Pop() { }

--- a/src/Castle.Core.Tests.WeakNamed/App.config
+++ b/src/Castle.Core.Tests.WeakNamed/App.config
@@ -21,6 +21,6 @@
 		</sources>
 	</system.diagnostics>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
 	</startup>
 </configuration>

--- a/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
+++ b/src/Castle.Core.Tests.WeakNamed/Castle.Core.Tests.WeakNamed.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Castle.Core.Tests/Castle.Core.Tests.csproj
+++ b/src/Castle.Core.Tests/Castle.Core.Tests.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -63,7 +63,7 @@
 		<PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
 		<PackageReference Include="System.Net.Primitives" Version="4.3.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
 		<PackageReference Include="PublicApiGenerator" Version="10.1.2" />
 	</ItemGroup>
 

--- a/src/Castle.Core.Tests/PublicApiTestCase.cs
+++ b/src/Castle.Core.Tests/PublicApiTestCase.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DOTNET45 // PublicApiGenerator requires .NET Standard 2.0, and we only need to run it once
+#if DOTNET462 // PublicApiGenerator requires .NET Standard 2.0, and we only need to run it once
 
 namespace Castle
 {

--- a/src/Castle.Core.Tests/config/netfx/App.config
+++ b/src/Castle.Core.Tests/config/netfx/App.config
@@ -29,6 +29,6 @@
 		</sources>
 	</system.diagnostics>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
 	</startup>
 </configuration>

--- a/src/Castle.Core/Castle.Core.csproj
+++ b/src/Castle.Core/Castle.Core.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -28,7 +28,7 @@
 		<EmbeddedResource Include="DynamicProxy\DynProxy.snk" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net45'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
 		<Reference Include="System.Configuration" />
 	</ItemGroup>
 

--- a/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
+++ b/src/Castle.Services.Logging.NLogIntegration/Castle.Services.Logging.NLogIntegration.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
+++ b/src/Castle.Services.Logging.SerilogIntegration/Castle.Services.Logging.SerilogIntegration.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
+++ b/src/Castle.Services.Logging.log4netIntegration/Castle.Services.Logging.log4netIntegration.csproj
@@ -3,7 +3,7 @@
 	<Import Project="..\..\buildscripts\common.props"></Import>
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/tools/Explicit.NuGet.Versions/Explicit.NuGet.Versions.csproj
+++ b/tools/Explicit.NuGet.Versions/Explicit.NuGet.Versions.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net45</TargetFramework>
+		<TargetFramework>net462</TargetFramework>
 		<OutputPath>build\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AssemblyName>nev</AssemblyName>


### PR DESCRIPTION
**What?**
Updates the minimum target framework version across the solution to 4.6.2, following discussion around target frameworks for v5.0.0 release (see issue #597).

**Why?**
4.5.2, 4.6, and 4.61 retire on April 26, 2022 (see https://docs.microsoft.com/en-gb/lifecycle/products/microsoft-net-framework).