### PR TITLE
Update copyright year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Debugging symbols are available in symbol packages in the AppVeyor build artifac
 
 ## License
 
-Castle Core is &copy; 2004-2021 Castle Project. It is free software, and may be redistributed under the terms of the [Apache 2.0](http://opensource.org/licenses/Apache-2.0) license.
+Castle Core is &copy; 2004-2022 Castle Project. It is free software, and may be redistributed under the terms of the [Apache 2.0](http://opensource.org/licenses/Apache-2.0) license.
 
 ## Contributing
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,6 @@
 @ECHO OFF
 REM ****************************************************************************
-REM Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+REM Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
 REM You may obtain a copy of the License at

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ****************************************************************************
-# Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+# Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/buildscripts/CommonAssemblyInfo.cs
+++ b/buildscripts/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buildscripts/build.cmd
+++ b/buildscripts/build.cmd
@@ -1,6 +1,6 @@
 @ECHO OFF
 REM ****************************************************************************
-REM Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+REM Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
 REM You may obtain a copy of the License at

--- a/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
+++ b/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/SimpleTestCase.cs
+++ b/src/Castle.Core.Tests.WeakNamed/DynamicProxy.Tests/SimpleTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests.WeakNamed/InternalsVisibleTo.cs
+++ b/src/Castle.Core.Tests.WeakNamed/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/BugAttribute.cs
+++ b/src/Castle.Core.Tests/BugAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/AdaptingGenericDictionaryTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/AdaptingGenericDictionaryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/AdaptingNameValueCollectionsTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/AdaptingNameValueCollectionsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Address.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Address.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Color.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Color.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CreateHashtableDictionaryStrategy.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CreateHashtableDictionaryStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CustomAssert.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CustomAssert.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CustomGetter.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/CustomGetter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DictionaryAdapterFactoryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DynamicDictionaryTests.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/DynamicDictionaryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IAddress.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IAddress.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IBook.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IBook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IConversions.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IConversions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IConversionsToString.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IConversionsToString.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IEmptyTest.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IEmptyTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IEnsureMetaDoesNotConflict.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IEnsureMetaDoesNotConflict.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IItemContainer.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IItemContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IItemContainerWithComponent.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IItemContainerWithComponent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IMutableName.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IMutableName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IName.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPerson.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPerson.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithDeniedInheritancePrefix.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithDeniedInheritancePrefix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithMethod.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefix.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefixOverride.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefixOverride.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefixOverrideFurtherOverride.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithPrefixOverrideFurtherOverride.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithTypePrefixOverride.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithTypePrefixOverride.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithoutPrefix.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPersonWithoutPrefix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPhone.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPhone.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPhoneWithFetch.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IPhoneWithFetch.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IStringLists.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IStringLists.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IUseBehaviorBuilder.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IUseBehaviorBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IdEqualityHashCodeStrategy.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/IdEqualityHashCodeStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/InfrastructureStub.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/InfrastructureStub.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/KeyBehaviorBuilderAttribute.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/KeyBehaviorBuilderAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/MemberwiseEqualityHashCodeStrategyTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/MemberwiseEqualityHashCodeStrategyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/NameValueCollectionAdapterTests.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/NameValueCollectionAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Phone.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Phone.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/PhoneConverter.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/PhoneConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/TestDictionaryValidator.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/TestDictionaryValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/VirtualObjectTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/VirtualObjectTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/ConflictBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/ConflictBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/DefaultBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/DefaultBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/ReferenceBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/ReferenceBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XPathBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XPathBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlArrayBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlArrayBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlAttributeBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlAttributeBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlElementBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlElementBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlIncludeBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlIncludeBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlRootBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlRootBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlTypeBehaviorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Behaviors/XmlTypeBehaviorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Collections/XmlNodeListTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Collections/XmlNodeListTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Collections/XmlNodeSetTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/Collections/XmlNodeSetTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterAcceptanceTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterAcceptanceTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlAdapterTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/DummyXmlNode.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/DummyXmlNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXPathFunction.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXPathFunction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXPathVariable.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXPathVariable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXmlIncludedTypeMap.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/MockXmlIncludedTypeMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/NamespaceSource.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/NamespaceSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/SysXmlCursorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/SysXmlCursorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/SysXmlNodeTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/SysXmlNodeTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathCompilerTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathCompilerTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathCursorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathCursorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathMutableCursorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathMutableCursorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathNodeTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathNodeTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathReadableCursorTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XPathReadableCursorTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XmlNodeTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlApis/XmlNodeTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlReferenceManagerTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlReferenceManagerTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlTypeSerializerCacheTestCase.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlTypeSerializerCacheTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlTypeSerializerTests.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/Xml/XmlTypeSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/XmlStructureComparer.cs
+++ b/src/Castle.Core.Tests/Components.DictionaryAdapter.Tests/XmlStructureComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Configuration/Xml/XmlConfigurationDeserializerTests.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Configuration/Xml/XmlConfigurationDeserializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Internal/InterfaceAttributeUtilTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Internal/InterfaceAttributeUtilTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Internal/WeakKeyDictionaryTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Internal/WeakKeyDictionaryTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Logging/ConsoleLoggerTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/ConsoleLoggerTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Logging/DiagnosticsLoggerTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/DiagnosticsLoggerTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Logging/LevelFilteredLoggerTests.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/LevelFilteredLoggerTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Logging/StreamLoggerTests.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/StreamLoggerTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Logging/TraceLoggerTests.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Logging/TraceLoggerTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/ReflectionBasedDictionaryAdapterTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/ReflectionBasedDictionaryAdapterTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Resource/AssemblyResourceFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Resource/AssemblyResourceFactoryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Resource/CustomUriTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Resource/CustomUriTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Resource/FileResourceFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Resource/FileResourceFactoryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Core.Tests/Resource/UncResourceFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Core.Tests/Resource/UncResourceFactoryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AccessLevelTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AccessLevelTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AsyncInterceptorTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAlwaysReplicateTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAlwaysReplicateTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/AttributesToAvoidReplicatingTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasePEVerifyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasePEVerifyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BaseTestCaseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BaseTestCaseTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicClassProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyWithoutTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BasicInterfaceProxyWithoutTargetTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //  
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Camera.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Camera.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/ConstraintViolationInDebuggerTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/ConstraintViolationInDebuggerTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Core40.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/Core40.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy132.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy132.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy145_SynchronizationContext.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy145_SynchronizationContext.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy159.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy159.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy46.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy46.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy88.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/DynProxy88.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/GitHubIssue536.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReported/GitHubIssue536.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReportedTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/BugsReportedTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CacheKeyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CacheKeyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CanDefineAdditionalCustomAttributes.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CanDefineAdditionalCustomAttributes.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetInterceptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ChangeProxyTargetTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassEmitterTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassEmitterTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyConstructorsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyConstructorsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassProxyWithTargetTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassWithAttributesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassWithAttributesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/AbstractClassWithMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/AbstractClassWithMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassCallingVirtualMethodFromCtor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassCallingVirtualMethodFromCtor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassOverridingEqualsAndGetHashCode.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassOverridingEqualsAndGetHashCode.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassToSerialize.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassToSerialize.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAsynchronousMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnConstructorParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnConstructorParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnMethodParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithAttributesOnMethodParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithCharRetType.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithCharRetType.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithConstructors.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithConstructors.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithDefaultConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithDefaultConstructor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithExplicitInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithExplicitInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithIndexer.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithIndexer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithInternalDefaultConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithInternalDefaultConstructor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithPrivateProtectedConstructor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedDefaultConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedDefaultConstructor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedGenericMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedGenericMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithProtectedMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithVariousConstructors.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithVariousConstructors.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithVirtualInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWithVirtualInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWith_Smart_Attribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ClassWith_Smart_Attribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/Component2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/Component2.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/DiffAccessLevelOnProperties.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/DiffAccessLevelOnProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/EmptyClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/EmptyClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithIntAndParamsArgument.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithIntAndParamsArgument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithParamsArgument.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithParamsArgument.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithParamsStrings.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasCtorWithParamsStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasFinalizeMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasFinalizeMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasFinalizer.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasFinalizer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasNonInheritableAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasNonInheritableAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasTwoProtectedMethods.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasTwoProtectedMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/HasVirtualStringAutoProperty.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/IHasNonInheritableAttributeWithArray.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/IHasNonInheritableAttributeWithArray.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/IHasNonInheritableAttributeWithArray2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/IHasNonInheritableAttributeWithArray2.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/InheritableAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/InheritableAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/InheritsAbstractClassWithMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/InheritsAbstractClassWithMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/MySerializableClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/MySerializableClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableWithArray2Attribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableWithArray2Attribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableWithArrayAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableWithArrayAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonPublicConstructorClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonPublicConstructorClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonPublicMethodsClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonPublicMethodsClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ProtectedInternalConstructorClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ProtectedInternalConstructorClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/RequiredAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/RequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ServiceClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/ServiceClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/SimpleClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/SimpleClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithAutoProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithAutoProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithNoDefaultCtor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithNoDefaultCtor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithProtectedGenericMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithProtectedGenericMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithProtectedMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithProtectedMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithPublicField.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtualClassWithPublicField.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtuallyImplementsInterfaceWithEvent.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtuallyImplementsInterfaceWithEvent.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtuallyImplementsInterfaceWithProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/VirtuallyImplementsInterfaceWithProperty.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInterfacesTests.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInterfacesTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Command.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Command.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Connection.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Connection.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Enums.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Enums.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Fields.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Fields.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameter.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Parameters.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Properties.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Properties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Recordset.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ComInteropTypes/ADODB/Recordset.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ConstructorWithAttributesOnParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ConstructorWithAttributesOnParametersTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CrossAppDomainCaller.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CrossAppDomainCaller.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributeInfoTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributeInfoTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CustomAttributesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CustomModifiersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CustomModifiersTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateMixinTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DelegateProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DictionarySerializationTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DictionarySerializationTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/GenInterfaceExplicit.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/GenInterfaceExplicit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/GenericMethodExplicit.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/GenericMethodExplicit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/SimpleInterfaceExplicit.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/SimpleInterfaceExplicit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/TwoInterfacesExplicit.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/TwoInterfacesExplicit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/WithRefOutExplicit.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Explicit/WithRefOutExplicit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitInterfaceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitInterfaceTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ExplicitlyImplementedMethodNamesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithGenArgs.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithGenArgs.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithIndexer.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithIndexer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithArrayOfListOfT.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithArrayOfListOfT.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithGenericOfGenericOfT.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithGenericOfGenericOfT.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithReturnArrayOfListOfT.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/ClassWithMethodWithReturnArrayOfListOfT.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassNameClash.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassNameClash.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithConstraints.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithConstraints.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithExplicitImpl.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithExplicitImpl.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenMethods.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenMethodsConstrained.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenMethodsConstrained.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenReturn.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/GenClassWithGenReturn.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/MethodWithArgumentBeingArrayOfGenericTypeOfT.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/MethodWithArgumentBeingArrayOfGenericTypeOfT.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/OnlyGenMethodsClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenClasses/OnlyGenMethodsClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenExplicitImplementation.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenExplicitImplementation.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceHierarchy.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceHierarchy.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenArray.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenArray.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenMethods.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenMethodsAndGenReturn.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenMethodsAndGenReturn.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenericTypes.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithGenericTypes.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericParameter.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericParameter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericParameterByRef.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericParameterByRef.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericReturn.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenInterfaceWithMethodWithNestedGenericReturn.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenericMethodWhereOneGenParamInheritsTheOther.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/GenericMethodWhereOneGenParamInheritsTheOther.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IConstraint_Method1IsTypeStructAndMethod2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IConstraint_Method1IsTypeStructAndMethod2.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IHaveGenericMethodWithNewClassStructConstraints.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IHaveGenericMethodWithNewClassStructConstraints.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/OnlyGenMethodsInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/OnlyGenMethodsInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenerationHookTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenerationHookTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericClassProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericClassProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericConstraintsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericConstraintsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericInterfaceProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericInterfaceProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericInterfaceWithGenericMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericInterfaceWithGenericMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericMethodsProxyTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericMethodsProxyTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericTestUtility.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericTestUtility.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InParamsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InParamsTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InheritedInterfacesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InheritedInterfacesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/AlwaysThrowsServiceImpl.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/AlwaysThrowsServiceImpl.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithIndexer.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithIndexer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithMarkerInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithMarkerInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithMultiDimentionalArray.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ClassWithMultiDimentionalArray.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IClassWithMultiDimentionalArray.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IClassWithMultiDimentionalArray.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IExtendedService.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IExtendedService.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IInterfaceWithGenericMethodWithDependentConstraint.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IInterfaceWithGenericMethodWithDependentConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IMyInterface2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IMyInterface2.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/IService2.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/InterfaceWithIndexer.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/InterfaceWithIndexer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/One.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/One.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/OneAndEmpty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/OneAndEmpty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/OneTwo.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/OneTwo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ServiceImpl.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/ServiceImpl.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/Two.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/Two.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithCallbackSimple.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithCallbackSimple.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithRefOut.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithRefOut.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithRefOutEmpty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterClasses/WithRefOutEmpty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptionRetryTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptionRetryTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTargetTypeTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTargetTypeTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorSelectorTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AddTwoInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AddTwoInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCanChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCanChangeTargetInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCannotChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/AssertCannotChangeTargetInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/CallCountingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/CallCountingInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ChangeTargetInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ChangeTargetInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/DoNothingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/DoNothingInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/KeepDataInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/KeepDataInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/LogInvocationInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/LogInvocationInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedNTimesInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedNTimesInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedOnTypeInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ProceedOnTypeInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/RequiredParamInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/RequiredParamInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetArgumentValueInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetArgumentValueInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetReturnValueInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/SetReturnValueInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptorException.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/ThrowingInterceptorException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //  
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/WithCallbackInterceptor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interceptors/WithCallbackInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorsMustReturnNonNullValueTypesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterceptorsMustReturnNonNullValueTypesTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyBaseTypeTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyBaseTypeTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithTargetInterfaceAdditionalInterfacesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithTargetInterfaceAdditionalInterfacesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithTargetInterfaceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InterfaceProxyWithTargetInterfaceTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IBase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IDecimalOutParam.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IDecimalOutParam.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IEmpty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IEmpty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithIntPtr.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutIntPtr.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutUIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithOutUIntPtr.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithUIntPtr.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IFooWithUIntPtr.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnAnyReferenceType.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnAnyReferenceType.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnAnyTypeWithDefaultConstructor.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnAnyTypeWithDefaultConstructor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnClass.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericInterfaceWithGenericMethodWithCascadingConstraintOnInterface.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithEvent.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithEvent.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithNonGenericMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithNonGenericMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithProperty.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithProperty.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithRefOut.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IGenericWithRefOut.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IHaveIndexers.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IHaveIndexers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IInterfaceWithAsynchronousMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/INullable.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/INullable.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IOne.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IOne.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISharedName.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISharedName.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISimple.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISimple.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISub1.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISub1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISub2.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ISub2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ITwo.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/ITwo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IWithRefOut.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IWithRefOut.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IdenticalInterfaces.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/IdenticalInterfaces.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Interfaces/InterfaceWithMethodsWithAllKindsOfOptionalParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationMethodInvocationTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationMethodInvocationTargetTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationProceedTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypesCachingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypesCachingTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/LoggingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/LoggingTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MethodComparerTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MethodComparerTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MethodEquivalenceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MethodEquivalenceTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MethodFinderTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MethodFinderTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MethodsWithAttributesOnParametersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MethodsWithAttributesOnParametersTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinDataTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MixinTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ClassImplementingIDerivedSImpleMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ClassImplementingIDerivedSImpleMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ClassImplementingISimpleMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ClassImplementingISimpleMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ComplexMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ComplexMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ConstructorArgumentsOrderWithMixinsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/ConstructorArgumentsOrderWithMixinsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/IDerivedSimpleMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/IDerivedSimpleMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/OtherMixinImplementingISimpleMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/OtherMixinImplementingISimpleMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SimpleMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SimpleMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SortingIssueOnMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Mixins/SortingIssueOnMixin.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ModuleScopeTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ModuleScopeTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/MultipleSavedAssembliesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/MultipleSavedAssembliesTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMethodsNoTargetTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMethodsNoTargetTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMixinMethodsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedMixinMethodsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedTargetMethodsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/NonProxiedTargetMethodsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/OrderOfInterfacePrecedenceTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/OrderOfInterfacePrecedenceTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/OutRefParamsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/OutRefParamsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ParameterDefaultValuesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ParameterDefaultValuesTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/PersistentProxyBuilderTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/PersistentProxyBuilderTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyGenerationOptionsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyGenerationOptionsTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyKind.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyNothingHook.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyNothingHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxySomeMethodsHook.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2019 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTargetAccessorHandlingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTargetAccessorHandlingTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTypeCachingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTypeCachingTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTypeCachingWithDifferentHooksTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyTypeCachingWithDifferentHooksTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ProxyUtilTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/ 
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/ 
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); 
 // you may not use this file except in compliance with the License. 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RhinoMocksTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/SerializableClassTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/SerializableClassTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/BadSerializable.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/BadSerializable.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/C.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/C.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ClassWithDirectAndIndirectSelfReference.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ClassWithDirectAndIndirectSelfReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ClassWithIndirectSelfReference.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ClassWithIndirectSelfReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ComplexHolder.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/ComplexHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/DelegateHolder.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/DelegateHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/EventHandlerClass.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/EventHandlerClass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/IMixedInterface.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/IMixedInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/IndirectDelegateHolder.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/IndirectDelegateHolder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/MethodFilterHook.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/MethodFilterHook.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableExplicitImpl.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableExplicitImpl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableInterceptorSelector.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableInterceptorSelector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableMixin.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Serialization/SerializableMixin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/WinFormsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/WinFormsTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/XmlSerializationTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/XmlSerializationTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/InternalsVisibleTo.cs
+++ b/src/Castle.Core.Tests/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/PublicApiTestCase.cs
+++ b/src/Castle.Core.Tests/PublicApiTestCase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Services.Logging.Tests/NLogIntegration/NLogTests.cs
+++ b/src/Castle.Core.Tests/Services.Logging.Tests/NLogIntegration/NLogTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Services.Logging.Tests/SerilogIntegration/SerilogTests.cs
+++ b/src/Castle.Core.Tests/Services.Logging.Tests/SerilogIntegration/SerilogTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core.Tests/Services.Logging.Tests/log4netIntegration/Log4netFactoryTestCase.cs
+++ b/src/Castle.Core.Tests/Services.Logging.Tests/log4netIntegration/Log4netFactoryTestCase.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License";
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapterVisitor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/AbstractDictionaryAdapterVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/ComponentAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/ComponentAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/DictionaryAdapterAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/DictionaryAdapterAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/DictionaryBehaviorAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/DictionaryBehaviorAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/FetchAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/FetchAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/GroupAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/GroupAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/IfExistsAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/IfExistsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeyAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeyAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeyPrefixAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeyPrefixAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeySubstitutionAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/KeySubstitutionAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/MultiLevelEditAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/MultiLevelEditAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/NewGuidAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/NewGuidAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/OnDemandAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/OnDemandAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/ReferenceAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/ReferenceAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfEmptyAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/RemoveIfEmptyAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringFormatAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringFormatAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringListAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringListAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringStorageAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringStorageAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License";
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringValuesAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/StringValuesAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/SuppressNotificationsAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/SuppressNotificationsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/TypeKeyPrefixAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/TypeKeyPrefixAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/VolatileAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/VolatileAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathFunctionAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathFunctionAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathVariableAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/XPathVariableAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/XmlDefaultsAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/XmlDefaultsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Attributes/XmlNamespaceAttribute.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Attributes/XmlNamespaceAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/CascadingDictionaryAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/CascadingDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DefaultPropertyGetter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DefaultPropertyGetter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Coerce.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Coerce.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Copy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Copy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Create.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Create.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Edit.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Edit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Notify.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Validate.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.Validate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterFactory.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterInstance.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterMeta.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryAdapterMeta.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DictionaryValidateGroup.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DictionaryValidateGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/DynamicDictionary.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/DynamicDictionary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/GenericDictionaryAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/GenericDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License";
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterFactory.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterVisitor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryAdapterVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryBehavior.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryBehavior.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryBehaviorBuilder.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryBehaviorBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCoerceStrategy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCoerceStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCopyStrategy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCopyStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCreate.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCreate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCreateStrategy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryCreateStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryEdit.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryEdit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryEqualityHashCodeStrategy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryEqualityHashCodeStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryInitializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryKeyBuilder.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryKeyBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryMetaInitializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryMetaInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryNotify.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryNotify.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryPropertyGetter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryPropertyGetter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryPropertySetter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryPropertySetter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryReferenceManager.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryReferenceManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryValidate.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryValidate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IDictionaryValidator.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IDictionaryValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/IPropertyDescriptorInitializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/IPropertyDescriptorInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/MemberwiseEqualityHashCodeStrategy.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/MemberwiseEqualityHashCodeStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/NameValueCollectionAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/NameValueCollectionAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/PropertyChangedEventArgsEx.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/PropertyChangedEventArgsEx.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/PropertyChangingEventArgsEx.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/PropertyChangingEventArgsEx.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/PropertyDescriptor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/PropertyDescriptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/BindingList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/BindingList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/BindingListInitializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/BindingListInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/DynamicValue.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/DynamicValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/DynamicValueDelegate.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/DynamicValueDelegate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/EditableBindingList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/EditableBindingList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/EditableList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/EditableList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingListSource.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IBindingListSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionAdapterObserver.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionAdapterObserver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionProjection.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ICollectionProjection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ICondition.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ICondition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IDynamicValue.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IDynamicValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IValueInitializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IValueInitializer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtual.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtual.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtualSite.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtualSite.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtualTarget.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/IVirtualTarget.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjection.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjectionDebugView.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/ListProjectionDebugView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/SetProjection.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/SetProjection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/VirtualObject.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/VirtualObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Util/VirtualSite.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Util/VirtualSite.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/DefaultXmlReferenceFormat.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/DefaultXmlReferenceFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/IXmlReferenceFormat.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/IXmlReferenceFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadata.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadataBehavior.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlMetadataBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Core/XmlReferenceManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlBehaviorSemantics.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlBehaviorSemantics.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlCollectionAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlCollectionAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlPropertyAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/IXmlPropertyAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XPathBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XPathBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessorFactory.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAccessorFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlArrayBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlArrayBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAttributeBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlAttributeBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlDefaultBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlDefaultBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlElementBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlElementBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlIgnoreBehaviorAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlIgnoreBehaviorAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlNodeAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlNodeAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlSelfAccessor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Accessors/XmlSelfAccessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlCollectionAdapter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlCollectionAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlCollectionItem.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlCollectionItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlNodeList.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlNodeList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlNodeSet.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Collections/XmlNodeSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/CursorFlags.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/CursorFlags.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlContext.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlCursor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlIterator.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlIterator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNamespaceSource.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNamespaceSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNode.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNodeSource.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/IXmlNodeSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlContext.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlContextBase.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlContextBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlName.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlNameComparer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlNameComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlNodeBase.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlNodeBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlPositionComparer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlPositionComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlSelfCursor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/Base/XmlSelfCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlCursor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlNode.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlSubtreeIterator.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/SystemXml/SysXmlSubtreeIterator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPath.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPath.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPathNode.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPathNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPathStep.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/CompiledXPathStep.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathBufferedNodeIterator.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathBufferedNodeIterator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathCompiler.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathCompiler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathContext.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathMutableCursor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathMutableCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathNode.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathReadOnlyCursor.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Cursors/XPath/XPathReadOnlyCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Wsdl.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Wsdl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/XRef.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/XRef.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xmlns.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xmlns.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xsd.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xsd.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xsi.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Namespaces/Xsi.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlArraySerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlArraySerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlCollectionSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlCollectionSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlComponentSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlComponentSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlCustomSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlCustomSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlDefaultSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlDefaultSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlDynamicSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlDynamicSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlEnumerationSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlEnumerationSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlListSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlListSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlSetSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlSetSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlSimpleSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlSimpleSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlStringSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlStringSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeKind.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializerCache.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlTypeSerializerCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlXmlNodeSerializer.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Serializers/XmlXmlNodeSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIdentity.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIdentity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIncludedType.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIncludedType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIncludedTypeMap.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlIncludedTypeMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlKnownType.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlKnownType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlKnownTypeMap.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/IXmlKnownTypeMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlIncludedType.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlIncludedType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlIncludedTypeSet.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlIncludedTypeSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlKnownType.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlKnownType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlKnownTypeSet.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Types/XmlKnownTypeSet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/DictionaryAdapterExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/DictionaryAdapterExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Error.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Error.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/IConfigurable.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/IConfigurable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/IRealizable.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/IRealizable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/SingletonDispenser.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/SingletonDispenser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/StringExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Try.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/Try.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/TypeExtensions.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/XmlSubtreeReader.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/XmlSubtreeReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/XmlSubtreeWriter.cs
+++ b/src/Castle.Core/Components.DictionaryAdapter/Xml/Internal/Utilities/XmlSubtreeWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/AbstractConfiguration.cs
+++ b/src/Castle.Core/Core/Configuration/AbstractConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/ConfigurationAttributeCollection.cs
+++ b/src/Castle.Core/Core/Configuration/ConfigurationAttributeCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/ConfigurationCollection.cs
+++ b/src/Castle.Core/Core/Configuration/ConfigurationCollection.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/IConfiguration.cs
+++ b/src/Castle.Core/Core/Configuration/IConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/MutableConfiguration.cs
+++ b/src/Castle.Core/Core/Configuration/MutableConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Configuration/Xml/XmlConfigurationDeserializer.cs
+++ b/src/Castle.Core/Core/Configuration/Xml/XmlConfigurationDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/IServiceEnabledComponent.cs
+++ b/src/Castle.Core/Core/IServiceEnabledComponent.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/IServiceProviderEx.cs
+++ b/src/Castle.Core/Core/IServiceProviderEx.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/IServiceProviderExAccessor.cs
+++ b/src/Castle.Core/Core/IServiceProviderExAccessor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/AttributesUtil.cs
+++ b/src/Castle.Core/Core/Internal/AttributesUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
+++ b/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/InternalsVisible.cs
+++ b/src/Castle.Core/Core/Internal/InternalsVisible.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/SynchronizedDictionary.cs
+++ b/src/Castle.Core/Core/Internal/SynchronizedDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/TypeExtensions.cs
+++ b/src/Castle.Core/Core/Internal/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/WeakKey.cs
+++ b/src/Castle.Core/Core/Internal/WeakKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/WeakKeyComparer.cs
+++ b/src/Castle.Core/Core/Internal/WeakKeyComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Internal/WeakKeyDictionary.cs
+++ b/src/Castle.Core/Core/Internal/WeakKeyDictionary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/AbstractExtendedLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/AbstractExtendedLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/AbstractLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/AbstractLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/ConsoleFactory.cs
+++ b/src/Castle.Core/Core/Logging/ConsoleFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/ConsoleLogger.cs
+++ b/src/Castle.Core/Core/Logging/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/DiagnosticsLogger.cs
+++ b/src/Castle.Core/Core/Logging/DiagnosticsLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/DiagnosticsLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/DiagnosticsLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/IContextProperties.cs
+++ b/src/Castle.Core/Core/Logging/IContextProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/IContextStack.cs
+++ b/src/Castle.Core/Core/Logging/IContextStack.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/IContextStacks.cs
+++ b/src/Castle.Core/Core/Logging/IContextStacks.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/IExtendedLogger.cs
+++ b/src/Castle.Core/Core/Logging/IExtendedLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/IExtendedLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/IExtendedLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/ILogger.cs
+++ b/src/Castle.Core/Core/Logging/ILogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/ILoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/ILoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
+++ b/src/Castle.Core/Core/Logging/LevelFilteredLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/LoggerException.cs
+++ b/src/Castle.Core/Core/Logging/LoggerException.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/LoggerLevel.cs
+++ b/src/Castle.Core/Core/Logging/LoggerLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/NullLogFactory.cs
+++ b/src/Castle.Core/Core/Logging/NullLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/NullLogger.cs
+++ b/src/Castle.Core/Core/Logging/NullLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/StreamLogger.cs
+++ b/src/Castle.Core/Core/Logging/StreamLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/StreamLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/StreamLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/TraceLogger.cs
+++ b/src/Castle.Core/Core/Logging/TraceLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/ProxyServices.cs
+++ b/src/Castle.Core/Core/ProxyServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/ReferenceEqualityComparer.cs
+++ b/src/Castle.Core/Core/ReferenceEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/ReflectionBasedDictionaryAdapter.cs
+++ b/src/Castle.Core/Core/ReflectionBasedDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/AbstractResource.cs
+++ b/src/Castle.Core/Core/Resource/AbstractResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/AbstractStreamResource.cs
+++ b/src/Castle.Core/Core/Resource/AbstractStreamResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/AssemblyBundleResource.cs
+++ b/src/Castle.Core/Core/Resource/AssemblyBundleResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/AssemblyResource.cs
+++ b/src/Castle.Core/Core/Resource/AssemblyResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/AssemblyResourceFactory.cs
+++ b/src/Castle.Core/Core/Resource/AssemblyResourceFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/ConfigResource.cs
+++ b/src/Castle.Core/Core/Resource/ConfigResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/ConfigResourceFactory.cs
+++ b/src/Castle.Core/Core/Resource/ConfigResourceFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/CustomUri.cs
+++ b/src/Castle.Core/Core/Resource/CustomUri.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/FileResource.cs
+++ b/src/Castle.Core/Core/Resource/FileResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/FileResourceFactory.cs
+++ b/src/Castle.Core/Core/Resource/FileResourceFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/IResource.cs
+++ b/src/Castle.Core/Core/Resource/IResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/IResourceFactory.cs
+++ b/src/Castle.Core/Core/Resource/IResourceFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/ResourceException.cs
+++ b/src/Castle.Core/Core/Resource/ResourceException.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/StaticContentResource.cs
+++ b/src/Castle.Core/Core/Resource/StaticContentResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/UncResource.cs
+++ b/src/Castle.Core/Core/Resource/UncResource.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Resource/UncResourceFactory.cs
+++ b/src/Castle.Core/Core/Resource/UncResourceFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Smtp/DefaultSmtpSender.cs
+++ b/src/Castle.Core/Core/Smtp/DefaultSmtpSender.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/Smtp/IEmailSender.cs
+++ b/src/Castle.Core/Core/Smtp/IEmailSender.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Core/StringObjectDictionaryAdapter.cs
+++ b/src/Castle.Core/Core/StringObjectDictionaryAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/AbstractInvocation.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/AllMethodsHook.cs
+++ b/src/Castle.Core/DynamicProxy/AllMethodsHook.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxySerializableContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/CompositeTypeContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/DelegateTypeMembersCollector.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/Delegates.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/Delegates.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/IInvocationCreationContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/IInvocationCreationContributor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/IMembersCollectorSink.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/IMembersCollectorSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ITypeContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ITypeContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxySerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxySerializableContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyTargetContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/NonInheritableAttributesContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/NonInheritableAttributesContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/ProxyTargetAccessorContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ProxyTargetAccessorContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/SerializableContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/SerializableContributor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/CustomAttributeInfo.cs
+++ b/src/Castle.Core/DynamicProxy/CustomAttributeInfo.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/DynamicProxyException.cs
+++ b/src/Castle.Core/DynamicProxy/DynamicProxyException.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/ExceptionMessageBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/AttributesToAvoidReplicating.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/AttributesToAvoidReplicating.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ClassProxyWithTargetGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ArgumentsUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/CodeBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ConstructorEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/IMemberEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/IMemberEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/LdcOpCodesDictionary.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/LdcOpCodesDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/LdindOpCodesDictionary.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/LdindOpCodesDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BlockStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BlockStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IExpressionOrStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IExpressionOrStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/Reference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/Reference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/StindOpCodesDictionary.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/StindOpCodesDictionary.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/StrongNameUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/StrongNameUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/IGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/IGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/INamingScope.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/INamingScope.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetInterfaceGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithoutTargetGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementCollection.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodFinder.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodFinder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MinimialisticMethodGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IChangeProxyTarget.cs
+++ b/src/Castle.Core/DynamicProxy/IChangeProxyTarget.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IInterceptor.cs
+++ b/src/Castle.Core/DynamicProxy/IInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IInterceptorSelector.cs
+++ b/src/Castle.Core/DynamicProxy/IInterceptorSelector.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocation.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IInvocationProceedInfo.cs
+++ b/src/Castle.Core/DynamicProxy/IInvocationProceedInfo.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/IProxyBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IProxyGenerationHook.cs
+++ b/src/Castle.Core/DynamicProxy/IProxyGenerationHook.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/IProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/IProxyTargetAccessor.cs
+++ b/src/Castle.Core/DynamicProxy/IProxyTargetAccessor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/CompositionInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/CompositionInvocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/InheritanceInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InheritanceInvocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/InterfaceMethodWithoutTargetInvocation.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InterfaceMethodWithoutTargetInvocation.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/MixinData.cs
+++ b/src/Castle.Core/DynamicProxy/MixinData.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/ModuleScope.cs
+++ b/src/Castle.Core/DynamicProxy/ModuleScope.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/PersistentProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/PersistentProxyBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerationOptions.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Serialization/CacheMappingsAttribute.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/CacheMappingsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/ProxyObjectReference.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Serialization/ProxyTypeConstants.cs
+++ b/src/Castle.Core/DynamicProxy/Serialization/ProxyTypeConstants.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
+++ b/src/Castle.Core/DynamicProxy/StandardInterceptor.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/DelegateMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/DelegateMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/FormatterServicesMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/FormatterServicesMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/InterceptorSelectorMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/InterceptorSelectorMethods.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/InvocationMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/MethodBaseMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/MethodBaseMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/SerializationInfoMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/SerializationInfoMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/TypeMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/TypeMethods.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/DynamicProxy/Tokens/TypeUtilMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/TypeUtilMethods.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Core/Properties/InternalsVisibleToTests.cs
+++ b/src/Castle.Core/Properties/InternalsVisibleToTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogFactory.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogLogger.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ExtendedNLogLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/GlobalContextProperties.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/GlobalContextProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/NLogFactory.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/NLogFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/NLogLogger.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/NLogLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/ThreadContextProperties.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ThreadContextProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/ThreadContextStack.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ThreadContextStack.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.NLogIntegration/ThreadContextStacks.cs
+++ b/src/Castle.Services.Logging.NLogIntegration/ThreadContextStacks.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.SerilogIntegration/SerilogFactory.cs
+++ b/src/Castle.Services.Logging.SerilogIntegration/SerilogFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.SerilogIntegration/SerilogLogger.cs
+++ b/src/Castle.Services.Logging.SerilogIntegration/SerilogLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/ExtendedLog4netFactory.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/ExtendedLog4netFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/ExtendedLog4netLogger.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/ExtendedLog4netLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/GlobalContextProperties.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/GlobalContextProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/Log4netFactory.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/Log4netFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/Log4netLogger.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/Log4netLogger.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/ThreadContextProperties.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/ThreadContextProperties.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/ThreadContextStack.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/ThreadContextStack.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Castle.Services.Logging.log4netIntegration/ThreadContextStacks.cs
+++ b/src/Castle.Services.Logging.log4netIntegration/ThreadContextStacks.cs
@@ -1,4 +1,4 @@
-// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/Explicit.NuGet.Versions/Program.cs
+++ b/tools/Explicit.NuGet.Versions/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Small change but touches many files - includes a couple of places where the copyright was still 2019.

Has there been any discussion around whether this is required in every single file, or whether it could just be in the README/LICENSE file in the root?