### PR TITLE
Unskip 3 tests that now pass starting with .NET 6

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ValueTypeReferenceSemanticsTestCase.cs
@@ -60,7 +60,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+#if !NET6_0_OR_GREATER  // bug got fixed in .NET 6, so run the test there (by omitting [Platform] because it doesn't support version specs for .NET Core)
 		[Platform(Exclude = "Net,NetCore", Reason = "Fails with a MissingMethodException due to a bug in System.Reflection.Emit. See https://github.com/dotnet/corefx/issues/29254.")]
+#endif
 		public void Can_proxy_method_in_generic_type_having_valuetyped_parameter_with_in_modifier()
 		{
 			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IGenericTypeWithInModifier<bool>>(new DoNothingInterceptor());
@@ -69,7 +71,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+#if !NET6_0_OR_GREATER  // as above
 		[Platform(Exclude = "Net,NetCore", Reason = "Fails with a MissingMethodException due to a bug in System.Reflection.Emit. See https://github.com/dotnet/corefx/issues/29254.")]
+#endif
 		public void Can_proxy_generic_method_in_nongeneric_type_having_valuetyped_parameter_with_in_modifier()
 		{
 			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IGenericMethodWithInModifier>(new DoNothingInterceptor());
@@ -78,7 +82,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+#if !NET6_0_OR_GREATER  // as above
 		[Platform(Exclude = "Net,NetCore", Reason = "Fails with a MissingMethodException due to a bug in System.Reflection.Emit. See https://github.com/dotnet/corefx/issues/29254.")]
+#endif
 		public void Can_proxy_generic_method_in_generic_type_having_valuetyped_parameter_with_in_modifier()
 		{
 			var proxy = this.generator.CreateInterfaceProxyWithoutTarget<IGenericTypeAndMethodWithInModifier<bool>>(new DoNothingInterceptor());


### PR DESCRIPTION
As requested in https://github.com/castleproject/Core/issues/430#issuecomment-1126707842.

We already added the tests back in #353, but we need to unskip them for .NET 6+. Unfortunately, NUnit's [`[Platform]` attribute does not support version specifications for .NET Core](https://github.com/nunit/nunit/blob/ccbbd117cc7983ff2f868b54a0eaa9c5f2a825d4/src/NUnitFramework/framework/Internal/PlatformHelper.cs#L302-L305), so we need to fake the version check using `#if NET6_0_OR_GREATER`. 🙁

Closes #430.