### PR TITLE
Fix `MissingMethodException` when proxying interfaces containing sealed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Enhancements:
 Bugfixes:
 - DynamicProxy emits invalid metadata for redeclared event (@stakx, #590)
 - Proxies using records with a base class broken using .NET 6 compiler (@ajcvickers, #601)
+- `MissingMethodException` when proxying interfaces containing sealed methods (@stakx, #621)
 
 ## 5.0.0 (2022-05-11)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace Castle.DynamicProxy.Tests
+{
+	[TestFixture]
+	public class DefaultInterfaceMembersTestCase : BasePEVerifyTestCase
+	{
+		[Test]
+		public void Can_proxy_interface_with_sealed_method()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget<IHaveSealedMethod>();
+		}
+
+		[Test]
+		public void Can_invoke_sealed_method_in_proxied_interface()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveSealedMethod>();
+			var invokedMethod = proxy.SealedMethod();
+			Assert.AreEqual(typeof(IHaveSealedMethod).GetMethod(nameof(IHaveSealedMethod.SealedMethod)), invokedMethod);
+		}
+
+		public interface IHaveSealedMethod
+		{
+			sealed MethodBase SealedMethod()
+			{
+				return MethodBase.GetCurrentMethod();
+			}
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -33,7 +33,13 @@ namespace Castle.DynamicProxy.Contributors
 				return null;
 			}
 
-			var proxyable = AcceptMethod(method, false, hook);
+			var proxyable = AcceptMethod(method, true, hook);
+			if (!proxyable && !method.IsAbstract)
+			{
+				// we don't need to do anything
+				return null;
+			}
+
 			return new MetaMethod(method, method, isStandalone, proxyable, false);
 		}
 	}


### PR DESCRIPTION
This is a first small step towards support for default interface methods (#447).

Not certain whether this warrants a changelog entry on its own, since what is being fixed here never got reported as an issue. Perhaps we just wait with a changelog entry until we have fully addressed #447?

P.S.: marking this as a draft as it may be incomplete; the same issue may still be present with proxies that have a target.