### PR TITLE
Use standard invocation type for abstract methods of class proxies w/o target 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Enhancements:
 - Support for covariant method returns (@stakx, #619)
+- Performance improvement with proxy type generation for class proxies (without target). Abstract class methods now reuse a predefined invocation type (like methods of interface proxies without target; see explanation below at version 5.0.0 enhancements) (@stakx, #626)
 
 Bugfixes:
 - DynamicProxy emits invalid metadata for redeclared event (@stakx, #590)

--- a/ref/Castle.Core-net462.cs
+++ b/ref/Castle.Core-net462.cs
@@ -2788,6 +2788,12 @@ namespace Castle.DynamicProxy.Internal
         protected abstract override void InvokeMethodOnTarget() { }
     }
     [System.Serializable]
+    public sealed class InheritanceInvocationWithoutTarget : Castle.DynamicProxy.Internal.InheritanceInvocation
+    {
+        public InheritanceInvocationWithoutTarget(System.Type targetType, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        protected override void InvokeMethodOnTarget() { }
+    }
+    [System.Serializable]
     public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
     {
         public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }

--- a/ref/Castle.Core-net6.0.cs
+++ b/ref/Castle.Core-net6.0.cs
@@ -2742,6 +2742,11 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    public sealed class InheritanceInvocationWithoutTarget : Castle.DynamicProxy.Internal.InheritanceInvocation
+    {
+        public InheritanceInvocationWithoutTarget(System.Type targetType, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
     {
         public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -2740,6 +2740,11 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    public sealed class InheritanceInvocationWithoutTarget : Castle.DynamicProxy.Internal.InheritanceInvocation
+    {
+        public InheritanceInvocationWithoutTarget(System.Type targetType, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
     {
         public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -2740,6 +2740,11 @@ namespace Castle.DynamicProxy.Internal
         public override System.Type TargetType { get; }
         protected abstract override void InvokeMethodOnTarget() { }
     }
+    public sealed class InheritanceInvocationWithoutTarget : Castle.DynamicProxy.Internal.InheritanceInvocation
+    {
+        public InheritanceInvocationWithoutTarget(System.Type targetType, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }
+        protected override void InvokeMethodOnTarget() { }
+    }
     public sealed class InterfaceMethodWithoutTargetInvocation : Castle.DynamicProxy.AbstractInvocation
     {
         public InterfaceMethodWithoutTargetInvocation(object target, object proxy, Castle.DynamicProxy.IInterceptor[] interceptors, System.Reflection.MethodInfo proxiedMethod, object[] arguments) { }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/InvocationTypeReuseTestCase.cs
@@ -52,6 +52,94 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(typeof(InterfaceMethodWithoutTargetInvocation), recorder.InvocationType);
 		}
 
+		[Test]
+		public void Non_generic_abstract_method_of_class_proxy__uses__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithNonGenericAbstractMethod>(recorder);
+			proxy.Method();
+
+			Assert.AreEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Non_generic_protected_abstract_method_of_class_proxy__uses__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithNonGenericProtectedAbstractMethod>(recorder);
+			proxy.InvokeMethod();
+
+			Assert.AreEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Non_generic_virtual_method_of_class_proxy__does_not_use__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithNonGenericVirtualMethod>(recorder);
+			proxy.Method();
+
+			Assert.AreNotEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Non_generic_protected_virtual_method_of_class_proxy__does_not_use__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithNonGenericProtectedVirtualMethod>(recorder);
+			proxy.InvokeMethod();
+
+			Assert.AreNotEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Generic_abstract_method_of_class_proxy__uses__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithGenericAbstractMethod>(recorder);
+			proxy.Method(42);
+
+			Assert.AreEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Generic_protected_abstract_method_of_class_proxy__uses__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithGenericProtectedAbstractMethod>(recorder);
+			proxy.InvokeMethod(42);
+
+			Assert.AreEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Generic_virtual_method_of_class_proxy__does_not_use__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithGenericVirtualMethod>(recorder);
+			proxy.Method(42);
+
+			Assert.AreNotEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
+		[Test]
+		public void Generic_protected_virtual_method_of_class_proxy__does_not_use__InheritanceInvocationWithoutTarget()
+		{
+			var recorder = new InvocationTypeRecorder();
+
+			var proxy = generator.CreateClassProxy<WithGenericProtectedVirtualMethod>(recorder);
+			proxy.InvokeMethod(42);
+
+			Assert.AreNotEqual(typeof(InheritanceInvocationWithoutTarget), recorder.InvocationType);
+		}
+
 		public interface IWithNonGenericMethod
 		{
 			void Method();
@@ -60,6 +148,50 @@ namespace Castle.DynamicProxy.Tests
 		public interface IWithGenericMethod
 		{
 			void Method<T>(T arg);
+		}
+
+		public abstract class WithNonGenericAbstractMethod
+		{
+			public abstract void Method();
+		}
+
+		public abstract class WithNonGenericProtectedAbstractMethod
+		{
+			protected abstract void Method();
+			public void InvokeMethod() => Method();
+		}
+
+		public class WithNonGenericVirtualMethod
+		{
+			public virtual void Method() { }
+		}
+
+		public class WithNonGenericProtectedVirtualMethod
+		{
+			protected virtual void Method() { }
+			public void InvokeMethod() => Method();
+		}
+
+		public abstract class WithGenericAbstractMethod
+		{
+			public abstract void Method<T>(T arg);
+		}
+
+		public abstract class WithGenericProtectedAbstractMethod
+		{
+			protected abstract void Method<T>(T arg);
+			public void InvokeMethod<T>(T arg) => Method(arg);
+		}
+
+		public class WithGenericVirtualMethod
+		{
+			public virtual void Method<T>(T arg) { }
+		}
+
+		public class WithGenericProtectedVirtualMethod
+		{
+			protected virtual void Method<T>(T arg) { }
+			public void InvokeMethod<T>(T arg) => Method(arg);
 		}
 
 		private sealed class InvocationTypeRecorder : IInterceptor

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -172,6 +172,13 @@ namespace Castle.DynamicProxy.Contributors
 
 		private Type GetInvocationType(MetaMethod method, ClassEmitter @class)
 		{
+			if (!method.HasTarget)
+			{
+				// We do not need to generate a custom invocation type because no custom implementation
+				// for `InvokeMethodOnTarget` will be needed (proceeding to target isn't possible here):
+				return typeof(InheritanceInvocationWithoutTarget);
+			}
+
 			// NOTE: No caching since invocation is tied to this specific proxy type via its invocation method
 			return BuildInvocationType(method, @class);
 		}

--- a/src/Castle.Core/DynamicProxy/Internal/InheritanceInvocationWithoutTarget.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InheritanceInvocationWithoutTarget.cs
@@ -1,0 +1,36 @@
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Internal
+{
+	using System;
+	using System.ComponentModel;
+	using System.Diagnostics;
+	using System.Reflection;
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public sealed class InheritanceInvocationWithoutTarget : InheritanceInvocation
+	{
+		public InheritanceInvocationWithoutTarget(Type targetType, object proxy, IInterceptor[] interceptors, MethodInfo proxiedMethod, object[] arguments)
+			: base(targetType, proxy, interceptors, proxiedMethod, arguments)
+		{
+			Debug.Assert(proxiedMethod.IsAbstract, $"{nameof(InheritanceInvocationWithoutTarget)} does not support non-abstract methods.");
+		}
+
+		protected override void InvokeMethodOnTarget() => ThrowOnNoTarget();
+	}
+}


### PR DESCRIPTION
This follows in the footsteps of #573, where we introduced a standard `IInvocation` implementation type and re-used it for all methods of interface proxies without target. This present PR does the same for abstract methods of class proxies without target: those would always get a custom-built invocation type with identical `InvokeMethodOnTarget` implementations; so they, too, are eligible for invocation type reuse.

The tests cover all combinations of (a) `abstract` vs. `virtual`, (b) `public` vs. `protected`, and (c) generic vs. non-generic method:

 * (a) is in fact the only distinction that really matters.
 * I've included (b) because of [`EmitCallThrowOnNoTarget` apparently depends on the presence of a callback method](https://github.com/castleproject/Core/blob/0176c319ea9feecf911e2fcf35319eaead866ea8/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs#L109-L114), and `protected` would regularly lead to callback methods being emitted.
 * I've included (c) i.e. generics mainly because I did so in #573 (even though TBH I cannot quite remember why I thought it necessary back then).