### PR TITLE
Support replication of attributes defined in AttributesToAlwaysReplicate list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Enhancements:
 - Two new generic method overloads `proxyGenerator.CreateClassProxy<TClass>([options], constructorArguments, interceptors)` (@backstromjoel, #636)
+- Allow specifying which attributes should always be copied to proxy class by adding attribute type to `AttributesToAlwaysReplicate`. Previously only non-inherited, with `Inherited=false`, attributes were copied. (@shoaibshakeel381, #633)
 
 ## 5.1.1 (2022-12-30)
 

--- a/ref/Castle.Core-net462.cs
+++ b/ref/Castle.Core-net462.cs
@@ -2768,6 +2768,12 @@ namespace Castle.DynamicProxy
 }
 namespace Castle.DynamicProxy.Generators
 {
+    public static class AttributesToAlwaysReplicate
+    {
+        public static void Add(System.Type attribute) { }
+        public static void Add<T>() { }
+        public static bool Contains(System.Type attribute) { }
+    }
     public static class AttributesToAvoidReplicating
     {
         public static void Add(System.Type attribute) { }

--- a/ref/Castle.Core-net6.0.cs
+++ b/ref/Castle.Core-net6.0.cs
@@ -2723,6 +2723,12 @@ namespace Castle.DynamicProxy
 }
 namespace Castle.DynamicProxy.Generators
 {
+    public static class AttributesToAlwaysReplicate
+    {
+        public static void Add(System.Type attribute) { }
+        public static void Add<T>() { }
+        public static bool Contains(System.Type attribute) { }
+    }
     public static class AttributesToAvoidReplicating
     {
         public static void Add(System.Type attribute) { }

--- a/ref/Castle.Core-netstandard2.0.cs
+++ b/ref/Castle.Core-netstandard2.0.cs
@@ -2721,6 +2721,12 @@ namespace Castle.DynamicProxy
 }
 namespace Castle.DynamicProxy.Generators
 {
+    public static class AttributesToAlwaysReplicate
+    {
+        public static void Add(System.Type attribute) { }
+        public static void Add<T>() { }
+        public static bool Contains(System.Type attribute) { }
+    }
     public static class AttributesToAvoidReplicating
     {
         public static void Add(System.Type attribute) { }

--- a/ref/Castle.Core-netstandard2.1.cs
+++ b/ref/Castle.Core-netstandard2.1.cs
@@ -2721,6 +2721,12 @@ namespace Castle.DynamicProxy
 }
 namespace Castle.DynamicProxy.Generators
 {
+    public static class AttributesToAlwaysReplicate
+    {
+        public static void Add(System.Type attribute) { }
+        public static void Add<T>() { }
+        public static bool Contains(System.Type attribute) { }
+    }
     public static class AttributesToAvoidReplicating
     {
         public static void Add(System.Type attribute) { }

--- a/src/Castle.Core/DynamicProxy/Generators/AttributesToAlwaysReplicate.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/AttributesToAlwaysReplicate.cs
@@ -53,7 +53,7 @@ namespace Castle.DynamicProxy.Generators
 
 		internal static bool ShouldAdd(Type attribute)
 		{
-			return attributes.Any(attr => attr == attribute);
+			return attributes.Any(attr => attr.IsAssignableFrom(attribute));
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/AttributesToAlwaysReplicate.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/AttributesToAlwaysReplicate.cs
@@ -1,0 +1,59 @@
+// Copyright 2004-2021 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Generators
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public static class AttributesToAlwaysReplicate
+	{
+		private static readonly object lockObject = new object();
+
+		private static IList<Type> attributes;
+
+		static AttributesToAlwaysReplicate()
+		{
+			attributes = new List<Type>()
+			{
+				typeof(ParamArrayAttribute)
+			};
+		}
+
+		public static void Add(Type attribute)
+		{
+			// note: this class is made thread-safe by replacing the backing list rather than adding to it
+			lock (lockObject)
+			{
+				attributes = new List<Type>(attributes) { attribute };
+			}
+		}
+
+		public static void Add<T>()
+		{
+			Add(typeof(T));
+		}
+
+		public static bool Contains(Type attribute)
+		{
+			return attributes.Contains(attribute);
+		}
+
+		internal static bool ShouldAdd(Type attribute)
+		{
+			return attributes.Any(attr => attr == attribute);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -185,7 +185,7 @@ namespace Castle.DynamicProxy.Internal
 			{
 				return false;
 			}
-			
+
 			if (!ignoreInheritance)
 			{
 				var attrs = attribute.GetCustomAttributes<AttributeUsageAttribute>(true).ToArray();

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -181,15 +181,11 @@ namespace Castle.DynamicProxy.Internal
 				return true;
 			}
 
-			// Later, there might be more special cases requiring attribute replication,
-			// which might justify creating a `SpecialCaseAttributeThatShouldBeReplicated`
-			// method and an `AttributesToAlwaysReplicate` class. For the moment, `Param-
-			// ArrayAttribute` is the only special case, so keep it simple for now:
-			if (attribute == typeof(ParamArrayAttribute))
+			if (AttributesToAlwaysReplicate.ShouldAdd(attribute))
 			{
 				return false;
 			}
-
+			
 			if (!ignoreInheritance)
 			{
 				var attrs = attribute.GetCustomAttributes<AttributeUsageAttribute>(true).ToArray();


### PR DESCRIPTION
- This is complementary to `AttributesToAvoidReplicating`
- It will allow consumers to specify attributes which should always be copied to generated proxy. It is especially useful where we do not own target interfeces and/or cannot override attributes, e.g. attributes used by various frameworks. See #593 for more context
- Similar effect could by achieved in Castle.Core Version 4.4.1 by simply extending various generator classes but since 5.0 all those classes were marked internal, forcing client code to override half the library. This fix offers an alternative path while keeping to code conventions already in place.
- Fixes #607 