### PR TITLE
Fix `NullReferenceException` caused by `null` argument for custom attribute's array-typed ctor parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bugfixes:
+- Failure proxying type that has a non-inheritable custom attribute type applied where `null` argument is given for array parameter  (@stakx, #637)
 - Nested custom attribute types do not get replicated (@stakx, #638)
 
 ## 5.1.0 (2022-08-02)

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ClassWithAttributesTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ClassWithAttributesTestCase.cs
@@ -14,6 +14,7 @@
 
 namespace Castle.DynamicProxy.Tests
 {
+	using System;
 	using System.IO;
 	using System.Linq;
 	using System.Reflection;
@@ -178,5 +179,22 @@ namespace Castle.DynamicProxy.Tests
 				.Cast<NonInheritableWithArray2Attribute>().Single();
 			CollectionAssert.AreEqual(attribute.Values, new[] { "1", "2", "3" });
 		}
+
+		[TestCase(typeof(HasAttributeWithNullAsPositionalArgument))]
+		[TestCase(typeof(HasAttributeWithEmptyArrayAsPositionalArgument))]
+		[TestCase(typeof(HasAttributeWithNullInArrayAsPositionalArgument))]
+		public void Can_proxy_type_with_attribute_with_positional_array_parameter(Type classType)
+		{
+			_ = generator.CreateClassProxy(classType);
+		}
+
+		[NonInheritableAttributeWithPositionalArrayParameter(null)]
+		public class HasAttributeWithNullAsPositionalArgument{ }
+
+		[NonInheritableAttributeWithPositionalArrayParameter(new object[0])]
+		public class HasAttributeWithEmptyArrayAsPositionalArgument { }
+
+		[NonInheritableAttributeWithPositionalArrayParameter(new object[1] { null })]
+		public class HasAttributeWithNullInArrayAsPositionalArgument { }
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableAttributeWithPositionalArrayParameterAttribute.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Classes/NonInheritableAttributeWithPositionalArrayParameterAttribute.cs
@@ -1,0 +1,29 @@
+// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Classes
+{
+	using System;
+
+#if FEATURE_SERIALIZATION
+	[Serializable]
+#endif
+	[AttributeUsage(AttributeTargets.All, Inherited = false)]
+	public class NonInheritableAttributeWithPositionalArrayParameterAttribute : Attribute
+	{
+		public NonInheritableAttributeWithPositionalArrayParameterAttribute(object[] arg)
+		{
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/AttributeUtil.cs
@@ -28,12 +28,7 @@ namespace Castle.DynamicProxy.Internal
 		{
 			Debug.Assert(attribute != null, "attribute != null");
 
-			// .NET Core does not provide CustomAttributeData.Constructor, so we'll implement it
-			// by finding a constructor ourselves
-			Type[] constructorArgTypes;
-			object[] constructorArgs;
-			GetArguments(attribute.ConstructorArguments, out constructorArgTypes, out constructorArgs);
-			var constructor = attribute.AttributeType.GetConstructor(constructorArgTypes);
+			object[] constructorArgs = GetArguments(attribute.ConstructorArguments);
 
 			PropertyInfo[] properties;
 			object[] propertyValues;
@@ -43,24 +38,12 @@ namespace Castle.DynamicProxy.Internal
 				attribute.AttributeType,
 				attribute.NamedArguments, out properties, out propertyValues, out fields, out fieldValues);
 
-			return new CustomAttributeInfo(constructor,
+			return new CustomAttributeInfo(attribute.Constructor,
 			                               constructorArgs,
 			                               properties,
 			                               propertyValues,
 			                               fields,
 			                               fieldValues);
-		}
-
-		private static void GetArguments(IList<CustomAttributeTypedArgument> constructorArguments,
-			out Type[] constructorArgTypes, out object[] constructorArgs)
-		{
-			constructorArgTypes = new Type[constructorArguments.Count];
-			constructorArgs = new object[constructorArguments.Count];
-			for (var i = 0; i < constructorArguments.Count; i++)
-			{
-				constructorArgTypes[i] = constructorArguments[i].ArgumentType;
-				constructorArgs[i] = ReadAttributeValue(constructorArguments[i]);
-			}
 		}
 
 		private static object[] GetArguments(IList<CustomAttributeTypedArgument> constructorArguments)


### PR DESCRIPTION
Fixes #637. See commit messages for details.