### PR TITLE
Improve support for covariant returns (where generic types are involved)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bugfixes:
+- Proxies using records derived from a base generic record broken using .NET 6 compiler (@CesarD, #632)
 - Failure proxying type that has a non-inheritable custom attribute type applied where `null` argument is given for array parameter  (@stakx, #637)
 - Nested custom attribute types do not get replicated (@stakx, #638)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/CovariantReturnsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/CovariantReturnsTestCase.cs
@@ -52,6 +52,7 @@ namespace Castle.DynamicProxy.Tests
 		[TestCase(typeof(DerivedClassWithStringInsteadOfObject))]
 		[TestCase(typeof(DerivedClassWithStringInsteadOfInterface))]
 		[TestCase(typeof(DerivedClassWithStringInsteadOfGenericArg))]
+		[TestCase(typeof(BottleOfWater))]
 		public void Can_proxy_type_having_method_with_covariant_return(Type classToProxy)
 		{
 			_ = generator.CreateClassProxy(classToProxy, new StandardInterceptor());
@@ -62,6 +63,7 @@ namespace Castle.DynamicProxy.Tests
 		[TestCase(typeof(DerivedClassWithStringInsteadOfObject), typeof(string))]
 		[TestCase(typeof(DerivedClassWithStringInsteadOfInterface), typeof(string))]
 		[TestCase(typeof(DerivedClassWithStringInsteadOfGenericArg), typeof(string))]
+		[TestCase(typeof(BottleOfWater), typeof(Glass<Water>))]
 		public void Proxied_method_has_correct_return_type(Type classToProxy, Type expectedMethodReturnType)
 		{
 			var proxy = generator.CreateClassProxy(classToProxy, new StandardInterceptor());
@@ -115,6 +117,22 @@ namespace Castle.DynamicProxy.Tests
 		public class DerivedClassWithStringInsteadOfGenericArg : BaseClassWithGenericArg<IComparable>
 		{
 			public override string Method() => nameof(DerivedClassWithStringInsteadOfGenericArg);
+		}
+
+		public interface Glass<out T> { }
+
+		public class Liquid { }
+
+		public class Water : Liquid { }
+
+		public class BottleOfLiquid
+		{
+			public virtual Glass<Liquid> Method() => default(Glass<Liquid>);
+		}
+
+		public class BottleOfWater : BottleOfLiquid
+		{
+			public override Glass<Water> Method() => default(Glass<Water>);
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedEmptyGenericRecord.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedEmptyGenericRecord.cs
@@ -1,0 +1,20 @@
+﻿// Copyright 2004-2022 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.Records
+{
+	public record DerivedEmptyGenericRecord : EmptyGenericRecord<object>
+	{
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedFromEmptyGenericRecord.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedFromEmptyGenericRecord.cs
@@ -14,7 +14,7 @@
 
 namespace Castle.DynamicProxy.Tests.Records
 {
-	public record DerivedEmptyRecord : EmptyRecord
+	public record DerivedFromEmptyGenericRecord : EmptyGenericRecord<object>
 	{
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedFromEmptyRecord.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Records/DerivedFromEmptyRecord.cs
@@ -14,7 +14,7 @@
 
 namespace Castle.DynamicProxy.Tests.Records
 {
-	public record DerivedEmptyGenericRecord : EmptyGenericRecord<object>
+	public record DerivedFromEmptyRecord : EmptyRecord
 	{
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/Records/EmptyGenericRecord.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/Records/EmptyGenericRecord.cs
@@ -12,31 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Castle.DynamicProxy.Tests.Records;
-
-using NUnit.Framework;
-
-namespace Castle.DynamicProxy.Tests
+namespace Castle.DynamicProxy.Tests.Records
 {
-	[TestFixture]
-	public class RecordsTestCase : BasePEVerifyTestCase
+	public record EmptyGenericRecord<T>
 	{
-		[Test]
-		public void Can_proxy_empty_record()
-		{
-			_ = generator.CreateClassProxy<EmptyRecord>(new StandardInterceptor());
-		}
-
-		[Test]
-		public void Can_proxy_derived_empty_record()
-		{
-			_ = generator.CreateClassProxy<DerivedEmptyRecord>(new StandardInterceptor());
-		}
-
-		[Test]
-		public void Can_proxy_empty_generic_record()
-		{
-			_ = generator.CreateClassProxy<EmptyGenericRecord<object>>(new StandardInterceptor());
-		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RecordsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RecordsTestCase.cs
@@ -28,9 +28,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void Can_proxy_derived_empty_record()
+		public void Can_proxy_record_derived_from_empty_record()
 		{
-			_ = generator.CreateClassProxy<DerivedEmptyRecord>(new StandardInterceptor());
+			_ = generator.CreateClassProxy<DerivedFromEmptyRecord>(new StandardInterceptor());
 		}
 
 		[Test]
@@ -40,9 +40,9 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void Can_proxy_derived_empty_generic_record()
+		public void Can_proxy_record_derived_from_empty_generic_record()
 		{
-			_ = generator.CreateClassProxy<DerivedEmptyGenericRecord>(new StandardInterceptor());
+			_ = generator.CreateClassProxy<DerivedFromEmptyGenericRecord>(new StandardInterceptor());
 		}
 	}
 }

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/RecordsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/RecordsTestCase.cs
@@ -38,5 +38,11 @@ namespace Castle.DynamicProxy.Tests
 		{
 			_ = generator.CreateClassProxy<EmptyGenericRecord<object>>(new StandardInterceptor());
 		}
+
+		[Test]
+		public void Can_proxy_derived_empty_generic_record()
+		{
+			_ = generator.CreateClassProxy<DerivedEmptyGenericRecord>(new StandardInterceptor());
+		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -16,6 +16,7 @@ namespace Castle.DynamicProxy.Generators
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Reflection;
 
 	internal class MethodSignatureComparer : IEqualityComparer<MethodInfo>
@@ -136,6 +137,9 @@ namespace Castle.DynamicProxy.Generators
 
 			static bool IsCovariantReturnTypes(Type x, Type y, MethodInfo xm, MethodInfo ym)
 			{
+				Debug.Assert((xm == null && ym == null)
+				          || (xm != null && ym != null && x == xm.ReturnType && y == ym.ReturnType));
+
 				// This enables covariant method returns for .NET 5 and newer.
 				// No need to check for runtime support, since such methods are marked with a custom attribute;
 				// see https://github.com/dotnet/runtime/blob/main/docs/design/features/covariant-return-methods.md.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -92,7 +92,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 			else if (x.IsGenericType != y.IsGenericType)
 			{
-				return false;
+				return IsCovariantReturnTypes(x, y, xm, ym);
 			}
 
 			if (x.IsGenericParameter)
@@ -129,19 +129,24 @@ namespace Castle.DynamicProxy.Generators
 			{
 				if (!x.Equals(y))
 				{
-					// This enables covariant method returns for .NET 5 and newer.
-					// No need to check for runtime support, since such methods are marked with a custom attribute;
-					// see https://github.com/dotnet/runtime/blob/main/docs/design/features/covariant-return-methods.md.
-					if (preserveBaseOverridesAttribute != null)
-					{
-						return (xm != null && xm.IsDefined(preserveBaseOverridesAttribute, inherit: false) && y.IsAssignableFrom(x))
-						    || (ym != null && ym.IsDefined(preserveBaseOverridesAttribute, inherit: false) && x.IsAssignableFrom(y));
-					}
-
-					return false;
+					return IsCovariantReturnTypes(x, y, xm, ym);
 				}
 			}
 			return true;
+
+			static bool IsCovariantReturnTypes(Type x, Type y, MethodInfo xm, MethodInfo ym)
+			{
+				// This enables covariant method returns for .NET 5 and newer.
+				// No need to check for runtime support, since such methods are marked with a custom attribute;
+				// see https://github.com/dotnet/runtime/blob/main/docs/design/features/covariant-return-methods.md.
+				if (preserveBaseOverridesAttribute != null)
+				{
+					return (xm != null && xm.IsDefined(preserveBaseOverridesAttribute, inherit: false) && y.IsAssignableFrom(x))
+					    || (ym != null && ym.IsDefined(preserveBaseOverridesAttribute, inherit: false) && x.IsAssignableFrom(y));
+				}
+
+				return false;
+			}
 		}
 
 		public bool Equals(MethodInfo x, MethodInfo y)

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -121,9 +121,12 @@ namespace Castle.DynamicProxy.Generators
 					return false;
 				}
 
-				for (var i = 0; i < xArgs.Length; ++i)
+				if (IsCovariantReturnTypes(x, y, xm, ym) == false)
 				{
-					 if(!EqualSignatureTypes(xArgs[i], yArgs[i])) return false;
+					for (var i = 0; i < xArgs.Length; ++i)
+					{
+						 if(!EqualSignatureTypes(xArgs[i], yArgs[i])) return false;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Fixes #632.

It turns out that we only added support for _non-generic_ covariant return types in #619; however there are two additional cases that we need to support, too:

* covariant return types where one of them is generic but the other is not
* covariant return types where both of them are generic

(I'm counting those as two distinct cases due to the code structure found inside `MethodSignatureComparer.EqualSignatureTypes`, which is the method that needs to be augmented.)