### PR TITLE
Fix `ArgumentException` caused by `Enum` constraint on method `out` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enhancements:
 
 Bugfixes:
 - `ArgumentException`: "Could not find method overriding method" with overridden class method having generic by-ref parameter (@stakx, #657)
+- `ArgumentException`: "Cannot create an instance of `TEnum` because `Type.ContainsGenericParameters` is true" caused by `Enum` constraint on method `out` parameter (@stakx, #658)
 
 ## 5.1.1 (2022-12-30)
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IHaveGenericMethodWithEnumConstraint.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenInterfaces/IHaveGenericMethodWithEnumConstraint.cs
@@ -1,0 +1,23 @@
+// Copyright 2004-2023 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tests.GenInterfaces
+{
+	using System;
+
+	public interface IHaveGenericMethodWithEnumConstraint
+	{
+		void Method<TEnum>(out TEnum result) where TEnum : Enum;
+	}
+}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/GenericConstraintsTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/GenericConstraintsTestCase.cs
@@ -33,6 +33,12 @@ namespace Castle.DynamicProxy.Tests
 			CreateProxyFor<IConstraint_Method1IsTypeStructAndMethod2<object>>();
 		}
 
+		[Test]
+		public void Non_generic_type_generic_method_with_by_ref_parameter_type_constrained_to_Enum()
+		{
+			CreateProxyFor<IHaveGenericMethodWithEnumConstraint>();
+		}
+
 
 		private T CreateProxyFor<T>(params IInterceptor[] interceptors) where T : class
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -27,12 +27,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// </summary>
 		public static void EmitLoadIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum && !type.IsGenericParameter)
-			{
-				EmitLoadIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
-				return;
-			}
-
 			if (type.IsByRef)
 			{
 				throw new NotSupportedException("Cannot load ByRef values");
@@ -48,13 +42,20 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 				gen.Emit(opCode);
 			}
-			else if (type.IsValueType)
-			{
-				gen.Emit(OpCodes.Ldobj, type);
-			}
 			else if (type.IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Ldobj, type);
+			}
+			else if (type.IsValueType)
+			{
+				if (type.IsEnum)
+				{
+					EmitLoadIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
+				}
+				else
+				{
+					gen.Emit(OpCodes.Ldobj, type);
+				}
 			}
 			else
 			{
@@ -107,12 +108,6 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// </summary>
 		public static void EmitStoreIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum && !type.IsGenericParameter)
-			{
-				EmitStoreIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
-				return;
-			}
-
 			if (type.IsByRef)
 			{
 				throw new NotSupportedException("Cannot store ByRef values");
@@ -128,13 +123,20 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 				gen.Emit(opCode);
 			}
-			else if (type.IsValueType)
-			{
-				gen.Emit(OpCodes.Stobj, type);
-			}
 			else if (type.IsGenericParameter)
 			{
 				gen.Emit(OpCodes.Stobj, type);
+			}
+			else if (type.IsValueType)
+			{
+				if (type.IsEnum)
+				{
+					EmitStoreIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
+				}
+				else
+				{
+					gen.Emit(OpCodes.Stobj, type);
+				}
 			}
 			else
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/OpCodeUtil.cs
@@ -27,7 +27,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// </summary>
 		public static void EmitLoadIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum)
+			if (type.IsEnum && !type.IsGenericParameter)
 			{
 				EmitLoadIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
 				return;
@@ -107,7 +107,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 		/// </summary>
 		public static void EmitStoreIndirectOpCodeForType(ILGenerator gen, Type type)
 		{
-			if (type.IsEnum)
+			if (type.IsEnum && !type.IsGenericParameter)
 			{
 				EmitStoreIndirectOpCodeForType(gen, GetUnderlyingTypeOfEnum(type));
 				return;


### PR DESCRIPTION
Fixes #656.