### PR TITLE
Add support for default interface members in inheritance-based proxy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Enhancements:
 - Two new generic method overloads `proxyGenerator.CreateClassProxy<TClass>([options], constructorArguments, interceptors)` (@backstromjoel, #636)
 - Allow specifying which attributes should always be copied to proxy class by adding attribute type to `AttributesToAlwaysReplicate`. Previously only non-inherited, with `Inherited=false`, attributes were copied. (@shoaibshakeel381, #633)
+- Support for C# 8+ [default interface methods](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods) in interface and class proxies without target (@stakx, #661)
 
 Bugfixes:
 - `ArgumentException`: "Could not find method overriding method" with overridden class method having generic by-ref parameter (@stakx, #657)

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<LangVersion>9.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<NoWarn>$(NoWarn);CS1591;CS3014;CS3003;CS3001;CS3021</NoWarn>
 		<NoWarn>$(NoWarn);CS0612;CS0618</NoWarn> <!-- TODO: Remove this line once `[Obsolete]` members have been dealt with. -->
 		<RepositoryType>git</RepositoryType>

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -33,15 +33,16 @@ namespace Castle.DynamicProxy.Tests
 		public void Can_invoke_sealed_method_in_proxied_interface()
 		{
 			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveSealedMethod>();
-			var invokedMethod = proxy.SealedMethod();
-			Assert.AreEqual(typeof(IHaveSealedMethod).GetMethod(nameof(IHaveSealedMethod.SealedMethod)), invokedMethod);
+			var expected = "default implementation";
+			var actual = proxy.SealedMethod();
+			Assert.AreEqual(expected, actual);
 		}
 
 		public interface IHaveSealedMethod
 		{
-			sealed MethodBase SealedMethod()
+			sealed string SealedMethod()
 			{
-				return MethodBase.GetCurrentMethod();
+				return "default implementation";
 			}
 		}
 	}

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -98,6 +98,46 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+		public void Can_intercept_method_with_overridden_default_implementation_in_proxied_class()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateClassProxy<OverridesMethodWithDefaultImplementation>(interceptor);
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_method_that_is_sibling_of_method_with_default_implementation_in_proxied_class()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateClassProxy<InheritsMethodWithDefaultImplementationAmongOtherThings>(interceptor);
+			var actual = proxy.Method();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_method_that_is_sibling_of_method_with_default_implementation_in_proxied_interface()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithDefaultImplementationAmongOtherThings>(interceptor);
+			var actual = proxy.Method();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_base_implementation_of_method_that_is_sibling_of_method_with_default_implementation_in_proxied_class()
+		{
+			var expected = "class implementation";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateClassProxy<InheritsMethodWithDefaultImplementationAmongOtherThings>(interceptor);
+			var actual = proxy.Method();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
 		public void Can_proxy_class_that_inherits_property_with_default_implementation_from_interface()
 		{
 			_ = generator.CreateClassProxy<InheritsPropertyWithDefaultImplementation>();
@@ -192,6 +232,11 @@ namespace Castle.DynamicProxy.Tests
 			}
 		}
 
+		public interface IHaveMethodWithDefaultImplementationAmongOtherThings : IHaveMethodWithDefaultImplementation
+		{
+			string Method();
+		}
+
 		public interface IHavePropertyWithDefaultImplementation
 		{
 			string PropertyWithDefaultImplementation
@@ -213,7 +258,23 @@ namespace Castle.DynamicProxy.Tests
 
 		public class InheritsMethodWithDefaultImplementation : IHaveMethodWithDefaultImplementation { }
 
+		public class InheritsMethodWithDefaultImplementationAmongOtherThings : IHaveMethodWithDefaultImplementationAmongOtherThings
+		{
+			public virtual string Method()
+			{
+				return "class implementation";
+			}
+		}
+
 		public class InheritsPropertyWithDefaultImplementation : IHavePropertyWithDefaultImplementation { }
+
+		public class OverridesMethodWithDefaultImplementation : IHaveMethodWithDefaultImplementation
+		{
+			public virtual string MethodWithDefaultImplementation()
+			{
+				return "class implementation";
+			}
+		}
 	}
 }
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -17,6 +17,7 @@
 using System.Reflection;
 
 using Castle.DynamicProxy.Tests.Interceptors;
+using Castle.DynamicProxy.Tests.Interfaces;
 
 using NUnit.Framework;
 
@@ -218,6 +219,58 @@ namespace Castle.DynamicProxy.Tests
 			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHavePropertyWithDefaultImplementation>(interceptor);
 			var expected = "default implementation";
 			var actual = proxy.PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proxy_class_that_inherits_method_with_default_implementation_from_additional_interface()
+		{
+			_ = generator.CreateClassProxy(typeof(object), new[] { typeof(IHaveMethodWithDefaultImplementation) });
+		}
+
+		[Test]
+		public void Can_proxy_interface_with_method_with_default_implementation_from_additional_interface()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget(typeof(IEmpty), new[] { typeof(IHaveMethodWithDefaultImplementation) });
+		}
+
+		[Test]
+		public void Can_intercept_method_with_default_implementation_from_additional_interface_in_proxied_class()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateClassProxy(typeof(object), new[] { typeof(IHaveMethodWithDefaultImplementation) },interceptor);
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_method_with_default_implementation_from_additional_interface_in_proxied_interface()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IEmpty), new[] { typeof(IHaveMethodWithDefaultImplementation) },interceptor);
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_method_default_implementation_from_additional_interface_in_proxied_class()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateClassProxy(typeof(object), new[] { typeof(IHaveMethodWithDefaultImplementation) }, interceptor);
+			var expected = "default implementation";
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_method_default_implementation_from_additional_interface_in_proxied_interface()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IEmpty), new[] { typeof(IHaveMethodWithDefaultImplementation) }, interceptor);
+			var expected = "default implementation";
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
 			Assert.AreEqual(expected, actual);
 		}
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -26,6 +26,8 @@ namespace Castle.DynamicProxy.Tests
 	[TestFixture]
 	public class DefaultInterfaceMembersTestCase : BasePEVerifyTestCase
 	{
+		#region Methods with default implementation
+
 		[Test]
 		public void Can_proxy_class_that_inherits_method_with_default_implementation_from_interface()
 		{
@@ -98,6 +100,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		#endregion
+
+		#region Generic methods with default implementation
+
 		[Test]
 		public void Can_proceed_to_generic_method_default_implementation_in_proxied_interface()
 		{
@@ -110,6 +116,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		#endregion
+
+		#region Methods with "overridden" default implementation
+
 		[Test]
 		public void Can_intercept_method_with_overridden_default_implementation_in_proxied_class()
 		{
@@ -119,6 +129,10 @@ namespace Castle.DynamicProxy.Tests
 			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
 			Assert.AreEqual(expected, actual);
 		}
+
+		#endregion
+
+		#region Siblings of methods with default implementation
 
 		[Test]
 		public void Can_intercept_method_that_is_sibling_of_method_with_default_implementation_in_proxied_class()
@@ -149,6 +163,10 @@ namespace Castle.DynamicProxy.Tests
 			var actual = proxy.Method();
 			Assert.AreEqual(expected, actual);
 		}
+
+		#endregion
+
+		#region Properties with default implementation
 
 		[Test]
 		public void Can_proxy_class_that_inherits_property_with_default_implementation_from_interface()
@@ -222,6 +240,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		#endregion
+
+		#region Methods with default implementation in additional interfaces
+
 		[Test]
 		public void Can_proxy_class_that_inherits_method_with_default_implementation_from_additional_interface()
 		{
@@ -274,6 +296,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		#endregion
+
+		#region Sealed members
+
 		[Test]
 		public void Can_proxy_interface_with_sealed_method()
 		{
@@ -289,6 +315,10 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		#endregion
+
+		#region Static members
+
 		[Test]
 		public void Can_proxy_interface_with_static_method()
 		{
@@ -303,6 +333,8 @@ namespace Castle.DynamicProxy.Tests
 			_ = generator.CreateInterfaceProxyWithoutTarget<IHaveStaticAbstractMethod>();
 		}
 #endif
+
+		#endregion
 
 		public interface IHaveGenericMethodWithDefaultImplementation
 		{

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -298,6 +298,77 @@ namespace Castle.DynamicProxy.Tests
 
 		#endregion
 
+		#region Non-public methods with default implementation
+
+		public void Can_proxy_class_that_inherits_protected_method_with_default_implementation_from_interface()
+		{
+			_ = generator.CreateClassProxy<InheritsProtectedMethodWithDefaultImplementation>();
+		}
+
+		[Test]
+		public void Can_proxy_interface_with_protected_method_with_default_implementation()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget<IHaveProtectedMethodWithDefaultImplementation>();
+		}
+
+		[Test]
+		public void Can_intercept_protected_method_with_default_implementation_in_proxied_class()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation =>
+			{
+				Assume.That(invocation.Method.Name == "ProtectedMethodWithDefaultImplementation");
+				invocation.ReturnValue = expected;
+			});
+			var proxy = generator.CreateClassProxy<InheritsProtectedMethodWithDefaultImplementation>(interceptor);
+			var actual = ((IHaveProtectedMethodWithDefaultImplementation)proxy).InvokeProtectedMethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_protected_method_with_default_implementation_in_proxied_interface()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation =>
+			{
+				Assume.That(invocation.Method.Name == "ProtectedMethodWithDefaultImplementation");
+				invocation.ReturnValue = expected;
+			});
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveProtectedMethodWithDefaultImplementation>(interceptor);
+			var actual = proxy.InvokeProtectedMethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_protected_method_default_implementation_in_proxied_class()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation =>
+			{
+				Assume.That(invocation.Method.Name == "ProtectedMethodWithDefaultImplementation");
+				invocation.Proceed();
+			});
+			var proxy = generator.CreateClassProxy<InheritsProtectedMethodWithDefaultImplementation>(interceptor);
+			var expected = "default implementation";
+			var actual = ((IHaveProtectedMethodWithDefaultImplementation)proxy).InvokeProtectedMethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_protected_method_default_implementation_in_proxied_interface()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation =>
+			{
+				Assume.That(invocation.Method.Name == "ProtectedMethodWithDefaultImplementation");
+				invocation.Proceed();
+			});
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveProtectedMethodWithDefaultImplementation>(interceptor);
+			var expected = "default implementation";
+			var actual = proxy.InvokeProtectedMethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		#endregion
+
 		#region Sealed members
 
 		[Test]
@@ -357,6 +428,19 @@ namespace Castle.DynamicProxy.Tests
 			string Method();
 		}
 
+		public interface IHaveProtectedMethodWithDefaultImplementation
+		{
+			sealed string InvokeProtectedMethodWithDefaultImplementation()
+			{
+				return ProtectedMethodWithDefaultImplementation();
+			}
+
+			protected string ProtectedMethodWithDefaultImplementation()
+			{
+				return "default implementation";
+			}
+		}
+
 		public interface IHavePropertyWithDefaultImplementation
 		{
 			string PropertyWithDefaultImplementation
@@ -400,6 +484,9 @@ namespace Castle.DynamicProxy.Tests
 				return "class implementation";
 			}
 		}
+
+		public class InheritsProtectedMethodWithDefaultImplementation : IHaveProtectedMethodWithDefaultImplementation { }
+
 
 		public class InheritsPropertyWithDefaultImplementation : IHavePropertyWithDefaultImplementation { }
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -236,6 +236,21 @@ namespace Castle.DynamicProxy.Tests
 			Assert.AreEqual(expected, actual);
 		}
 
+		[Test]
+		public void Can_proxy_interface_with_static_method()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget<IHaveStaticMethod>();
+		}
+
+#if NET7_0_OR_GREATER
+		[Test]
+		[Ignore("Support for static abstract interface members has not yet been implemented.")]
+		public void Can_proxy_interface_with_static_abstract_method()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget<IHaveStaticAbstractMethod>();
+		}
+#endif
+
 		public interface IHaveGenericMethodWithDefaultImplementation
 		{
 			string GenericMethodWithDefaultImplementation<T>()
@@ -275,6 +290,21 @@ namespace Castle.DynamicProxy.Tests
 				return "default implementation";
 			}
 		}
+
+		public interface IHaveStaticMethod
+		{
+			static string StaticMethod()
+			{
+				return "default implementation";
+			}
+		}
+
+#if NET7_0_OR_GREATER
+		public interface IHaveStaticAbstractMethod
+		{
+			static abstract string StaticAbstractMethod();
+		}
+#endif
 
 		public class InheritsMethodWithDefaultImplementation : IHaveMethodWithDefaultImplementation { }
 

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -407,6 +407,57 @@ namespace Castle.DynamicProxy.Tests
 
 		#endregion
 
+		#region Mixins
+
+		[Test]
+		public void Can_intercept_method_with_default_implementation_from_mixin_in_proxied_class()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddMixinInstance(new InheritsMethodWithDefaultImplementation());
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_method_with_default_implementation_from_mixin_in_proxied_interface()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddMixinInstance(new InheritsMethodWithDefaultImplementation());
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IEmpty), options, interceptor);
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_method_default_implementation_from_mixin_in_proxied_class()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddMixinInstance(new InheritsMethodWithDefaultImplementation());
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateClassProxy(typeof(object), options, interceptor);
+			var expected = "default implementation";
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_method_default_implementation_from_mixin_in_proxied_interface()
+		{
+			var options = new ProxyGenerationOptions();
+			options.AddMixinInstance(new InheritsMethodWithDefaultImplementation());
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateInterfaceProxyWithoutTarget(typeof(IEmpty), options, interceptor);
+			var expected = "default implementation";
+			var actual = ((IHaveMethodWithDefaultImplementation)proxy).MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+		#endregion
+
 		public interface IHaveGenericMethodWithDefaultImplementation
 		{
 			string GenericMethodWithDefaultImplementation<T>()

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -98,6 +98,18 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
+		public void Can_proceed_to_generic_method_default_implementation_in_proxied_interface()
+		{
+			// (This test targets the code regarding generics inside `InterfaceProxyWithoutTargetContributor.CreateCallbackMethod`.)
+
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveGenericMethodWithDefaultImplementation>(interceptor);
+			var expected = "default implementation for Int32";
+			var actual = proxy.GenericMethodWithDefaultImplementation<int>();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
 		public void Can_intercept_method_with_overridden_default_implementation_in_proxied_class()
 		{
 			var expected = "intercepted";
@@ -222,6 +234,14 @@ namespace Castle.DynamicProxy.Tests
 			var expected = "default implementation";
 			var actual = proxy.SealedMethod();
 			Assert.AreEqual(expected, actual);
+		}
+
+		public interface IHaveGenericMethodWithDefaultImplementation
+		{
+			string GenericMethodWithDefaultImplementation<T>()
+			{
+				return "default implementation for " + typeof(T).Name;
+			}
 		}
 
 		public interface IHaveMethodWithDefaultImplementation

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/DefaultInterfaceMembersTestCase.cs
@@ -78,7 +78,7 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void Can_proceed_to_default_implementation_in_proxied_class()
+		public void Can_proceed_to_method_default_implementation_in_proxied_class()
 		{
 			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
 			var proxy = generator.CreateClassProxy<InheritsMethodWithDefaultImplementation>(interceptor);
@@ -88,12 +88,84 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		[Test]
-		public void Can_proceed_to_default_implementation_in_proxied_interface()
+		public void Can_proceed_to_method_default_implementation_in_proxied_interface()
 		{
 			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
 			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithDefaultImplementation>(interceptor);
 			var expected = "default implementation";
 			var actual = proxy.MethodWithDefaultImplementation();
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proxy_class_that_inherits_property_with_default_implementation_from_interface()
+		{
+			_ = generator.CreateClassProxy<InheritsPropertyWithDefaultImplementation>();
+		}
+
+		[Test]
+		public void Can_proxy_interface_with_property_with_default_implementation()
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget<IHavePropertyWithDefaultImplementation>();
+		}
+
+		[Test]
+		public void Default_implementation_gets_called_when_property_not_intercepted_in_proxied_class()
+		{
+			var options = new ProxyGenerationOptions(new ProxyNothingHook());
+			var proxy = generator.CreateClassProxy<InheritsPropertyWithDefaultImplementation>(options);
+			var expected = "default implementation";
+			var actual = ((IHavePropertyWithDefaultImplementation)proxy).PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Default_implementation_gets_called_when_property_not_intercepted_in_proxied_interface()
+		{
+			var options = new ProxyGenerationOptions(new ProxyNothingHook());
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHavePropertyWithDefaultImplementation>(options);
+			var expected = "default implementation";
+			var actual = proxy.PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_property_with_default_implementation_in_proxied_class()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateClassProxy<InheritsPropertyWithDefaultImplementation>(interceptor);
+			var actual = ((IHavePropertyWithDefaultImplementation)proxy).PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_intercept_property_with_default_implementation_in_proxied_interface()
+		{
+			var expected = "intercepted";
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.ReturnValue = expected);
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHavePropertyWithDefaultImplementation>(interceptor);
+			var actual = proxy.PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_property_default_implementation_in_proxied_class()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateClassProxy<InheritsPropertyWithDefaultImplementation>(interceptor);
+			var expected = "default implementation";
+			var actual = ((IHavePropertyWithDefaultImplementation)proxy).PropertyWithDefaultImplementation;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
+		public void Can_proceed_to_property_default_implementation_in_proxied_interface()
+		{
+			var interceptor = new WithCallbackInterceptor(invocation => invocation.Proceed());
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHavePropertyWithDefaultImplementation>(interceptor);
+			var expected = "default implementation";
+			var actual = proxy.PropertyWithDefaultImplementation;
 			Assert.AreEqual(expected, actual);
 		}
 
@@ -120,6 +192,17 @@ namespace Castle.DynamicProxy.Tests
 			}
 		}
 
+		public interface IHavePropertyWithDefaultImplementation
+		{
+			string PropertyWithDefaultImplementation
+			{
+				get
+				{
+					return "default implementation";
+				}
+			}
+		}
+
 		public interface IHaveSealedMethod
 		{
 			sealed string SealedMethod()
@@ -129,6 +212,8 @@ namespace Castle.DynamicProxy.Tests
 		}
 
 		public class InheritsMethodWithDefaultImplementation : IHaveMethodWithDefaultImplementation { }
+
+		public class InheritsPropertyWithDefaultImplementation : IHavePropertyWithDefaultImplementation { }
 	}
 }
 

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -42,6 +42,11 @@ namespace Castle.DynamicProxy.Contributors
 			var targetItem = new ClassMembersCollector(targetType) { Logger = Logger };
 			yield return targetItem;
 
+			foreach (var @interface in targetType.GetAllInterfaces())
+			{
+				yield return new InterfaceMembersWithDefaultImplementationCollector(@interface, targetType);
+			}
+
 			foreach (var @interface in interfaces)
 			{
 				var item = new InterfaceMembersOnClassCollector(@interface, true,

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -44,6 +44,11 @@ namespace Castle.DynamicProxy.Contributors
 
 			foreach (var @interface in targetType.GetAllInterfaces())
 			{
+				if (@interface.HasAnyOverridableDefaultImplementations() == false)
+				{
+					continue;
+				}
+
 				yield return new InterfaceMembersWithDefaultImplementationCollector(@interface, targetType);
 			}
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -35,7 +35,7 @@ namespace Castle.DynamicProxy.Contributors
 				return null;
 			}
 
-			return new MetaMethod(method, method, isStandalone, proxyable, false);
+			return new MetaMethod(method, method, isStandalone, proxyable, hasTarget: !method.IsAbstract);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
@@ -62,7 +62,7 @@ namespace Castle.DynamicProxy.Contributors
 				return null;
 			}
 
-			return new MetaMethod(method, methodOnTarget, true, proxyable, !method.IsAbstract);
+			return new MetaMethod(method, methodOnTarget, isStandalone, proxyable, !method.IsAbstract);
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
@@ -38,10 +38,13 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (method.IsAbstract)
+			if (method.IsAbstract || method.IsFinal || method.IsVirtual == false)
 			{
-				// This collector is only interested in methods with default implementations.
+				// This collector is only interested in overridable methods with default implementations.
 				// All other interface methods should be dealt with in other contributors.
+				//
+				// (Note this is the opposite check of that in `TypeUtil.HasAnyOverridableDefaultImplementations`,
+				// which is the method used to filter out whole interfaces before this collector gets run for them.)
 				return null;
 			}
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
@@ -38,6 +38,13 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
+			if (method.IsAbstract)
+			{
+				// This collector is only interested in methods with default implementations.
+				// All other interface methods should be dealt with in other contributors.
+				return null;
+			}
+
 			var index = Array.IndexOf(map.InterfaceMethods, method);
 			Debug.Assert(index >= 0);
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersWithDefaultImplementationCollector.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2004-2023 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Contributors
+{
+	using System;
+	using System.Diagnostics;
+	using System.Reflection;
+
+	using Castle.DynamicProxy.Generators;
+
+	internal sealed class InterfaceMembersWithDefaultImplementationCollector : MembersCollector
+	{
+		private readonly InterfaceMapping map;
+
+		public InterfaceMembersWithDefaultImplementationCollector(Type interfaceType, Type classToProxy)
+			: base(interfaceType)
+		{
+			Debug.Assert(interfaceType != null);
+			Debug.Assert(interfaceType.IsInterface);
+
+			Debug.Assert(classToProxy != null);
+			Debug.Assert(classToProxy.IsClass);
+
+			map = classToProxy.GetInterfaceMap(interfaceType);
+		}
+
+		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
+		{
+			var index = Array.IndexOf(map.InterfaceMethods, method);
+			Debug.Assert(index >= 0);
+
+			var methodOnTarget = map.TargetMethods[index];
+			if (methodOnTarget.DeclaringType.IsInterface == false)
+			{
+				// An interface method can have its default implementation "overridden" in the class,
+				// in which case this collector isn't interested in it and another should deal with it.
+				return null;
+			}
+
+			var proxyable = AcceptMethod(method, true, hook);
+			if (!proxyable)
+			{
+				return null;
+			}
+
+			return new MetaMethod(method, methodOnTarget, true, proxyable, !method.IsAbstract);
+		}
+	}
+}

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithoutTargetContributor.cs
@@ -65,33 +65,32 @@ namespace Castle.DynamicProxy.Contributors
 		{
 			var methodInfo = method.Method;
 
-			if (canChangeTarget == false && methodInfo.IsAbstract)
+			if (canChangeTarget == false)
 			{
-				// We do not need to generate a custom invocation type because no custom implementation
-				// for `InvokeMethodOnTarget` will be needed (proceeding to target isn't possible here):
-				return typeof(InterfaceMethodWithoutTargetInvocation);
+				if (!method.HasTarget)
+				{
+					// We do not need to generate a custom invocation type because no custom implementation
+					// for `InvokeMethodOnTarget` will be needed (proceeding to target isn't possible here):
+					return typeof(InterfaceMethodWithoutTargetInvocation);
+				}
+				else
+				{
+					// We end up here for interface methods with a default implementation:
+					Debug.Assert(methodInfo.DeclaringType.IsInterface && methodInfo.IsAbstract == false);
+
+					// This allows proceeding to a interface method's default implementation.
+					// The code has been copied over from `ClassProxyTargetContributor`.
+					var callback = CreateCallbackMethod(emitter, methodInfo, method.MethodOnTarget);
+					return new InheritanceInvocationTypeGenerator(callback.DeclaringType, method, callback, null)
+					       .Generate(emitter, namingScope)
+					       .BuildType();
+				}
 			}
 
-			if (canChangeTarget == false && methodInfo.IsAbstract == false)
-			{
-				// This allows proceeding to a interface method's default implementation.
-				// The code has been copied over from `ClassProxyTargetContributor`.
-				var callback = CreateCallbackMethod(emitter, methodInfo, method.MethodOnTarget);
-				return new InheritanceInvocationTypeGenerator(callback.DeclaringType, method, callback, null)
-				       .Generate(emitter, namingScope)
-				       .BuildType();
-			}
+			Debug.Assert(canChangeTarget);
 
 			var scope = emitter.ModuleScope;
-			Type[] invocationInterfaces;
-			if (canChangeTarget)
-			{
-				invocationInterfaces = new[] { typeof(IInvocation), typeof(IChangeProxyTarget) };
-			}
-			else
-			{
-				invocationInterfaces = new[] { typeof(IInvocation) };
-			}
+			Type[] invocationInterfaces = new[] { typeof(IInvocation), typeof(IChangeProxyTarget) };
 			var key = new CacheKey(methodInfo, CompositionInvocationTypeGenerator.BaseType, invocationInterfaces, null);
 
 			// no locking required as we're already within a lock


### PR DESCRIPTION
This is another step towards completing #447. I'm limiting this PR to inheritance-based proxy types (i. e. those without target) due to time constraints &ndash; having to adjust only 2 out of 5 implementations is a lot less work! &ndash; and because these are likely the most important proxy types for downstream testing libraries such as Moq, NSubstitute, etc.

 * [X] methods
 * [X] generic methods
 * [X] properties and events (i. e. where the accessor methods are not "standalone" ones) &ndash; only testing properties at this time, which should be enough
 * [X] different accessibilities (e. g. `protected` ~~, `protected internal`, `internal`~~)
 * [X] mixins
 * [X] additional interfaces
 * [X] `static` members
 * [X] ~~`static abstract` members~~ (requires targeting .NET 7 or newer & a major architectural expansion to include non-instance members; let's do this in a future PR)

Testing all possible combinations of these aspects would be prohibitive, I've therefore restricted tests to a subset of these combinations that seemed reasonable and justifiable by the nature of the actual code changes / extensions made to DynamicProxy.