### PR TITLE
Draft: Prevent disallowed conversions between `object` and by-ref-like parameter and return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 Enhancements:
 - Two new generic method overloads `proxyGenerator.CreateClassProxy<TClass>([options], constructorArguments, interceptors)` (@backstromjoel, #636)
 - Allow specifying which attributes should always be copied to proxy class by adding attribute type to `AttributesToAlwaysReplicate`. Previously only non-inherited, with `Inherited=false`, attributes were copied. (@shoaibshakeel381, #633)
+- Minimally improved support for methods having `ref struct` parameter and return types such as `Span<T>`: Intercepting such methods caused the runtime to throw `InvalidProgramException` and `NullReferenceException` due to forbidden conversions of `ref struct` values when transferring them into & out of `IInvocation` instances. To prevent these exceptions from being thrown, such values now get replaced with `null` in `IInvocation`, and with `default` values in return values and `out` arguments. (@stakx, #665)
 
 Bugfixes:
+- `InvalidProgramException` when proxying `MemoryStream` with .NET 7 (@stakx, #651)
 - `ArgumentException`: "Could not find method overriding method" with overridden class method having generic by-ref parameter (@stakx, #657)
 - `ArgumentException`: "Cannot create an instance of `TEnum` because `Type.ContainsGenericParameters` is true" caused by `Enum` constraint on method `out` parameter (@stakx, #658)
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,16 @@ For known Mono defects, check [our issue tracker](https://github.com/castleproje
 
 The following conditional compilation symbols (vertical) are currently defined for each of the build configurations (horizontal):
 
-Symbol                              | .NET 4.6.2         | .NET Standard 2.x and .NET 6
------------------------------------ | ------------------ | ----------------------------
-`FEATURE_APPDOMAIN`                 | :white_check_mark: | :no_entry_sign:
-`FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:
-`FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:
-`FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:
+Symbol                              | .NET 4.6.2         | .NET Standard 2.0 | .NET Standard 2.1 and .NET 6
+----------------------------------- | ------------------ | ------------------| ----------------------------
+`FEATURE_APPDOMAIN`                 | :white_check_mark: | :no_entry_sign:   | :no_entry_sign:
+`FEATURE_ASSEMBLYBUILDER_SAVE`      | :white_check_mark: | :no_entry_sign:   | :no_entry_sign:
+`FEATURE_BYREFLIKE`                 | :no_entry_sign:    | :no_entry_sign:   | :white_check_mark:
+`FEATURE_SERIALIZATION`             | :white_check_mark: | :no_entry_sign:   | :no_entry_sign:
+`FEATURE_SYSTEM_CONFIGURATION`      | :white_check_mark: | :no_entry_sign:   | :no_entry_sign:
 
 * `FEATURE_APPDOMAIN` - enables support for features that make use of an AppDomain in the host.
 * `FEATURE_ASSEMBLYBUILDER_SAVE` - enabled support for saving the dynamically generated proxy assembly.
+* `FEATURE_BYREFLIKE` - enables support for by-ref-like (`ref struct`) types such as `Span<T>` and `ReadOnlySpan<T>`.
 * `FEATURE_SERIALIZATION` - enables support for serialization of dynamic proxies and other types.
 * `FEATURE_SYSTEM_CONFIGURATION` - enables features that use System.Configuration and the ConfigurationManager.

--- a/buildscripts/common.props
+++ b/buildscripts/common.props
@@ -46,7 +46,7 @@
 	<PropertyGroup>
 		<DiagnosticsConstants>DEBUG</DiagnosticsConstants>
 		<NetStandard20Constants>TRACE</NetStandard20Constants>
-		<NetStandard21Constants>TRACE</NetStandard21Constants>
+		<NetStandard21Constants>TRACE;FEATURE_BYREFLIKE</NetStandard21Constants>
 		<DesktopClrConstants>TRACE;FEATURE_APPDOMAIN;FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_SERIALIZATION;FEATURE_SYSTEM_CONFIGURATION</DesktopClrConstants>
 	</PropertyGroup>
 
@@ -89,7 +89,15 @@
 	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='netcoreapp3.1|Release'">
 		<DefineConstants>$(NetStandard21Constants)</DefineConstants>
 	</PropertyGroup>
-	
+
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net6.0|Debug'">
+		<DefineConstants>$(DiagnosticsConstants);$(NetStandard21Constants)</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)|$(Configuration)'=='net6.0|Release'">
+		<DefineConstants>$(NetStandard21Constants)</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<None Include="$(SolutionDir)docs\images\castle-logo.png" Pack="true" PackagePath=""/>
 	</ItemGroup>

--- a/src/Castle.Core.Tests/DynamicProxy.Tests/ByRefLikeTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/ByRefLikeTestCase.cs
@@ -1,0 +1,190 @@
+﻿// Copyright 2004-2023 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if FEATURE_BYREFLIKE
+
+namespace Castle.DynamicProxy.Tests
+{
+	using System;
+
+	using Castle.DynamicProxy.Tests.Interceptors;
+
+	using NUnit.Framework;
+
+	/// <summary>
+	///   Tests for by-ref-like (<see langword="ref"/> <see langword="struct"/>) method parameter and return types.
+	/// </summary>
+	[TestFixture]
+	public class ByRefLikeTestCase : BasePEVerifyTestCase
+	{
+		[TestCase(typeof(IHaveMethodWithByRefLikeParameter))]
+		[TestCase(typeof(IHaveMethodWithByRefLikeInParameter))]
+		[TestCase(typeof(IHaveMethodWithByRefLikeRefParameter))]
+		[TestCase(typeof(IHaveMethodWithByRefLikeOutParameter))]
+		[TestCase(typeof(IHaveMethodWithByRefLikeReturnType))]
+		public void Can_proxy_type(Type interfaceType)
+		{
+			_ = generator.CreateInterfaceProxyWithoutTarget(interfaceType);
+		}
+
+		[Test]
+		public void Can_invoke_method_with_by_ref_like_parameter()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithByRefLikeParameter>(new DoNothingInterceptor());
+			var arg = default(ByRefLike);
+			proxy.Method(arg);
+		}
+
+		[Test]
+		public void Can_invoke_method_with_by_ref_like_in_parameter()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithByRefLikeInParameter>(new DoNothingInterceptor());
+			ByRefLike arg = default;
+			proxy.Method(in arg);
+		}
+
+		[Test]
+		public void Can_invoke_method_with_by_ref_like_ref_parameter()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithByRefLikeRefParameter>(new DoNothingInterceptor());
+			ByRefLike arg = default;
+			proxy.Method(ref arg);
+		}
+
+		[Test]
+		public void Can_invoke_method_with_by_ref_like_out_parameter()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithByRefLikeOutParameter>(new DoNothingInterceptor());
+			proxy.Method(out _);
+		}
+
+		[Test]
+		public void Can_invoke_method_with_by_ref_like_return_type()
+		{
+			var proxy = generator.CreateInterfaceProxyWithoutTarget<IHaveMethodWithByRefLikeReturnType>(new DoNothingInterceptor());
+			_ = proxy.Method();
+		}
+
+		[Test]
+		public void Can_proceed_to_target_method_with_by_ref_like_parameter()
+		{
+			var target = new HasMethodWithByRefLikeParameter();
+			var proxy = generator.CreateInterfaceProxyWithTarget<IHaveMethodWithByRefLikeParameter>(target, new StandardInterceptor());
+			ByRefLike arg = default;
+			proxy.Method(arg);
+		}
+
+		[Test]
+		public void Can_proceed_to_target_method_with_by_ref_like_in_parameter()
+		{
+			var target = new HasMethodWithByRefLikeInParameter();
+			var proxy = generator.CreateInterfaceProxyWithTarget<IHaveMethodWithByRefLikeInParameter>(target, new StandardInterceptor());
+			ByRefLike arg = default;
+			proxy.Method(in arg);
+		}
+
+		[Test]
+		public void Can_proceed_to_target_method_with_by_ref_like_ref_parameter()
+		{
+			var target = new HasMethodWithByRefLikeRefParameter();
+			var proxy = generator.CreateInterfaceProxyWithTarget<IHaveMethodWithByRefLikeRefParameter>(target, new StandardInterceptor());
+			ByRefLike arg = default;
+			proxy.Method(ref arg);
+		}
+
+		[Test]
+		public void Can_proceed_to_target_method_with_by_ref_like_out_parameter()
+		{
+			var target = new HasMethodWithByRefLikeOutParameter();
+			var proxy = generator.CreateInterfaceProxyWithTarget<IHaveMethodWithByRefLikeOutParameter>(target, new StandardInterceptor());
+			proxy.Method(out _);
+		}
+
+		[Test]
+		public void Can_proceed_to_target_method_with_by_ref_like_return_type()
+		{
+			var target = new HasMethodWithByRefLikeReturnType();
+			var proxy = generator.CreateInterfaceProxyWithTarget<IHaveMethodWithByRefLikeReturnType>(target, new StandardInterceptor());
+			_ = proxy.Method();
+		}
+
+		public ref struct ByRefLike
+		{
+		}
+
+		public interface IHaveMethodWithByRefLikeParameter
+		{
+			void Method(ByRefLike arg);
+		}
+
+		public class HasMethodWithByRefLikeParameter : IHaveMethodWithByRefLikeParameter
+		{
+			public virtual void Method(ByRefLike arg)
+			{
+			}
+		}
+
+		public interface IHaveMethodWithByRefLikeInParameter
+		{
+			void Method(in ByRefLike arg);
+		}
+
+		public class HasMethodWithByRefLikeInParameter : IHaveMethodWithByRefLikeInParameter
+		{
+			public virtual void Method(in ByRefLike arg)
+			{
+			}
+		}
+
+		public interface IHaveMethodWithByRefLikeRefParameter
+		{
+			void Method(ref ByRefLike arg);
+		}
+
+		public class HasMethodWithByRefLikeRefParameter : IHaveMethodWithByRefLikeRefParameter
+		{
+			public virtual void Method(ref ByRefLike arg)
+			{
+			}
+		}
+
+		public interface IHaveMethodWithByRefLikeOutParameter
+		{
+			void Method(out ByRefLike arg);
+		}
+
+		public class HasMethodWithByRefLikeOutParameter : IHaveMethodWithByRefLikeOutParameter
+		{
+			public virtual void Method(out ByRefLike arg)
+			{
+				arg = default;
+			}
+		}
+
+		public interface IHaveMethodWithByRefLikeReturnType
+		{
+			ByRefLike Method();
+		}
+
+		public class HasMethodWithByRefLikeReturnType : IHaveMethodWithByRefLikeReturnType
+		{
+			public virtual ByRefLike Method()
+			{
+				return default;
+			}
+		}
+	}
+}
+
+#endif

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -18,6 +18,8 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
+	using Castle.DynamicProxy.Internal;
+
 	internal class ReferencesToObjectArrayExpression : IExpression
 	{
 		private readonly TypeReference[] args;
@@ -43,7 +45,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 				var reference = args[i];
 
 #if FEATURE_BYREFLIKE
-				if (reference.Type.IsByRefLike)
+				if (reference.Type.IsByRefLikeSafe())
 				{
 					// The by-ref-like argument value cannot be put into the `object[]` array,
 					// because it cannot be boxed. We need to replace it with some other value.

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -42,6 +42,20 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 				var reference = args[i];
 
+#if FEATURE_BYREFLIKE
+				if (reference.Type.IsByRefLike)
+				{
+					// The by-ref-like argument value cannot be put into the `object[]` array,
+					// because it cannot be boxed. We need to replace it with some other value.
+
+					// For now, we just erase it by substituting `null`:
+					gen.Emit(OpCodes.Ldnull);
+					gen.Emit(OpCodes.Stelem_Ref);
+
+					continue;
+				}
+#endif
+
 				ArgumentsUtil.EmitLoadOwnerAndReference(reference, gen);
 
 				if (reference.Type.IsByRef)

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -41,7 +41,22 @@ namespace Castle.DynamicProxy.Generators
 						arguments = StoreInvocationArgumentsInLocal(emitter, invocation);
 					}
 
-					emitter.CodeBuilder.AddStatement(AssignArgument(dereferencedArguments, i, arguments));
+#if FEATURE_BYREFLIKE
+					var dereferencedParameterType = parameters[i].ParameterType.GetElementType();
+					if (dereferencedParameterType.IsByRefLike)
+					{
+						// The argument value in the invocation `Arguments` array is an `object`
+						// and cannot be converted back to its original by-ref-like type.
+						// We need to replace it with some other value.
+
+						// For now, we just substitute the by-ref-like type's default value:
+						emitter.CodeBuilder.AddStatement(new AssignStatement(dereferencedArguments[i], new DefaultValueExpression(dereferencedParameterType)));
+					}
+					else
+#endif
+					{
+						emitter.CodeBuilder.AddStatement(AssignArgument(dereferencedArguments, i, arguments));
+					}
 				}
 			}
 

--- a/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/GeneratorUtil.cs
@@ -20,6 +20,7 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
 	internal static class GeneratorUtil
@@ -43,7 +44,7 @@ namespace Castle.DynamicProxy.Generators
 
 #if FEATURE_BYREFLIKE
 					var dereferencedParameterType = parameters[i].ParameterType.GetElementType();
-					if (dereferencedParameterType.IsByRefLike)
+					if (dereferencedParameterType.IsByRefLikeSafe())
 					{
 						// The argument value in the invocation `Arguments` array is an `object`
 						// and cannot be converted back to its original by-ref-like type.

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -130,7 +130,7 @@ namespace Castle.DynamicProxy.Generators
 					IExpression localValue;
 
 #if FEATURE_BYREFLIKE
-					if (paramType.GetElementType().IsByRefLike)
+					if (paramType.GetElementType().IsByRefLikeSafe())
 					{
 						// The argument value in the invocation `Arguments` array is an `object`
 						// and cannot be converted back to its original by-ref-like type.
@@ -156,7 +156,7 @@ namespace Castle.DynamicProxy.Generators
 				else
 				{
 #if FEATURE_BYREFLIKE
-					if (paramType.IsByRefLike)
+					if (paramType.IsByRefLikeSafe())
 					{
 						// The argument value in the invocation `Arguments` array is an `object`
 						// and cannot be converted back to its original by-ref-like type.
@@ -203,7 +203,7 @@ namespace Castle.DynamicProxy.Generators
 				IExpression retVal;
 
 #if FEATURE_BYREFLIKE
-				if (returnValue.Type.IsByRefLike)
+				if (returnValue.Type.IsByRefLikeSafe())
 				{
 					// The by-ref-like return value cannot be put into the `ReturnValue` property,
 					// because it cannot be boxed. We need to replace it with some other value.
@@ -243,7 +243,7 @@ namespace Castle.DynamicProxy.Generators
 				IExpression localValue;
 
 #if FEATURE_BYREFLIKE
-				if (localReference.Type.IsByRefLike)
+				if (localReference.Type.IsByRefLikeSafe())
 				{
 					// The by-ref-like value in the local buffer variable cannot be put back
 					// into the invocation `Arguments` array, because it cannot be boxed.

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -138,20 +138,37 @@ namespace Castle.DynamicProxy.Generators
 
 			if (MethodToOverride.ReturnType != typeof(void))
 			{
-				var getRetVal = new MethodInvocationExpression(invocationLocal, InvocationMethods.GetReturnValue);
+				IExpression retVal;
 
-				// Emit code to ensure a value type return type is not null, otherwise the cast will cause a null-deref
-				if (emitter.ReturnType.IsValueType && !emitter.ReturnType.IsNullableType())
+#if FEATURE_BYREFLIKE
+				if (emitter.ReturnType.IsByRefLike)
 				{
-					LocalReference returnValue = emitter.CodeBuilder.DeclareLocal(typeof(object));
-					emitter.CodeBuilder.AddStatement(new AssignStatement(returnValue, getRetVal));
+					// The return value in the `ReturnValue` property is an `object`
+					// and cannot be converted back to the original by-ref-like return type.
+					// We need to replace it with some other value.
 
-					emitter.CodeBuilder.AddStatement(new IfNullExpression(returnValue, new ThrowStatement(typeof(InvalidOperationException),
-						"Interceptors failed to set a return value, or swallowed the exception thrown by the target")));
+					// For now, we just substitute the by-ref-like type's default value:
+					retVal = new DefaultValueExpression(emitter.ReturnType);
+				}
+				else
+#endif
+				{
+					retVal = new MethodInvocationExpression(invocationLocal, InvocationMethods.GetReturnValue);
+
+					// Emit code to ensure a value type return type is not null, otherwise the cast will cause a null-deref
+					if (emitter.ReturnType.IsValueType && !emitter.ReturnType.IsNullableType())
+					{
+						LocalReference returnValue = emitter.CodeBuilder.DeclareLocal(typeof(object));
+						emitter.CodeBuilder.AddStatement(new AssignStatement(returnValue, retVal));
+
+						emitter.CodeBuilder.AddStatement(new IfNullExpression(returnValue, new ThrowStatement(typeof(InvalidOperationException),
+							"Interceptors failed to set a return value, or swallowed the exception thrown by the target")));
+					}
+
+					retVal = new ConvertExpression(emitter.ReturnType, retVal);
 				}
 
-				// Emit code to return with cast from ReturnValue
-				emitter.CodeBuilder.AddStatement(new ReturnStatement(new ConvertExpression(emitter.ReturnType, getRetVal)));
+				emitter.CodeBuilder.AddStatement(new ReturnStatement(retVal));
 			}
 			else
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -141,7 +141,7 @@ namespace Castle.DynamicProxy.Generators
 				IExpression retVal;
 
 #if FEATURE_BYREFLIKE
-				if (emitter.ReturnType.IsByRefLike)
+				if (emitter.ReturnType.IsByRefLikeSafe())
 				{
 					// The return value in the `ReturnValue` property is an `object`
 					// and cannot be converted back to the original by-ref-like return type.

--- a/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/TypeUtil.cs
@@ -144,6 +144,22 @@ namespace Castle.DynamicProxy.Internal
 			return types;
 		}
 
+#if FEATURE_BYREFLIKE
+		internal static bool IsByRefLikeSafe(this Type type)
+		{
+			try
+			{
+				return type.IsByRefLike;
+			}
+			catch (NotSupportedException)
+			{
+				// Certain System.Reflection.Emit implementations of `Type.IsByRefLike` throw this exception
+				// with the message "Derived classes must provide an implementation." This might be a bug in the runtime.
+				return false;
+			}
+		}
+#endif
+
 		internal static bool IsFinalizer(this MethodInfo methodInfo)
 		{
 			return string.Equals("Finalize", methodInfo.Name) && methodInfo.GetBaseDefinition().DeclaringType == typeof(object);


### PR DESCRIPTION
DynamicProxy currently does not support intercepting methods that have any by-ref-like (`ref struct`) parameter or return types (such as `Span<T>` or `ReadOnlySpan<T>`), because by-ref-like types cannot be converted to or from `object`. DynamicProxy however attempts such conversions when it transfers argument and return values into or out of `IInvocation` instances.

This PR targets the code locations (hopefully all of them) where such conversions between `object` and by-ref-like types occur, and suppresses those conversions in favor of writing certain default values:

 * `null` where assignments are made to `IInvocation.Arguments` or `IInvocation.ReturnValue`
 * the `default` value of the by-ref-like type where assignments are made to `out` arguments or when values are `return`-ed to callers.
 
This work should be merged before #664, because the code locations that it touches are the same ones where #664 would introduce (optional) user-defined conversions instead of always writing fixed default values.

This is currently still a draft because one thing is still missing:

 * [ ] no `default` values should be written back to `ref` arguments, i. e. those parameters should be left unmodified. They are already initialized and may contain more meaningful values that should perhaps not be overwritten with a `default` value.