### PR TITLE
Remove redundant method accessibility checks & optimize `ProxyUtil.IsAccessibleMethod`

### DIFF
--- a/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassMembersCollector.cs
@@ -28,11 +28,6 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (ProxyUtil.IsAccessibleMethod(method) == false)
-			{
-				return null;
-			}
-
 			var accepted = AcceptMethod(method, true, hook);
 			if (!accepted && !method.IsAbstract)
 			{

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -28,11 +28,6 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (ProxyUtil.IsAccessibleMethod(method) == false)
-			{
-				return null;
-			}
-
 			var proxyable = AcceptMethod(method, true, hook);
 			if (!proxyable && !method.IsAbstract)
 			{

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
@@ -32,11 +32,6 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (ProxyUtil.IsAccessibleMethod(method) == false)
-			{
-				return null;
-			}
-
 			if (onlyProxyVirtual && IsVirtuallyImplementedInterfaceMethod(method))
 			{
 				return null;

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -143,6 +143,11 @@ namespace Castle.DynamicProxy.Contributors
 					return null;
 				}
 
+				if (ProxyUtil.IsAccessibleMethod(method) == false)
+				{
+					return null;
+				}
+
 				var methodToGenerate = GetMethodToGenerate(method, hook, isStandalone);
 				if (methodToGenerate != null)
 				{

--- a/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MembersCollector.cs
@@ -178,10 +178,7 @@ namespace Castle.DynamicProxy.Contributors
 		/// </remarks>
 		protected bool AcceptMethodPreScreen(MethodInfo method, bool onlyVirtuals, IProxyGenerationHook hook)
 		{
-			if (IsInternalAndNotVisibleToDynamicProxy(method))
-			{
-				return false;
-			}
+			// NOTE: at this point, the method's accessibility should already have been checked (see `AddMethod` above)
 
 			var isOverridable = method.IsVirtual && !method.IsFinal;
 			if (onlyVirtuals && !isOverridable)
@@ -205,12 +202,6 @@ namespace Castle.DynamicProxy.Contributors
 				return false;
 			}
 
-			//can only proxy methods that are public or protected (or internals that have already been checked above)
-			if ((method.IsPublic || method.IsFamily || method.IsAssembly || method.IsFamilyOrAssembly || method.IsFamilyAndAssembly) == false)
-			{
-				return false;
-			}
-
 			if (method.DeclaringType == typeof(MarshalByRefObject))
 			{
 				return false;
@@ -222,12 +213,6 @@ namespace Castle.DynamicProxy.Contributors
 			}
 
 			return true;
-		}
-
-		private static bool IsInternalAndNotVisibleToDynamicProxy(MethodInfo method)
-		{
-			return ProxyUtil.IsInternal(method) &&
-				   ProxyUtil.AreInternalsVisibleToDynamicProxy(method.DeclaringType.Assembly) == false;
 		}
 	}
 }

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -37,11 +37,6 @@ namespace Castle.DynamicProxy.Contributors
 
 		protected override MetaMethod GetMethodToGenerate(MethodInfo method, IProxyGenerationHook hook, bool isStandalone)
 		{
-			if (ProxyUtil.IsAccessibleMethod(method) == false)
-			{
-				return null;
-			}
-
 			var interceptable = AcceptMethodPreScreen(method, true, hook);
 			if (!interceptable)
 			{

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -194,17 +194,20 @@ namespace Castle.DynamicProxy
 		/// <returns><c>true</c> if the method is accessible to DynamicProxy, <c>false</c> otherwise.</returns>
 		internal static bool IsAccessibleMethod(MethodBase method)
 		{
-			if (method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly)
+			switch (method.Attributes & MethodAttributes.MemberAccessMask)
 			{
-				return true;
-			}
+				case MethodAttributes.Assembly:
+				case MethodAttributes.FamANDAssem:
+					return AreInternalsVisibleToDynamicProxy(method.DeclaringType.Assembly);
 
-			if (method.IsAssembly || method.IsFamilyAndAssembly)
-			{
-				return AreInternalsVisibleToDynamicProxy(method.DeclaringType.Assembly);
-			}
+				case MethodAttributes.Family:
+				case MethodAttributes.FamORAssem:
+				case MethodAttributes.Public:
+					return true;
 
-			return false;
+				default:  // `MethodAttributes.Private` or `MethodAttributes.PrivateScope`
+					return false;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is a mostly straightforward refactoring. If there are no comments to the contrary, I'll probably go ahead and merge this pretty soon.