### PR TITLE
Make internal & private classes sealed where possible. Make private methods static where possible

### DIFF
--- a/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
+++ b/src/Castle.Core/Core/Internal/InterfaceAttributeUtil.cs
@@ -65,7 +65,7 @@ namespace Castle.Core.Internal
 			results    = new List<object>();
 		}
 
-		private Aged<Type>[] CollectTypes(Type derivedType, Type[] baseTypes)
+		private static Aged<Type>[] CollectTypes(Type derivedType, Type[] baseTypes)
 		{
 			var ages = new Dictionary<Type, int>();
 			int age;

--- a/src/Castle.Core/Core/Internal/WeakKeyComparer.cs
+++ b/src/Castle.Core/Core/Internal/WeakKeyComparer.cs
@@ -17,7 +17,7 @@ namespace Castle.Core.Internal
 	using System;
 	using System.Collections.Generic;
 
-	internal class WeakKeyComparer<TKey> : IEqualityComparer<object>
+	internal sealed class WeakKeyComparer<TKey> : IEqualityComparer<object>
 		where TKey : class
 	{
 		public static readonly WeakKeyComparer<TKey>

--- a/src/Castle.Core/Core/Internal/WeakKeyDictionary.cs
+++ b/src/Castle.Core/Core/Internal/WeakKeyDictionary.cs
@@ -18,7 +18,7 @@ namespace Castle.Core.Internal
 	using System.Collections;
 	using System.Collections.Generic;
 
-	internal class WeakKeyDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+	internal sealed class WeakKeyDictionary<TKey, TValue> : IDictionary<TKey, TValue>
 		where TKey : class
 	{
 		private readonly Dictionary<object, TValue> dictionary;
@@ -177,7 +177,7 @@ namespace Castle.Core.Internal
 					dictionary.Remove(key);
 		}
 
-		private class KeyCollection : ICollection<TKey>
+		private sealed class KeyCollection : ICollection<TKey>
 		{
 			private readonly ICollection<object> keys;
 

--- a/src/Castle.Core/Core/Logging/NullLogger.cs
+++ b/src/Castle.Core/Core/Logging/NullLogger.cs
@@ -479,7 +479,7 @@ namespace Castle.Core.Logging
 		{
 		}
 
-		private class NullContextProperties : IContextProperties
+		private sealed class NullContextProperties : IContextProperties
 		{
 			public static readonly NullContextProperties Instance = new NullContextProperties();
 
@@ -490,7 +490,7 @@ namespace Castle.Core.Logging
 			}
 		}
 
-		private class NullContextStack : IContextStack, IDisposable
+		private sealed class NullContextStack : IContextStack, IDisposable
 		{
 			public static readonly NullContextStack Instance = new NullContextStack();
 
@@ -519,7 +519,7 @@ namespace Castle.Core.Logging
 			}
 		}
 
-		private class NullContextStacks : IContextStacks
+		private sealed class NullContextStacks : IContextStacks
 		{
 			public static readonly NullContextStacks Instance = new NullContextStacks();
 

--- a/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
+++ b/src/Castle.Core/Core/Logging/TraceLoggerFactory.cs
@@ -39,7 +39,7 @@ namespace Castle.Core.Logging
 			return InternalCreate(name);
 		}
 
-		private ILogger InternalCreate(string name)
+		private static ILogger InternalCreate(string name)
 		{
 			return new TraceLogger(name);
 		}
@@ -49,7 +49,7 @@ namespace Castle.Core.Logging
 			return InternalCreate(name, level);
 		}
 
-		private ILogger InternalCreate(string name, LoggerLevel level)
+		private static ILogger InternalCreate(string name, LoggerLevel level)
 		{
 			return new TraceLogger(name, level);
 		}

--- a/src/Castle.Core/Core/ReflectionBasedDictionaryAdapter.cs
+++ b/src/Castle.Core/Core/ReflectionBasedDictionaryAdapter.cs
@@ -248,7 +248,7 @@ namespace Castle.Core
 			return property.CanRead && property.GetIndexParameters().Length == 0;
 		}
 
-		private class DictionaryEntryEnumeratorAdapter : IDictionaryEnumerator
+		private sealed class DictionaryEntryEnumeratorAdapter : IDictionaryEnumerator
 		{
 			private readonly IDictionaryEnumerator enumerator;
 			private KeyValuePair<string, object> current;

--- a/src/Castle.Core/Core/Resource/AssemblyResource.cs
+++ b/src/Castle.Core/Core/Resource/AssemblyResource.cs
@@ -113,14 +113,14 @@ namespace Castle.Core.Resource
 			return nameFound;
 		}
 
-		private string ConvertToResourceName(string assembly, string resource)
+		private static string ConvertToResourceName(string assembly, string resource)
 		{
 			assembly = GetSimpleName(assembly);
 			// TODO: use path for relative name construction
 			return string.Format(CultureInfo.CurrentCulture, "{0}{1}", assembly, resource.Replace('/', '.'));
 		}
 
-		private string GetSimpleName(string assembly)
+		private static string GetSimpleName(string assembly)
 		{
 			int indexOfComma = assembly.IndexOf(',');
 			if(indexOfComma<0)
@@ -130,7 +130,7 @@ namespace Castle.Core.Resource
 			return assembly.Substring(0, indexOfComma);
 		}
 
-		private string ConvertToPath(string resource)
+		private static string ConvertToPath(string resource)
 		{
 			string path = resource.Replace('.', '/');
 			if (path[0] != '/')

--- a/src/Castle.Core/Core/StringObjectDictionaryAdapter.cs
+++ b/src/Castle.Core/Core/StringObjectDictionaryAdapter.cs
@@ -178,7 +178,7 @@ namespace Castle.Core
 			return ((IEnumerable) dictionary).GetEnumerator();
 		}
 
-		internal class EnumeratorAdapter : IEnumerator<KeyValuePair<string, object>>
+		internal sealed class EnumeratorAdapter : IEnumerator<KeyValuePair<string, object>>
 		{
 			private readonly StringObjectDictionaryAdapter adapter;
 			private readonly IEnumerator<string> keyEnumerator;

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyTargetContributor.cs
@@ -25,7 +25,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class ClassProxyTargetContributor : CompositeTypeContributor
+	internal sealed class ClassProxyTargetContributor : CompositeTypeContributor
 	{
 		private readonly Type targetType;
 
@@ -129,7 +129,7 @@ namespace Castle.DynamicProxy.Contributors
 			return callBackMethod.MethodBuilder;
 		}
 
-		private bool ExplicitlyImplementedInterfaceMethod(MetaMethod method)
+		private static bool ExplicitlyImplementedInterfaceMethod(MetaMethod method)
 		{
 			return method.MethodOnTarget.IsPrivate;
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/ClassProxyWithTargetTargetContributor.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class ClassProxyWithTargetTargetContributor : CompositeTypeContributor
+	internal sealed class ClassProxyWithTargetTargetContributor : CompositeTypeContributor
 	{
 		private readonly Type targetType;
 
@@ -156,7 +156,7 @@ namespace Castle.DynamicProxy.Contributors
 			                                         contributor);
 		}
 
-		private bool IsDirectlyAccessible(MetaMethod method)
+		private static bool IsDirectlyAccessible(MetaMethod method)
 		{
 			return method.MethodOnTarget.IsPublic;
 		}

--- a/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/FieldReferenceComparer.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using System;
 	using System.Collections.Generic;
 
-	internal class FieldReferenceComparer : IComparer<Type>
+	internal sealed class FieldReferenceComparer : IComparer<Type>
 	{
 		public int Compare(Type x, Type y)
 		{

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersCollector.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceMembersCollector : MembersCollector
+	internal sealed class InterfaceMembersCollector : MembersCollector
 	{
 		public InterfaceMembersCollector(Type @interface)
 			: base(@interface)

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceMembersOnClassCollector.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceMembersOnClassCollector : MembersCollector
+	internal sealed class InterfaceMembersOnClassCollector : MembersCollector
 	{
 		private readonly InterfaceMapping map;
 		private readonly bool onlyProxyVirtual;

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithOptionalTargetContributor.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class InterfaceProxyWithOptionalTargetContributor : InterfaceProxyWithoutTargetContributor
+	internal sealed class InterfaceProxyWithOptionalTargetContributor : InterfaceProxyWithoutTargetContributor
 	{
 		private readonly GetTargetReferenceDelegate getTargetReference;
 

--- a/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InterfaceProxyWithTargetInterfaceTargetContributor.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Contributors
 
 	using Castle.DynamicProxy.Generators;
 
-	internal class InterfaceProxyWithTargetInterfaceTargetContributor : InterfaceProxyTargetContributor
+	internal sealed class InterfaceProxyWithTargetInterfaceTargetContributor : InterfaceProxyTargetContributor
 	{
 		public InterfaceProxyWithTargetInterfaceTargetContributor(Type proxyTargetType, bool allowChangeTarget,
 		                                                          INamingScope namingScope)

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithDelegateContributor.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InvocationWithDelegateContributor : IInvocationCreationContributor
+	internal sealed class InvocationWithDelegateContributor : IInvocationCreationContributor
 	{
 		private readonly Type delegateType;
 		private readonly MetaMethod method;

--- a/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/InvocationWithGenericDelegateContributor.cs
@@ -16,7 +16,6 @@ namespace Castle.DynamicProxy.Contributors
 {
 	using System;
 	using System.Diagnostics;
-	using System.Linq;
 	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
@@ -25,7 +24,7 @@ namespace Castle.DynamicProxy.Contributors
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InvocationWithGenericDelegateContributor : IInvocationCreationContributor
+	internal sealed class InvocationWithGenericDelegateContributor : IInvocationCreationContributor
 	{
 		private readonly Type delegateType;
 		private readonly MetaMethod method;
@@ -73,7 +72,7 @@ namespace Castle.DynamicProxy.Contributors
 			return localReference;
 		}
 
-		private AssignStatement SetDelegate(LocalReference localDelegate, Reference localTarget,
+		private static AssignStatement SetDelegate(LocalReference localDelegate, Reference localTarget,
 		                                    Type closedDelegateType, MethodInfo closedMethodOnTarget)
 		{
 			var delegateCreateDelegate = new MethodInvocationExpression(

--- a/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/MixinContributor.cs
@@ -17,14 +17,13 @@ namespace Castle.DynamicProxy.Contributors
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
-	using System.Reflection;
 
 	using Castle.DynamicProxy.Generators;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;
 
-	internal class MixinContributor : CompositeTypeContributor
+	internal sealed class MixinContributor : CompositeTypeContributor
 	{
 		private readonly bool canChangeTarget;
 		private readonly IList<Type> empty = new List<Type>();

--- a/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
+++ b/src/Castle.Core/DynamicProxy/Contributors/WrappedClassMembersCollector.cs
@@ -19,10 +19,9 @@ namespace Castle.DynamicProxy.Contributors
 	using System.Runtime.CompilerServices;
 
 	using Castle.DynamicProxy.Generators;
-	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Internal;
 
-	internal class WrappedClassMembersCollector : ClassMembersCollector
+	internal sealed class WrappedClassMembersCollector : ClassMembersCollector
 	{
 		public WrappedClassMembersCollector(Type type) : base(type)
 		{
@@ -49,13 +48,13 @@ namespace Castle.DynamicProxy.Contributors
 			return new MetaMethod(method, method, isStandalone, accepted, hasTarget: true);
 		}
 
-		protected bool IsGeneratedByTheCompiler(FieldInfo field)
+		private static bool IsGeneratedByTheCompiler(FieldInfo field)
 		{
 			// for example fields backing autoproperties
 			return field.IsDefined(typeof(CompilerGeneratedAttribute));
 		}
 
-		protected virtual bool IsOKToBeOnProxy(FieldInfo field)
+		private static bool IsOKToBeOnProxy(FieldInfo field)
 		{
 			return IsGeneratedByTheCompiler(field);
 		}

--- a/src/Castle.Core/DynamicProxy/CustomAttributeInfo.cs
+++ b/src/Castle.Core/DynamicProxy/CustomAttributeInfo.cs
@@ -295,7 +295,7 @@ namespace Castle.DynamicProxy
 			}
 		}
 
-		private IDictionary<string, object?> MakeNameValueDictionary<T>(T[] members, object?[] values)
+		private static IDictionary<string, object?> MakeNameValueDictionary<T>(T[] members, object?[] values)
 			where T : MemberInfo
 		{
 			var dict = new Dictionary<string, object?>();
@@ -306,7 +306,7 @@ namespace Castle.DynamicProxy
 			return dict;
 		}
 
-		private class AttributeArgumentValueEqualityComparer : IEqualityComparer<object?>
+		private sealed class AttributeArgumentValueEqualityComparer : IEqualityComparer<object?>
 		{
 			new public bool Equals(object? x, object? y)
 			{

--- a/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
+++ b/src/Castle.Core/DynamicProxy/DefaultProxyBuilder.cs
@@ -117,7 +117,7 @@ namespace Castle.DynamicProxy
 			return generator.GetProxyType();
 		}
 
-		private void AssertValidMixins(ProxyGenerationOptions options, string paramName)
+		private static void AssertValidMixins(ProxyGenerationOptions options, string paramName)
 		{
 			try
 			{
@@ -129,12 +129,12 @@ namespace Castle.DynamicProxy
 			}
 		}
 
-		private void AssertValidType(Type target, string paramName)
+		private static void AssertValidType(Type target, string paramName)
 		{
 			AssertValidTypeForTarget(target, target, paramName);
 		}
 
-		private void AssertValidTypeForTarget(Type type, Type target, string paramName)
+		private static void AssertValidTypeForTarget(Type type, Type target, string paramName)
 		{
 			if (type.IsGenericTypeDefinition)
 			{
@@ -152,7 +152,7 @@ namespace Castle.DynamicProxy
 			}
 		}
 
-		private void AssertValidTypes(IEnumerable<Type>? targetTypes, string paramName)
+		private static void AssertValidTypes(IEnumerable<Type>? targetTypes, string paramName)
 		{
 			if (targetTypes != null)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseClassProxyGenerator.cs
@@ -203,7 +203,7 @@ namespace Castle.DynamicProxy.Generators
 			return typeImplementerMapping.Keys;
 		}
 
-		private void EnsureDoesNotImplementIProxyTargetAccessor(Type type, string name)
+		private static void EnsureDoesNotImplementIProxyTargetAccessor(Type type, string name)
 		{
 			if (!typeof(IProxyTargetAccessor).IsAssignableFrom(type))
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseInterfaceProxyGenerator.cs
@@ -259,7 +259,7 @@ namespace Castle.DynamicProxy.Generators
 #endif
 		}
 
-		private void EnsureValidBaseType(Type type)
+		private static void EnsureValidBaseType(Type type)
 		{
 			if (type == null)
 			{
@@ -286,7 +286,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 		}
 
-		private void ThrowInvalidBaseType(Type type, string doesNotHaveAccessibleParameterlessConstructor)
+		private static void ThrowInvalidBaseType(Type type, string doesNotHaveAccessibleParameterlessConstructor)
 		{
 			var format =
 				"Type {0} is not valid base type for interface proxy, because {1}. Only a non-sealed class with non-private default constructor can be used as base type for interface proxy. Please use some other valid type.";

--- a/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/BaseProxyGenerator.cs
@@ -97,7 +97,7 @@ namespace Castle.DynamicProxy.Generators
 
 		protected abstract Type GenerateType(string name, INamingScope namingScope);
 
-		protected void AddMapping(Type @interface, ITypeContributor implementer, IDictionary<Type, ITypeContributor> mapping)
+		protected static void AddMapping(Type @interface, ITypeContributor implementer, IDictionary<Type, ITypeContributor> mapping)
 		{
 			Debug.Assert(implementer != null, "implementer != null");
 			Debug.Assert(@interface != null, "@interface != null");
@@ -120,7 +120,7 @@ namespace Castle.DynamicProxy.Generators
 		/// <summary>
 		///   It is safe to add mapping (no mapping for the interface exists)
 		/// </summary>
-		protected void AddMappingNoCheck(Type @interface, ITypeContributor implementer,
+		protected static void AddMappingNoCheck(Type @interface, ITypeContributor implementer,
 		                                 IDictionary<Type, ITypeContributor> mapping)
 		{
 			mapping.Add(@interface, implementer);
@@ -154,7 +154,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 		}
 
-		protected void CompleteInitCacheMethod(CodeBuilder constCodeBuilder)
+		protected static void CompleteInitCacheMethod(CodeBuilder constCodeBuilder)
 		{
 			constCodeBuilder.AddStatement(new ReturnStatement());
 		}
@@ -166,7 +166,7 @@ namespace Castle.DynamicProxy.Generators
 			CreateInterceptorsField(emitter);
 		}
 
-		protected void CreateInterceptorsField(ClassEmitter emitter)
+		protected static void CreateInterceptorsField(ClassEmitter emitter)
 		{
 			var interceptorsField = emitter.CreateField("__interceptors", typeof(IInterceptor[]));
 
@@ -175,7 +175,7 @@ namespace Castle.DynamicProxy.Generators
 #endif
 		}
 
-		protected FieldReference CreateOptionsField(ClassEmitter emitter)
+		protected static FieldReference CreateOptionsField(ClassEmitter emitter)
 		{
 			return emitter.CreateStaticField("proxyGenerationOptions", typeof(ProxyGenerationOptions));
 		}
@@ -214,7 +214,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 		}
 
-		protected void GenerateConstructor(ClassEmitter emitter, ConstructorInfo baseConstructor,
+		protected static void GenerateConstructor(ClassEmitter emitter, ConstructorInfo baseConstructor,
 		                                   params FieldReference[] fields)
 		{
 			ArgumentReference[] args;
@@ -284,7 +284,7 @@ namespace Castle.DynamicProxy.Generators
 			constructor.CodeBuilder.AddStatement(new ReturnStatement());
 		}
 
-		protected void GenerateConstructors(ClassEmitter emitter, Type baseType, params FieldReference[] fields)
+		protected static void GenerateConstructors(ClassEmitter emitter, Type baseType, params FieldReference[] fields)
 		{
 			var constructors =
 				baseType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
@@ -307,7 +307,7 @@ namespace Castle.DynamicProxy.Generators
 		///     This constructor is important to allow proxies to be XML serializable
 		///   </para>
 		/// </summary>
-		protected void GenerateParameterlessConstructor(ClassEmitter emitter, Type baseClass, FieldReference interceptorField)
+		protected static void GenerateParameterlessConstructor(ClassEmitter emitter, Type baseClass, FieldReference interceptorField)
 		{
 			// Check if the type actually has a default constructor
 			var defaultConstructor = baseClass.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes,
@@ -340,7 +340,7 @@ namespace Castle.DynamicProxy.Generators
 			constructor.CodeBuilder.AddStatement(new ReturnStatement());
 		}
 
-		protected ConstructorEmitter GenerateStaticConstructor(ClassEmitter emitter)
+		protected static ConstructorEmitter GenerateStaticConstructor(ClassEmitter emitter)
 		{
 			return emitter.CreateTypeConstructor();
 		}
@@ -389,7 +389,7 @@ namespace Castle.DynamicProxy.Generators
 			builtType.SetStaticField("proxyGenerationOptions", BindingFlags.NonPublic, ProxyGenerationOptions);
 		}
 
-		private bool OverridesEqualsAndGetHashCode(Type type)
+		private static bool OverridesEqualsAndGetHashCode(Type type)
 		{
 			var equalsMethod = type.GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance);
 			if (equalsMethod == null || equalsMethod.DeclaringType == typeof(object) || equalsMethod.IsAbstract)

--- a/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CacheKey.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators
 #if FEATURE_SERIALIZATION
 	[Serializable]
 #endif
-	internal class CacheKey
+	internal sealed class CacheKey
 	{
 		private readonly MemberInfo target;
 		private readonly Type[] interfaces;

--- a/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/CompositionInvocationTypeGenerator.cs
@@ -23,7 +23,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class CompositionInvocationTypeGenerator : InvocationTypeGenerator
+	internal sealed class CompositionInvocationTypeGenerator : InvocationTypeGenerator
 	{
 		public static readonly Type BaseType = typeof(CompositionInvocation);
 

--- a/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/DelegateTypeGenerator.cs
@@ -19,9 +19,8 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
-	using Castle.DynamicProxy.Internal;
 
-	internal class DelegateTypeGenerator : IGenerator<AbstractTypeEmitter>
+	internal sealed class DelegateTypeGenerator : IGenerator<AbstractTypeEmitter>
 	{
 		private const TypeAttributes DelegateFlags = TypeAttributes.Class |
 		                                             TypeAttributes.Public |
@@ -46,7 +45,7 @@ namespace Castle.DynamicProxy.Generators
 			return emitter;
 		}
 
-		private void BuildConstructor(AbstractTypeEmitter emitter)
+		private static void BuildConstructor(AbstractTypeEmitter emitter)
 		{
 			var constructor = emitter.CreateConstructor(new ArgumentReference(typeof(object)),
 			                                            new ArgumentReference(typeof(IntPtr)));

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/AbstractTypeEmitter.cs
@@ -337,7 +337,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			genericTypeParams = genericTypeParameterBuilders;
 		}
 
-		protected Type CreateType(TypeBuilder type)
+		protected static Type CreateType(TypeBuilder type)
 		{
 			return type.CreateTypeInfo();
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/ClassEmitter.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 	using Castle.DynamicProxy.Internal;
 
-	internal class ClassEmitter : AbstractTypeEmitter
+	internal sealed class ClassEmitter : AbstractTypeEmitter
 	{
 		internal const TypeAttributes DefaultAttributes =
 			TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Serializable;
@@ -75,7 +75,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			get { return StrongNameUtil.IsAssemblySigned(TypeBuilder.Assembly); }
 		}
 
-		protected virtual IEnumerable<Type> InitializeGenericArgumentsFromBases(ref Type baseType,
+		private static IEnumerable<Type> InitializeGenericArgumentsFromBases(ref Type baseType,
 		                                                                        IEnumerable<Type> interfaces)
 		{
 			if (baseType != null && baseType.IsGenericTypeDefinition)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/EventEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class EventEmitter : IMemberEmitter
+	internal sealed class EventEmitter : IMemberEmitter
 	{
 		private readonly EventBuilder eventBuilder;
 		private readonly Type type;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/GenericUtil.cs
@@ -19,12 +19,11 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	using Castle.Core.Internal;
 	using Castle.DynamicProxy.Internal;
 
 	internal delegate GenericTypeParameterBuilder[] ApplyGenArgs(string[] argumentNames);
 
-	internal class GenericUtil
+	internal sealed class GenericUtil
 	{
 		public static GenericTypeParameterBuilder[] CopyGenericArguments(
 			MethodInfo methodToCopyGenericsFrom,

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/MethodEmitter.cs
@@ -15,10 +15,8 @@
 namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using System;
-	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Globalization;
-	using System.Linq;
 	using System.Reflection;
 	using System.Reflection.Emit;
 
@@ -26,7 +24,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using Castle.DynamicProxy.Internal;
 
 	[DebuggerDisplay("{builder.Name}")]
-	internal class MethodEmitter : IMemberEmitter
+	internal sealed class MethodEmitter : IMemberEmitter
 	{
 		private readonly MethodBuilder builder;
 		private readonly CodeBuilder codeBuilder;
@@ -34,7 +32,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 
 		private ArgumentReference[] arguments;
 
-		protected internal MethodEmitter(MethodBuilder builder)
+		private MethodEmitter(MethodBuilder builder)
 		{
 			this.builder = builder;
 			codeBuilder = new CodeBuilder();
@@ -124,7 +122,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			ArgumentsUtil.InitializeArgumentsByPosition(arguments, MethodBuilder.IsStatic);
 		}
 
-		public virtual void EnsureValidCodeBlock()
+		public void EnsureValidCodeBlock()
 		{
 			if (ImplementedByRuntime == false && CodeBuilder.IsEmpty)
 			{
@@ -139,7 +137,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			}
 		}
 
-		public virtual void Generate()
+		public void Generate()
 		{
 			if (ImplementedByRuntime)
 			{
@@ -186,7 +184,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 			}
 		}
 
-		private void CopyDefaultValueConstant(ParameterInfo from, ParameterBuilder to)
+		private static void CopyDefaultValueConstant(ParameterInfo from, ParameterBuilder to)
 		{
 			Debug.Assert(from != null);
 			Debug.Assert(to != null);

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/NestedClassEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class NestedClassEmitter : AbstractTypeEmitter
+	internal sealed class NestedClassEmitter : AbstractTypeEmitter
 	{
 		public NestedClassEmitter(AbstractTypeEmitter mainType, string name, Type baseType, Type[] interfaces)
 			: this(

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/PropertyEmitter.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class PropertyEmitter : IMemberEmitter
+	internal sealed class PropertyEmitter : IMemberEmitter
 	{
 		private readonly PropertyBuilder builder;
 		private readonly AbstractTypeEmitter parentTypeEmitter;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ArgumentReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("argument {Type}")]
-	internal class ArgumentReference : TypeReference
+	internal sealed class ArgumentReference : TypeReference
 	{
 		public ArgumentReference(Type argumentType)
 			: base(argumentType)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AsTypeReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{reference} as {type}")]
-	internal class AsTypeReference : Reference
+	internal sealed class AsTypeReference : Reference
 	{
 		private readonly Reference reference;
 		private readonly Type type;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArgumentStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignArgumentStatement : IStatement
+	internal sealed class AssignArgumentStatement : IStatement
 	{
 		private readonly ArgumentReference argument;
 		private readonly IExpression expression;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignArrayStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignArrayStatement : IStatement
+	internal sealed class AssignArrayStatement : IStatement
 	{
 		private readonly Reference targetArray;
 		private readonly int targetPosition;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/AssignStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class AssignStatement : IStatement
+	internal sealed class AssignStatement : IStatement
 	{
 		private readonly IExpression expression;
 		private readonly Reference target;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BlockStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/BlockStatement.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Collections.Generic;
 	using System.Reflection.Emit;
 
-	internal class BlockStatement : IStatement
+	internal sealed class BlockStatement : IStatement
 	{
 		private readonly List<IStatement> statements = new List<IStatement>();
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ByRefReference.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 
 	[DebuggerDisplay("&{localReference}")]
-	internal class ByRefReference : TypeReference
+	internal sealed class ByRefReference : TypeReference
 	{
 		private readonly LocalReference localReference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConstructorInvocationStatement.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ConstructorInvocationStatement : IStatement
+	internal sealed class ConstructorInvocationStatement : IStatement
 	{
 		private readonly IExpression[] args;
 		private readonly ConstructorInfo cmethod;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ConvertExpression.cs
@@ -15,10 +15,9 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ConvertExpression : IExpression
+	internal sealed class ConvertExpression : IExpression
 	{
 		private readonly IExpression right;
 		private Type fromType;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/DefaultValueExpression.cs
@@ -15,10 +15,9 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class DefaultValueExpression : IExpression
+	internal sealed class DefaultValueExpression : IExpression
 	{
 		private readonly Type type;
 
@@ -70,7 +69,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 			}
 		}
 
-		private bool IsPrimitiveOrClass(Type type)
+		private static bool IsPrimitiveOrClass(Type type)
 		{
 			if (type.IsPrimitive && type != typeof(IntPtr) && type != typeof(UIntPtr))
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/EndExceptionBlockStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class EndExceptionBlockStatement : IStatement
+	internal sealed class EndExceptionBlockStatement : IStatement
 	{
 		public void Emit(ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FieldReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("{fieldBuilder.Name} ({fieldBuilder.FieldType})")]
-	internal class FieldReference : Reference
+	internal sealed class FieldReference : Reference
 	{
 		private readonly FieldInfo field;
 		private readonly FieldBuilder fieldBuilder;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/FinallyStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class FinallyStatement : IStatement
+	internal sealed class FinallyStatement : IStatement
 	{
 		public void Emit(ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IfNullExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class IfNullExpression : IExpression, IStatement
+	internal sealed class IfNullExpression : IExpression, IStatement
 	{
 		private readonly IExpressionOrStatement ifNotNull;
 		private readonly IExpressionOrStatement ifNull;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/IndirectReference.cs
@@ -16,7 +16,6 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
 	using System.Diagnostics;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
 	/// <summary>
@@ -24,7 +23,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	///   ByRef and provides indirect load/store support.
 	/// </summary>
 	[DebuggerDisplay("&{OwnerReference}")]
-	internal class IndirectReference : TypeReference
+	internal sealed class IndirectReference : TypeReference
 	{
 		public IndirectReference(TypeReference byRefReference) :
 			base(byRefReference, byRefReference.Type.GetElementType())

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralBoolExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LiteralBoolExpression : IExpression
+	internal sealed class LiteralBoolExpression : IExpression
 	{
 		private readonly bool value;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralIntExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LiteralIntExpression : IExpression
+	internal sealed class LiteralIntExpression : IExpression
 	{
 		private readonly int value;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LiteralStringExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LiteralStringExpression : IExpression
+	internal sealed class LiteralStringExpression : IExpression
 	{
 		private readonly string value;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LoadRefArrayElementExpression.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class LoadRefArrayElementExpression : IExpression
+	internal sealed class LoadRefArrayElementExpression : IExpression
 	{
 		private readonly Reference arrayReference;
 		private readonly LiteralIntExpression index;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/LocalReference.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("local {Type}")]
-	internal class LocalReference : TypeReference
+	internal sealed class LocalReference : TypeReference
 	{
 		private LocalBuilder localBuilder;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodInvocationExpression.cs
@@ -17,11 +17,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class MethodInvocationExpression : IExpression, IStatement
+	internal sealed class MethodInvocationExpression : IExpression, IStatement
 	{
-		protected readonly IExpression[] args;
-		protected readonly MethodInfo method;
-		protected readonly Reference owner;
+		private readonly IExpression[] args;
+		private readonly MethodInfo method;
+		private readonly Reference owner;
 
 		public MethodInvocationExpression(MethodInfo method, params IExpression[] args) :
 			this(SelfReference.Self, method, args)

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/MethodTokenExpression.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	using Castle.DynamicProxy.Tokens;
 
-	internal class MethodTokenExpression : IExpression
+	internal sealed class MethodTokenExpression : IExpression
 	{
 		private readonly MethodInfo method;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewArrayExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class NewArrayExpression : IExpression
+	internal sealed class NewArrayExpression : IExpression
 	{
 		private readonly Type arrayType;
 		private readonly int size;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NewInstanceExpression.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class NewInstanceExpression : IExpression
+	internal sealed class NewInstanceExpression : IExpression
 	{
 		private readonly IExpression[] arguments;
 		private ConstructorInfo constructor;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullCoalescingOperatorExpression.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System;
 	using System.Reflection.Emit;
 
-	internal class NullCoalescingOperatorExpression : IExpression
+	internal sealed class NullCoalescingOperatorExpression : IExpression
 	{
 		private readonly IExpression @default;
 		private readonly IExpression expression;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/NullExpression.cs
@@ -16,11 +16,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class NullExpression : IExpression
+	internal sealed class NullExpression : IExpression
 	{
 		public static readonly NullExpression Instance = new NullExpression();
 
-		protected NullExpression()
+		private NullExpression()
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReferencesToObjectArrayExpression.cs
@@ -15,10 +15,9 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ReferencesToObjectArrayExpression : IExpression
+	internal sealed class ReferencesToObjectArrayExpression : IExpression
 	{
 		private readonly TypeReference[] args;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ReturnStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class ReturnStatement : IStatement
+	internal sealed class ReturnStatement : IStatement
 	{
 		private readonly IExpression expression;
 		private readonly Reference reference;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/SelfReference.cs
@@ -19,11 +19,11 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 	using System.Reflection.Emit;
 
 	[DebuggerDisplay("this")]
-	internal class SelfReference : Reference
+	internal sealed class SelfReference : Reference
 	{
 		public static readonly SelfReference Self = new SelfReference();
 
-		protected SelfReference() : base(null)
+		private SelfReference() : base(null)
 		{
 		}
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/ThrowStatement.cs
@@ -15,10 +15,9 @@
 namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System;
-	using System.Reflection;
 	using System.Reflection.Emit;
 
-	internal class ThrowStatement : IStatement
+	internal sealed class ThrowStatement : IStatement
 	{
 		private readonly string errorMessage;
 		private readonly Type exceptionType;

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TryStatement.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 {
 	using System.Reflection.Emit;
 
-	internal class TryStatement : IStatement
+	internal sealed class TryStatement : IStatement
 	{
 		public void Emit(ILGenerator gen)
 		{

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/SimpleAST/TypeTokenExpression.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators.Emitters.SimpleAST
 
 	using Castle.DynamicProxy.Tokens;
 
-	internal class TypeTokenExpression : IExpression
+	internal sealed class TypeTokenExpression : IExpression
 	{
 		private readonly Type type;
 

--- a/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/Emitters/TypeConstructorEmitter.cs
@@ -16,7 +16,7 @@ namespace Castle.DynamicProxy.Generators.Emitters
 {
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class TypeConstructorEmitter : ConstructorEmitter
+	internal sealed class TypeConstructorEmitter : ConstructorEmitter
 	{
 		internal TypeConstructorEmitter(AbstractTypeEmitter mainType)
 			: base(mainType, mainType.TypeBuilder.DefineTypeInitializer())

--- a/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/ForwardingMethodGenerator.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class ForwardingMethodGenerator : MethodGenerator
+	internal sealed class ForwardingMethodGenerator : MethodGenerator
 	{
 		private readonly GetTargetReferenceDelegate getTargetReference;
 

--- a/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InheritanceInvocationTypeGenerator.cs
@@ -22,7 +22,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class InheritanceInvocationTypeGenerator : InvocationTypeGenerator
+	internal sealed class InheritanceInvocationTypeGenerator : InvocationTypeGenerator
 	{
 		public static readonly Type BaseType = typeof(InheritanceInvocation);
 

--- a/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InterfaceProxyWithTargetGenerator.cs
@@ -60,7 +60,7 @@ namespace Castle.DynamicProxy.Generators
 			}
 		}
 
-		private bool ImplementedByTarget(ICollection<Type> targetInterfaces, Type @interface)
+		private static bool ImplementedByTarget(ICollection<Type> targetInterfaces, Type @interface)
 		{
 			return targetInterfaces.Contains(@interface);
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/InvocationTypeGenerator.cs
@@ -182,7 +182,7 @@ namespace Castle.DynamicProxy.Generators
 			invokeMethodOnTarget.CodeBuilder.AddStatement(new ReturnStatement());
 		}
 
-		private void AssignBackByRefArguments(MethodEmitter invokeMethodOnTarget, Dictionary<int, LocalReference> byRefArguments)
+		private static void AssignBackByRefArguments(MethodEmitter invokeMethodOnTarget, Dictionary<int, LocalReference> byRefArguments)
 		{
 			if (byRefArguments.Count == 0)
 			{
@@ -226,7 +226,7 @@ namespace Castle.DynamicProxy.Generators
 			return contributor.CreateConstructor(baseCtorArguments, invocation);
 		}
 
-		private void EmitCallThrowOnNoTarget(MethodEmitter invokeMethodOnTarget)
+		private static void EmitCallThrowOnNoTarget(MethodEmitter invokeMethodOnTarget)
 		{
 			var throwOnNoTarget = new MethodInvocationExpression(InvocationMethods.ThrowOnNoTarget);
 

--- a/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaEvent.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class MetaEvent : MetaTypeElement, IEquatable<MetaEvent>
+	internal sealed class MetaEvent : MetaTypeElement, IEquatable<MetaEvent>
 	{
 		private readonly MetaMethod adder;
 		private readonly MetaMethod remover;

--- a/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaMethod.cs
@@ -19,7 +19,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Reflection;
 
 	[DebuggerDisplay("{Method}")]
-	internal class MetaMethod : MetaTypeElement, IEquatable<MetaMethod>
+	internal sealed class MetaMethod : MetaTypeElement, IEquatable<MetaMethod>
 	{
 		private const MethodAttributes ExplicitImplementationAttributes = MethodAttributes.Virtual |
 		                                                                  MethodAttributes.Public |

--- a/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaProperty.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Generators
 
 	using Castle.DynamicProxy.Generators.Emitters;
 
-	internal class MetaProperty : MetaTypeElement, IEquatable<MetaProperty>
+	internal sealed class MetaProperty : MetaTypeElement, IEquatable<MetaProperty>
 	{
 		private readonly Type[] arguments;
 		private readonly PropertyAttributes attributes;

--- a/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaType.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Reflection;
 
-	internal class MetaType
+	internal sealed class MetaType
 	{
 		private readonly MetaTypeElementCollection<MetaEvent> events = new MetaTypeElementCollection<MetaEvent>();
 		private readonly MetaTypeElementCollection<MetaMethod> methods = new MetaTypeElementCollection<MetaMethod>();

--- a/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementCollection.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MetaTypeElementCollection.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections;
 	using System.Collections.Generic;
 
-	internal class MetaTypeElementCollection<TElement> : IEnumerable<TElement>
+	internal sealed class MetaTypeElementCollection<TElement> : IEnumerable<TElement>
 		where TElement : MetaTypeElement, IEquatable<TElement>
 	{
 		private readonly ICollection<TElement> items = new List<TElement>();

--- a/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodSignatureComparer.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Reflection;
 
-	internal class MethodSignatureComparer : IEqualityComparer<MethodInfo>
+	internal sealed class MethodSignatureComparer : IEqualityComparer<MethodInfo>
 	{
 		public static readonly MethodSignatureComparer Instance = new MethodSignatureComparer();
 
@@ -101,7 +101,7 @@ namespace Castle.DynamicProxy.Generators
 			return false;
 		}
 
-		private bool EqualSignatureTypes(Type x, Type y)
+		private static bool EqualSignatureTypes(Type x, Type y)
 		{
 			if (x.IsByRef != y.IsByRef)
 			{
@@ -186,7 +186,7 @@ namespace Castle.DynamicProxy.Generators
 			return obj.Name.GetHashCode() ^ obj.GetParameters().Length; // everything else would be too cumbersome
 		}
 
-		private bool EqualNames(MethodInfo x, MethodInfo y)
+		private static bool EqualNames(MethodInfo x, MethodInfo y)
 		{
 			return x.Name == y.Name;
 		}

--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -15,21 +15,19 @@
 namespace Castle.DynamicProxy.Generators
 {
 	using System;
-	using System.Diagnostics;
 	using System.Reflection;
 	using System.Reflection.Emit;
 #if FEATURE_SERIALIZATION
 	using System.Xml.Serialization;
 #endif
 
-	using Castle.Core.Internal;
 	using Castle.DynamicProxy.Contributors;
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 	using Castle.DynamicProxy.Internal;
 	using Castle.DynamicProxy.Tokens;
 
-	internal class MethodWithInvocationGenerator : MethodGenerator
+	internal sealed class MethodWithInvocationGenerator : MethodGenerator
 	{
 		private readonly IInvocationCreationContributor contributor;
 		private readonly GetTargetExpressionDelegate getTargetExpression;
@@ -57,7 +55,7 @@ namespace Castle.DynamicProxy.Generators
 			this.contributor = contributor;
 		}
 
-		protected FieldReference BuildMethodInterceptorsField(ClassEmitter @class, MethodInfo method, INamingScope namingScope)
+		private static FieldReference BuildMethodInterceptorsField(ClassEmitter @class, MethodInfo method, INamingScope namingScope)
 		{
 			var methodInterceptors = @class.CreateField(
 				namingScope.GetUniqueName(string.Format("interceptors_{0}", method.Name)),
@@ -195,7 +193,7 @@ namespace Castle.DynamicProxy.Generators
 			return methodInterceptorsField;
 		}
 
-		private void EmitLoadGenericMethodArguments(MethodEmitter methodEmitter, MethodInfo method, Reference invocationLocal)
+		private static void EmitLoadGenericMethodArguments(MethodEmitter methodEmitter, MethodInfo method, Reference invocationLocal)
 		{
 			var genericParameters = Array.FindAll(method.GetGenericArguments(), t => t.IsGenericParameter);
 			var genericParamsArrayLocal = methodEmitter.CodeBuilder.DeclareLocal(typeof(Type[]));
@@ -235,7 +233,7 @@ namespace Castle.DynamicProxy.Generators
 			return contributor.GetConstructorInvocationArguments(arguments, @class);
 		}
 
-		private bool HasByRefArguments(ArgumentReference[] arguments)
+		private static bool HasByRefArguments(ArgumentReference[] arguments)
 		{
 			for (int i = 0; i < arguments.Length; i++ )
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/MinimalisticMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MinimalisticMethodGenerator.cs
@@ -20,7 +20,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class MinimalisticMethodGenerator : MethodGenerator
+	internal sealed class MinimalisticMethodGenerator : MethodGenerator
 	{
 		public MinimalisticMethodGenerator(MetaMethod method, OverrideMethodDelegate overrideMethod)
 			: base(method, overrideMethod)
@@ -44,7 +44,7 @@ namespace Castle.DynamicProxy.Generators
 			return emitter;
 		}
 
-		private void InitOutParameters(MethodEmitter emitter, ParameterInfo[] parameters)
+		private static void InitOutParameters(MethodEmitter emitter, ParameterInfo[] parameters)
 		{
 			for (var index = 0; index < parameters.Length; index++)
 			{

--- a/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/NamingScope.cs
@@ -17,7 +17,7 @@ namespace Castle.DynamicProxy.Generators
 	using System.Collections.Generic;
 	using System.Diagnostics;
 
-	internal class NamingScope : INamingScope
+	internal sealed class NamingScope : INamingScope
 	{
 		private readonly IDictionary<string, int> names = new Dictionary<string, int>();
 		private readonly INamingScope parentScope;

--- a/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/OptionallyForwardingMethodGenerator.cs
@@ -21,7 +21,7 @@ namespace Castle.DynamicProxy.Generators
 	using Castle.DynamicProxy.Generators.Emitters;
 	using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 
-	internal class OptionallyForwardingMethodGenerator : MethodGenerator
+	internal sealed class OptionallyForwardingMethodGenerator : MethodGenerator
 	{
 		// TODO: This class largely duplicates code from Forwarding and Minimalistic generators. Should be refactored to change that
 		private readonly GetTargetReferenceDelegate getTargetReference;
@@ -76,7 +76,7 @@ namespace Castle.DynamicProxy.Generators
 			return statements;
 		}
 
-		private void InitOutParameters(BlockStatement statements, ParameterInfo[] parameters)
+		private static void InitOutParameters(BlockStatement statements, ParameterInfo[] parameters)
 		{
 			for (var index = 0; index < parameters.Length; index++)
 			{


### PR DESCRIPTION
`sealed`/`static` part of https://github.com/castleproject/Core/pull/687, except for DictionaryAdapter

By doing this, lookups in Virtual Method Table before calling are avoided.