### PR TITLE
Fix closure

### DIFF
--- a/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
+++ b/src/Castle.Core/DynamicProxy/Internal/InvocationHelper.cs
@@ -50,7 +50,7 @@ namespace Castle.DynamicProxy.Internal
 
 			var cacheKey = new CacheKey(proxiedMethod, type);
 
-			return cache.GetOrAdd(cacheKey, ck => ObtainMethod(proxiedMethod, type));
+			return cache.GetOrAdd(cacheKey, static ck => ObtainMethod(ck.Method, ck.Type));
 		}
 
 		private static MethodInfo ObtainMethod(MethodInfo proxiedMethod, Type type)

--- a/src/Castle.Core/DynamicProxy/ProxyUtil.cs
+++ b/src/Castle.Core/DynamicProxy/ProxyUtil.cs
@@ -162,9 +162,9 @@ namespace Castle.DynamicProxy
 		/// <param name="asm">The assembly to inspect.</param>
 		internal static bool AreInternalsVisibleToDynamicProxy(Assembly asm)
 		{
-			return internalsVisibleToDynamicProxy.GetOrAdd(asm, a =>
+			return internalsVisibleToDynamicProxy.GetOrAdd(asm, static a =>
 			{
-				var internalsVisibleTo = asm.GetCustomAttributes<InternalsVisibleToAttribute>();
+				var internalsVisibleTo = a.GetCustomAttributes<InternalsVisibleToAttribute>();
 				return internalsVisibleTo.Any(attr => attr.AssemblyName.Contains(ModuleScope.DEFAULT_ASSEMBLY_NAME));
 			});
 		}


### PR DESCRIPTION
`InvocationHelper.GetMethodOnType` is in on a hot path and creates relatively much garbage.
`ProxyUtil.AreInternalsVisibleToDynamicProxy` is not on a hot path but was easy to fix.
There is another closure in `BaseProxyGenerator.GetProxyType`, which is a bit harder to fix, but since it's not a hot path I left it as is. Let me know if you want to fix it too.