### PR TITLE
Remove `nuget.config` as it is likely no longer needed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
A while back we had to add workarounds for NuGet package restore to work correctly (see commit ec49bff). This issue appears to have been resolved so our boilerplate `nuget.config` should now be redundant.

See:
* https://github.com/NuGet/Home/issues/10586
* https://github.com/actions/runner-images/pull/3373