### PR TITLE
Don't allocate empty `IInvocation.Arguments` arrays

### DIFF
--- a/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
+++ b/src/Castle.Core/DynamicProxy/Generators/MethodWithInvocationGenerator.cs
@@ -266,7 +266,8 @@ namespace Castle.DynamicProxy.Generators
 				method.CodeBuilder.AddStatement(
 					new AssignStatement(
 						argumentsArray,
-						new NewArrayExpression(arguments.Length, typeof(object))));
+						arguments.Length > 0 ? new NewArrayExpression(arguments.Length, typeof(object))
+						                     : new MethodInvocationExpression(instance: null, ArrayMethods.EmptyOfObject)));
 
 				for (int i = 0, n = arguments.Length; i < n; ++i)
 				{

--- a/src/Castle.Core/DynamicProxy/Tokens/ArrayMethods.cs
+++ b/src/Castle.Core/DynamicProxy/Tokens/ArrayMethods.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2004-2026 Castle Project - http://www.castleproject.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.DynamicProxy.Tokens
+{
+	using System;
+	using System.Reflection;
+
+	internal static class ArrayMethods
+	{
+		public static readonly MethodInfo EmptyOfObject = typeof(Array).GetMethod(nameof(Array.Empty)).MakeGenericMethod(typeof(object));
+	}
+}


### PR DESCRIPTION
This is a small and straightforward runtime memory optimization: for parameter-less intercepted methods, reuse `Array.Empty<object?>()` as the backing array for `IInvocation.Arguments` instead of allocating a `new object?[0]` on every invocation.