### PR TITLE
Ensure TraceLogger log level is maintained property

### DIFF
--- a/src/Castle.Core.Tests/DynamicProxy.Tests/LoggingTestCase.cs
+++ b/src/Castle.Core.Tests/DynamicProxy.Tests/LoggingTestCase.cs
@@ -109,6 +109,16 @@ namespace Castle.DynamicProxy.Tests
 				"Castle.DynamicProxy.Tests.LoggingTestCase+NonVirtualMethodClass because it cannot be intercepted."));
 		}
 
+		[Test]
+		public void LogsWarningOnlyByDefault()
+		{
+			var generator = new ProxyGenerator();
+			Assert.IsInstanceOf<TraceLogger>(generator.Logger);
+
+			var logger = (TraceLogger)generator.Logger;
+			Assert.AreEqual(LoggerLevel.Warn, logger.Level);
+		}
+
 		#region Test Types
 
 		public interface IEmptyInterface

--- a/src/Castle.Core/Core/Logging/TraceLogger.cs
+++ b/src/Castle.Core/Core/Logging/TraceLogger.cs
@@ -134,6 +134,7 @@ namespace Castle.Core.Logging
 
 				// reconfigure the created source to act like the found source
 				traceSource.Switch = foundSource.Switch;
+				traceSource.Switch.Level = defaultLevel;
 				traceSource.Listeners.Clear();
 				foreach (TraceListener listener in foundSource.Listeners)
 				{

--- a/src/Castle.Core/Core/Logging/TraceLogger.cs
+++ b/src/Castle.Core/Core/Logging/TraceLogger.cs
@@ -108,6 +108,7 @@ namespace Castle.Core.Logging
 
 				var defaultLevel = MapSourceLevels(Level);
 				traceSource = new TraceSource(Name, defaultLevel);
+				traceSource.Switch.Level = defaultLevel;
 
 				// no further action necessary when the named source is configured
 				if (IsSourceConfigured(traceSource))


### PR DESCRIPTION
The added test would fail only under .NET Framework without the production change in this PR.

Under .NET Framework, if you execute the following:

```csharp
new TraceSource("Default", SourceLevels.Warning).Switch.Level
```

it will produce `-1` (corresponding to `SourceLevels.All`).

After `Initialize` gets called in `TraceLogger` constructor, the level is set as:

```csharp
Level = MapLoggerLevel(traceSource.Switch.Level);
```

which used to set it to Trace, even when Warning is explicitly requested.

The caching in `TraceLogger` generally looks wrong to me though. It caches TraceSource per Name, not taking into account the fact that multiple `TraceLogger` might be requested with the same name but different levels.